### PR TITLE
アプデ導線、GitHub Actions動確完了に伴い初回りリースを `v0.1.0`へ戻し

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
* 初回リリース