### PR TITLE
v0.3.5

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,13 @@ pub fn run() {
             {
                 let app = _app;
                 let window = app.get_webview_window("main").unwrap();
+                let window_height = window.inner_size().unwrap().height;
+                // 横幅だけ0まで縮小可能にする
+                // 縦幅は現状の値をそのままにする
+                let _ = window.set_min_size(Some(tauri::Size::Logical(tauri::LogicalSize {
+                    width: 0.0,
+                    height: window_height as f64, // 現在の高さを保持
+                })));
                 window.open_devtools();
             }
             Ok(())

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -123,7 +123,9 @@ pub async fn download_url(
     // println!("Planned segments: {} (segment_size={}MB)", segments.len(), DEFAULT_SEGMENT_MB);
 
     // 推奨並列度
-    let concurrency: usize = if total < 64 * 1024 * 1024 { 1 } else { 3 };
+    // let concurrency: usize = if total < 64 * 1024 * 1024 { 1 } else { 3 };
+    // NOTE: bilibiliへ並列実行するとHTTPが安定しないため1に固定
+    let concurrency: usize = 1;
     // DEBUG: concurrency chosen
     // println!("Concurrency: {}", concurrency);
 
@@ -168,7 +170,8 @@ pub async fn download_url(
         futs.push(tokio::spawn(async move {
             let _permit = sem_c.acquire().await.unwrap();
             let mut attempt: u8 = 0;
-            let max_seg_retries: u8 = 10;
+            // 最大セグメント再試行回数 (全体リトライ導入に伴い 10 -> 3 に縮小)
+            let max_seg_retries: u8 = 3;
             let size = e - s + 1;
             loop {
                 attempt += 1;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/video/useVideoInfo.ts
+++ b/src/features/video/useVideoInfo.ts
@@ -59,7 +59,8 @@ export const useVideoInfo = () => {
       }
       const description = messageKey ? t(messageKey) : raw
       toast.error(t('video.download_failed'), {
-        duration: 10000,
+        // Keep the error toast persistent until user closes it
+        duration: Infinity,
         description,
         closeButton: true,
       })


### PR DESCRIPTION

## English

### Release Notes

#### Features & Improvements
- **Download Performance:**  
  - The download logic for videos has been refactored. Audio is now downloaded first, followed by video, with a global retry mechanism (up to 3 attempts) for both. This improves reliability and error handling.
  - Parallel downloads to Bilibili are now disabled (concurrency fixed to 1) to avoid HTTP instability.
  - Segment retry count reduced from 10 to 3 for better control and faster failure feedback.

- **UI/UX:**
  - In development mode, the minimum window width is set to 0, allowing the window to be resized horizontally without restriction. The current height is preserved.

- **Error Handling:**
  - When a video download fails, the error toast notification now stays visible until the user closes it (duration set to `Infinity`).

#### Other Changes
- **Version Update:**  
  - App version bumped from `0.3.4` to `0.3.5` in `tauri.conf.json`.

---

## 日本語

### リリースノート

#### 機能・改善
- **ダウンロードパフォーマンス:**  
  - 動画のダウンロード処理をリファクタリング。音声を先にダウンロードし、その後に動画をダウンロード。両方に対して最大3回のグローバルリトライ制御を導入し、信頼性とエラーハンドリングを向上。
  - Bilibiliへの並列ダウンロードを無効化（並列度を1に固定）し、HTTPの安定性を確保。
  - セグメントの再試行回数を10回から3回に縮小し、失敗時のフィードバックを高速化。

- **UI/UX:**
  - 開発モードではウィンドウの最小横幅が0に設定され、横方向のサイズ変更が制限なく可能に。高さは現状の値を保持。

- **エラーハンドリング:**
  - 動画ダウンロード失敗時のエラートースト通知が、ユーザーが閉じるまで表示されるように（durationを`Infinity`に設定）。

#### その他の変更
- **バージョン更新:**  
  - `tauri.conf.json`のアプリバージョンが`0.3.4`から`0.3.5`に更新。

