### PR TITLE
v0.5.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# GA4 Measurement Protocol (development only)
+# このファイルをコピーして `.env` を作り、値を設定してください。
+# `.env` は `.gitignore` 済みでリポジトリには含まれません。
+
+# GA4 の Data Stream で確認できる Measurement ID (例: G-XXXXXXX)
+GA_MEASUREMENT_ID=G-XXXXXXX
+
+# GA4 Data Stream の Measurement Protocol API secrets で生成した Secret
+GA_API_SECRET=REPLACE_WITH_SECRET
+
+# 開発時は常に debug endpoint (validationMessages) を使うため不要ですが、
+# release ビルドで debug を強制したい場合に 1 を設定可能。
+# GA_DEBUG=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          GA_API_SECRET: ${{ secrets.GA_API_SECRET }}
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/README-JP.md
+++ b/README-JP.md
@@ -156,6 +156,50 @@ src-tauri/src/
 - Frontend: React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
 - Desktop: Tauri (Rust)
 
+## アナリティクス (GA4)
+
+本アプリは Google Analytics 4 (GA4) の Measurement Protocol を用いて、極めて最小限の利用状況イベントを送信します。インストールおよび継続利用は以下のデータ送信に同意したものと見なされます。今後、アプリ内でオプトアウト設定を追加予定です。
+
+### 送信イベント一覧
+
+| イベント名        | 送信タイミング                | パラメータ                                                                     |
+| ----------------- | ----------------------------- | ------------------------------------------------------------------------------ |
+| `first_install`   | 初回インストール後最初の起動  | `app_version`, `os`                                                            |
+| `app_update`      | バージョン更新後最初の起動    | `prev_version`, `new_version`, `os`                                            |
+| `app_start`       | 毎回のアプリ起動              | `app_version`, `os`                                                            |
+| `download_click`  | ダウンロードボタン押下        | `download_id`                                                                  |
+| `download_result` | ダウンロード完了（成功/失敗） | `download_id`, `status`, `duration_ms`, `error_category?`, `app_version`, `os` |
+
+`download_id` は各ダウンロード試行を内部的に識別するランダムな ID であり、個人や動画内容の特定には利用できません。
+
+### 送信しない情報
+
+- ファイル名 / 動画タイトル / URL / 保存パス
+- ユーザー名・アカウント情報・Cookie・認証情報
+- 個人を特定し得る一切の情報 (PII)
+
+### エラーカテゴリ
+
+失敗したダウンロードでは、内部エラーコード (`ERR::...`) から抽出した高レベル分類のみ（例: `COOKIE_MISSING`, `QUALITY_NOT_FOUND`, `NETWORK`, `MERGE_FAILED`）を送信します。
+
+### 技術的詳細
+
+- GA4 測定 ID: GitHub Actions のビルド時にバイナリへ埋め込み(G-xxxxxxxx)
+- API Secret は GitHub Actions のビルド時にバイナリへ埋め込み
+- 送信失敗（オフライン等）はリトライせず破棄
+- Secret はクライアント配布バイナリから抽出され得るため、異常トラフィック検出時は Secret ローテーション + 新バージョンリリースを推奨
+
+### リスクと今後の緩和策
+
+埋め込み Secret は不正イベント送信に悪用される可能性があります。大規模な偽データが流入した場合は Secret を更新し、将来的にプロキシ経由送信やレート制限・オプトアウト設定を導入予定です。
+
+### 予定されている改善
+
+- 設定画面からの送信オプトアウト
+- プロキシ中継による Secret 非露出化とレート制御
+
+アナリティクスに関する懸念や提案があれば Issue を作成してください。
+
 ## エラーコード
 
 フロント側で i18n マッピングされる戻り値コード:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "futures",
  "libc",
  "once_cell",
+ "rand 0.8.5",
  "reqwest",
  "rusqlite",
  "serde",
@@ -307,6 +308,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tokio",
  "xz2",
  "zip 2.4.2",
@@ -4447,6 +4449,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.3.0",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5f6fe3291bfa609c7e0b0ee3bedac294d94c7018934086ce782c1d0f2a468e"
+dependencies = [
+ "bitflags 2.9.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,8 +34,10 @@ futures = "0.3.31"
 once_cell = "1.18.0"
 base64 = "0.22.1"
 libc = "0.2"
+rand = "0.8"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
+tauri-plugin-window-state = "2"
 tauri-plugin-updater = "2"
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,47 @@
 fn main() {
+    // 開発ビルド時はルート .env を優先読み込みし GA 関連値を埋め込む
+    // .env フォーマット: KEY=VALUE (空行/ # コメント行は無視)
+    #[cfg(debug_assertions)]
+    {
+        let mut loaded: Option<&str> = None;
+        for candidate in ["../.env", ".env"] {
+            if let Ok(env_content) = std::fs::read_to_string(candidate) {
+                loaded = Some(candidate);
+                for line in env_content.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with('#') {
+                        continue;
+                    }
+                    if let Some((key, val)) = trimmed.split_once('=') {
+                        let key_u = key.trim();
+                        let val_u = val.trim();
+                        match key_u {
+                            "GA_MEASUREMENT_ID" => println!("cargo:rustc-env=GA_MEASUREMENT_ID={val_u}"),
+                            "GA_API_SECRET" => println!("cargo:rustc-env=GA_API_SECRET={val_u}"),
+                            "GA_DEBUG" => println!("cargo:rustc-env=GA_DEBUG={val_u}"),
+                            _ => {}
+                        }
+                    }
+                }
+                break;
+            }
+        }
+        match loaded {
+            Some(path) => println!("cargo:warning=Loaded GA .env from {path} (development only)"),
+            None => println!("cargo:warning=No .env found at repo root or src-tauri (.env); GA secrets not embedded"),
+        }
+    }
+
+    // CI / 本番など環境変数で直接渡された値があれば (開発でも .env が与えないキーを補完)
+    if let Ok(secret) = std::env::var("GA_API_SECRET") {
+        println!("cargo:rustc-env=GA_API_SECRET={secret}");
+    }
+    if let Ok(mid) = std::env::var("GA_MEASUREMENT_ID") {
+        println!("cargo:rustc-env=GA_MEASUREMENT_ID={mid}");
+    }
+    if let Ok(debug) = std::env::var("GA_DEBUG") {
+        println!("cargo:rustc-env=GA_DEBUG={debug}");
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/utils/analytics.rs
+++ b/src-tauri/src/utils/analytics.rs
@@ -1,0 +1,288 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use serde_json::{json, Map, Value};
+use tauri::AppHandle;
+
+static DOWNLOAD_STARTS: Lazy<Mutex<HashMap<String, Instant>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+const GA_ENDPOINT: &str = "https://www.google-analytics.com/mp/collect";
+static GA_MEASUREMENT_ID: Option<&'static str> = option_env!("GA_MEASUREMENT_ID");
+static GA_API_SECRET: Option<&'static str> = option_env!("GA_API_SECRET");
+
+// Initialize analytics on app setup.
+pub async fn init_analytics(app: &AppHandle) {
+    // If secrets are missing (empty), skip (build-time embedding should set them)
+    if GA_MEASUREMENT_ID.unwrap_or("").is_empty() || GA_API_SECRET.unwrap_or("").is_empty() {
+        #[cfg(debug_assertions)]
+        println!("[GA DISABLED] init_analytics missing GA_MEASUREMENT_ID/GA_API_SECRET");
+        return;
+    }
+
+    let lib_path = crate::utils::paths::get_lib_path(app);
+    let analytics_dir = lib_path.join(".analytics");
+    let _ = fs::create_dir_all(&analytics_dir);
+
+    let client_id = get_or_create_client_id(&analytics_dir);
+
+    let version_current = env!("CARGO_PKG_VERSION");
+    let last_version_path = analytics_dir.join("last_version");
+    let mut is_first_install = false;
+    let mut is_update = false;
+    let prev_version_opt = if last_version_path.exists() {
+        match fs::read_to_string(&last_version_path) {
+            Ok(prev) => {
+                if prev.trim() != version_current {
+                    is_update = true;
+                }
+                Some(prev.trim().to_string())
+            }
+            Err(_) => None,
+        }
+    } else {
+        is_first_install = true;
+        None
+    };
+
+    // Persist current version
+    let _ = fs::write(&last_version_path, version_current);
+
+    // Events
+    if is_first_install {
+        let mut p = Map::new();
+        p.insert("app_version".into(), Value::from(version_current));
+        p.insert("os".into(), Value::from(std::env::consts::OS));
+        let _ = send_event_internal(&client_id, "first_install", p).await;
+    } else if is_update {
+        let mut p = Map::new();
+        p.insert(
+            "prev_version".into(),
+            Value::from(prev_version_opt.unwrap_or_default()),
+        );
+        p.insert("new_version".into(), Value::from(version_current));
+        p.insert("os".into(), Value::from(std::env::consts::OS));
+        let _ = send_event_internal(&client_id, "app_update", p).await;
+    }
+
+    // Always app_start
+    let mut p = Map::new();
+    p.insert("app_version".into(), Value::from(version_current));
+    p.insert("os".into(), Value::from(std::env::consts::OS));
+    let _ = send_event_internal(&client_id, "app_start", p).await;
+}
+
+// Record user clicked download button.
+pub async fn record_download_click(app: &AppHandle, download_id: &str) {
+    if GA_MEASUREMENT_ID.unwrap_or("").is_empty() || GA_API_SECRET.unwrap_or("").is_empty() {
+        #[cfg(debug_assertions)]
+        println!("[GA DISABLED] record_download_click skipped (missing GA secrets)");
+        return;
+    }
+    let lib_path = crate::utils::paths::get_lib_path(app);
+    let client_id_path = lib_path.join(".analytics/client_id");
+    let client_id = fs::read_to_string(client_id_path).unwrap_or_else(|_| "".into());
+    if client_id.is_empty() {
+        return;
+    }
+
+    let mut p = Map::new();
+    p.insert("download_id".into(), Value::from(download_id));
+    let _ = send_event_internal(&client_id, "download_click", p).await;
+}
+
+// Mark the start time of a download.
+pub fn mark_download_start(download_id: &str) {
+    let mut map = DOWNLOAD_STARTS.lock().unwrap();
+    map.insert(download_id.to_string(), Instant::now());
+}
+
+// Finish download (success or failure) and send result.
+pub async fn finish_download(
+    app: &AppHandle,
+    download_id: &str,
+    success: bool,
+    err_code: Option<&str>,
+) {
+    if GA_MEASUREMENT_ID.unwrap_or("").is_empty() || GA_API_SECRET.unwrap_or("").is_empty() {
+        #[cfg(debug_assertions)]
+        println!("[GA DISABLED] finish_download skipped (missing GA secrets)");
+        return;
+    }
+    let start_opt = {
+        let mut map = DOWNLOAD_STARTS.lock().unwrap();
+        map.remove(download_id)
+    };
+    let duration_ms = start_opt
+        .map(|inst| inst.elapsed().as_millis() as u64)
+        .unwrap_or(0);
+
+    let lib_path = crate::utils::paths::get_lib_path(app);
+    let client_id_path = lib_path.join(".analytics/client_id");
+    let client_id = fs::read_to_string(client_id_path).unwrap_or_else(|_| "".into());
+    if client_id.is_empty() {
+        return;
+    }
+
+    let mut p = Map::new();
+    p.insert("download_id".into(), Value::from(download_id));
+    p.insert(
+        "status".into(),
+        Value::from(if success { "success" } else { "failed" }),
+    );
+    p.insert("duration_ms".into(), Value::from(duration_ms));
+    if let Some(code) = err_code {
+        if let Some(cat) = extract_error_category(code) {
+            p.insert("error_category".into(), Value::from(cat));
+        }
+    }
+    let _ = send_event_internal(&client_id, "download_result", p).await;
+}
+
+fn extract_error_category(err: &str) -> Option<String> {
+    if let Some(rest) = err.strip_prefix("ERR::") {
+        // Take up to next '::'
+        let parts: Vec<&str> = rest.split("::").collect();
+        if !parts.is_empty() {
+            return Some(parts[0].to_string());
+        }
+    }
+    None
+}
+
+// Get or create client_id file.
+fn get_or_create_client_id(dir: &PathBuf) -> String {
+    let path = dir.join("client_id");
+    if path.exists() {
+        if let Ok(val) = fs::read_to_string(&path) {
+            return val.trim().to_string();
+        }
+    }
+    let uuid = uuid_v4();
+    let _ = fs::write(&path, &uuid);
+    uuid
+}
+
+// Minimal UUID v4 (pseudo-random) generator without external crate.
+fn uuid_v4() -> String {
+    use rand::rngs::StdRng;
+    use rand::{RngCore, SeedableRng};
+    let mut rng = StdRng::from_entropy();
+    let mut bytes = [0u8; 16];
+    rng.fill_bytes(&mut bytes);
+    // Set variant and version bits
+    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 2
+    let hex = bytes
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>();
+    format!(
+        "{}{}{}{}-{}{}-{}{}-{}{}-{}{}{}{}{}{}",
+        hex[0],
+        hex[1],
+        hex[2],
+        hex[3],
+        hex[4],
+        hex[5],
+        hex[6],
+        hex[7],
+        hex[8],
+        hex[9],
+        hex[10],
+        hex[11],
+        hex[12],
+        hex[13],
+        hex[14],
+        hex[15]
+    )
+}
+
+async fn send_event_internal(
+    client_id: &str,
+    name: &str,
+    mut params: Map<String, Value>,
+) -> Result<(), String> {
+    params.insert("app_version".into(), Value::from(env!("CARGO_PKG_VERSION")));
+    params.insert("os".into(), Value::from(std::env::consts::OS));
+    params.insert("timestamp_ms".into(), Value::from(current_time_ms() as i64));
+
+    let mut event_obj = Map::new();
+    event_obj.insert("name".into(), Value::from(name));
+    event_obj.insert("params".into(), Value::from(Value::Object(params)));
+
+    let body = json!({
+        "client_id": client_id,
+        "events": [Value::Object(event_obj)],
+    });
+
+    // Debug モード判定: release build では GA_DEBUG=1 を指定しても無効 (cfg 判定)
+    #[cfg(debug_assertions)]
+    let debug_mode = true;
+    #[cfg(not(debug_assertions))]
+    let debug_mode = option_env!("GA_DEBUG") == Some("1");
+
+    let endpoint = if debug_mode {
+        "https://www.google-analytics.com/debug/mp/collect"
+    } else {
+        GA_ENDPOINT
+    };
+
+    let url = format!(
+        "{endpoint}?measurement_id={}&api_secret={}",
+        GA_MEASUREMENT_ID.unwrap_or(""),
+        GA_API_SECRET.unwrap_or("")
+    );
+    let client = Client::new();
+    let resp = client.post(url).json(&body).send().await;
+    match resp {
+        Ok(r) => {
+            let status = r.status().as_u16();
+            if debug_mode {
+                // Debug エンドポイントは常に 200 で JSON を返す想定
+                let parsed = r.json::<serde_json::Value>().await.ok();
+                let mut msgs: Vec<String> = Vec::new();
+                if let Some(p) = parsed.as_ref() {
+                    if let Some(arr) = p.get("validationMessages").and_then(|v| v.as_array()) {
+                        for m in arr.iter().take(5) {
+                            if let Some(desc) = m.get("description").and_then(|d| d.as_str()) {
+                                msgs.push(desc.to_string());
+                            }
+                        }
+                    }
+                }
+                #[cfg(debug_assertions)]
+                println!(
+                    "[GA DEBUG] event='{}' status={} messages_count={} first={:?}",
+                    name,
+                    status,
+                    msgs.len(),
+                    msgs
+                );
+            } else if !r.status().is_success() {
+                // 非 debug で失敗時は swallow
+                return Ok(());
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if debug_mode {
+                #[cfg(debug_assertions)]
+                println!("[GA DEBUG] event='{}' request error={}", name, e);
+            }
+            Ok(()) // swallow
+        }
+    }
+}
+
+fn current_time_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod downloads;
 pub mod paths;
+pub mod analytics;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/video/useVideoInfo.ts
+++ b/src/features/video/useVideoInfo.ts
@@ -13,6 +13,7 @@ import {
 import { selectDuplicateIndices } from '@/features/video/selectors'
 import { setVideo } from '@/features/video/videoSlice'
 import { enqueue } from '@/shared/queue/queueSlice'
+import { invoke } from '@tauri-apps/api/core'
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -105,6 +106,8 @@ export const useVideoInfo = () => {
       if (!videoId) return
       // Parent ID
       const parentId = `${videoId}-${Date.now()}`
+      // Analytics: record click
+      await invoke<void>('record_download_click', { downloadId: parentId })
       // Enqueue parent (placeholder filename = video.title)
       store.dispatch(
         enqueue({


### PR DESCRIPTION
* feat(analytics): introduce GA4 Measurement Protocol events (install/update/start/download) with debug endpoint logging

* chore(analytics): add debug prints when GA secrets missing

* feat(analytics): support root .env for GA secrets in dev and document usage

* 測定ID値をenv化

* fix(build): emit cargo:warning on .env load result (root or src-tauri)

* Updated

* windowポジション、サイズの保存と復元

* new version 0.5.0