### PR TITLE
style(ui): add max-width constraints to prevent layout overstretch on large screens

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -68,7 +68,7 @@ use tauri::AppHandle;
 /// * `app` - Tauriアプリケーションハンドル
 /// * `bvid` - Bilibili動画ID (BV識別子)
 /// * `cid` - 動画パートごとのコンテンツID
-/// * `filename` - 出力ファイル名（拡張子を除く）
+/// * `filename` - Output filename (extension is optional; .mp4 will be added if not present)
 /// * `quality` - 動画画質ID（利用不可の場合は最高画質にフォールバック）
 /// * `audio_quality` - 音声画質ID（利用不可の場合は最高画質にフォールバック）
 /// * `download_id` - 進捗追跡用の一意識別子
@@ -113,19 +113,17 @@ pub async fn download_video(
     };
 
     // Avoid double extension if user already provided .mp4
-    let safe_filename = if filename.to_lowercase().ends_with(".mp4") {
-        filename.to_string()
+    let filename_with_ext = if filename.to_lowercase().ends_with(".mp4") {
+        filename
     } else {
-        format!("{}.mp4", filename)
+        &format!("{filename}.mp4")
     };
 
-    // Get directory from output_path (parent() returns Option<&Path>)
-    // and construct final path by joining directory with safe filename
+    // Get directory from output_path and construct final path
     if let Some(parent) = output_path.parent() {
-        output_path = parent.join(&safe_filename);
+        output_path = parent.join(filename_with_ext);
     } else {
-        // Fallback to current directory if parent is None
-        output_path = PathBuf::from(&safe_filename);
+        output_path = PathBuf::from(filename_with_ext);
     }
     output_path = auto_rename(&output_path);
 
@@ -644,7 +642,7 @@ async fn fetch_video_details(
 /// # 引数
 ///
 /// * `app` - 設定アクセス用Tauriアプリケーションハンドル
-/// * `filename` - 希望するファイル名（拡張子を除く）
+/// * `filename` - Desired filename (extension is optional; .mp4 will be added if not present)
 ///
 /// # 戻り値
 ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,7 +243,7 @@ async fn fetch_video_info(app: AppHandle, video_id: String) -> Result<Video, Str
 /// * `app` - Tauri application handle
 /// * `bvid` - Bilibili video ID (BV identifier)
 /// * `cid` - Content ID for the specific video part
-/// * `filename` - Desired output filename (without extension)
+/// * `filename` - Desired output filename (extension is optional; .mp4 will be added if not present)
 /// * `quality` - Video quality ID (e.g., 116 for 1080P60)
 /// * `audio_quality` - Audio quality ID
 /// * `download_id` - Unique identifier for tracking this download

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -92,8 +92,8 @@ function HomePage() {
           <div className="flex h-full w-full flex-col">
             <header className="bg-accent flex">
               <SidebarTrigger
-                size={'lg'}
-                className="h-full cursor-pointer shadow-md"
+                size="lg"
+                className="h-full shrink-0 cursor-pointer shadow-md"
               />
               <AppBar user={user} theme={theme} setTheme={setTheme} />
             </header>
@@ -103,43 +103,37 @@ function HomePage() {
               }}
               className="flex w-full"
             >
-              <div className="box-border flex w-full flex-col items-center justify-center p-3">
-                <div className="flex h-full w-4/5 flex-col justify-center gap-3">
-                  <div className="block">
-                    <VideoForm1 />
+              <div className="mx-auto flex w-full max-w-5xl flex-col justify-center gap-3 p-3 sm:px-6">
+                <VideoForm1 />
+                <Separator className="my-3" />
+                {video.parts.length > 0 && (
+                  <div className="flex items-center gap-2 px-3">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleSelectAll}
+                    >
+                      {t('video.select_all')}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDeselectAll}
+                    >
+                      {t('video.deselect_all')}
+                    </Button>
                   </div>
-                  <Separator className="my-3" />
-                  {video.parts.length > 0 && (
-                    <div className="flex items-center gap-2 px-3">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleSelectAll}
-                      >
-                        {t('video.select_all')}
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleDeselectAll}
-                      >
-                        {t('video.deselect_all')}
-                      </Button>
-                    </div>
-                  )}
-                  <div className="block">
-                    {video.parts.map((_v, idx) => (
-                      <VideoForm2
-                        key={idx}
-                        video={video}
-                        page={idx + 1}
-                        isDuplicate={duplicateIndices.includes(idx)}
-                      />
-                    ))}
-                  </div>
-                  <div className="box-border flex w-full justify-center p-3">
-                    <DownloadButton />
-                  </div>
+                )}
+                {video.parts.map((_v, idx) => (
+                  <VideoForm2
+                    key={idx}
+                    video={video}
+                    page={idx + 1}
+                    isDuplicate={duplicateIndices.includes(idx)}
+                  />
+                ))}
+                <div className="box-border flex w-full justify-center p-3">
+                  <DownloadButton />
                 </div>
               </div>
               <ScrollBar />

--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -55,7 +55,7 @@ function AppBar({ user, theme, setTheme }: Props) {
   const maskedUserName = maskUserName(userName)
 
   return (
-    <div className="bg-accent box-border flex h-9 w-full items-center justify-between p-3 shadow-md">
+    <div className="bg-accent box-border flex h-9 w-full items-center justify-between px-3 shadow-md sm:mx-auto sm:max-w-7xl sm:px-6">
       <div>
         <span className="text-muted-foreground">
           {t('app.logged_in_user')}:


### PR DESCRIPTION
## Summary
Add responsive max-width constraints to AppBar and main content to prevent layout overstretch on large screens.

## Changes
- Add `max-w-7xl` with `sm:mx-auto sm:px-6` to AppBar for responsive centering
- Add `max-w-5xl` with `mx-auto` to main content container
- Remove unnecessary wrapper `div` elements for cleaner code structure
- Update Rust documentation comments to English for consistency
- Bump version to 0.10.3

## Test Plan
- [ ] Test on large screen (1920px+) to verify max-width constraints
- [ ] Test on mobile (375px) to verify responsive behavior
- [ ] Verify dark/light mode both work correctly
- [ ] Check that no horizontal scrolling occurs on any screen size

---
🤖 Generated with [Claude Code](https://claude.ai/code)