### PR TITLE
chore(release): bump version to 0.13.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Bump version from 0.12.3 to 0.13.0 in tauri.conf.json

## Changes
- Updated version field in `src-tauri/tauri.conf.json` from `0.12.3` to `0.13.0`

## Test Plan
- [x] Verified that `tauri.conf.json` version is correctly set to `0.13.0`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)