### PR TITLE
fix: Clear queue when URL changes to prevent stale completion UI

### DIFF
--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -40,37 +40,25 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const setupListener = async (): Promise<void> => {
       unlisten = await listen('progress', (event) => {
         const payload = event.payload as Progress
+        const { stage, downloadId } = payload
         store.dispatch(setProgress(payload))
 
         // Update queue status based on progress stage
-        const stage = payload.stage
+        const isDownloadStage =
+          stage && ['audio', 'video', 'merge'].includes(stage)
         if (stage === 'complete') {
           // Mark as done - keep in queue so completion actions remain visible
-          store.dispatch(
-            updateQueueStatus({
-              downloadId: payload.downloadId,
-              status: 'done',
-            }),
-          )
-        } else if (
-          stage === 'audio' ||
-          stage === 'video' ||
-          stage === 'merge'
-        ) {
+          store.dispatch(updateQueueStatus({ downloadId, status: 'done' }))
+        } else if (isDownloadStage) {
           // Mark as running when download stages start
-          store.dispatch(
-            updateQueueStatus({
-              downloadId: payload.downloadId,
-              status: 'running',
-            }),
-          )
+          store.dispatch(updateQueueStatus({ downloadId, status: 'running' }))
         }
 
         // Show toast for quality fallback warnings
-        if (
+        const isFallbackWarning =
           stage === 'warn-video-quality-fallback' ||
           stage === 'warn-audio-quality-fallback'
-        ) {
+        if (isFallbackWarning) {
           const key =
             stage === 'warn-video-quality-fallback'
               ? 'video.video_quality_fallback'

--- a/src/features/video/hooks/useVideoInfo.ts
+++ b/src/features/video/hooks/useVideoInfo.ts
@@ -13,7 +13,12 @@ import {
 import { selectDuplicateIndices } from '@/features/video/model/selectors'
 import { setVideo } from '@/features/video/model/videoSlice'
 import { setError } from '@/shared/downloadStatus/downloadStatusSlice'
-import { clearQueue, clearQueueItem, enqueue } from '@/shared/queue/queueSlice'
+import {
+  clearQueue,
+  clearQueueItem,
+  enqueue,
+  findCompletedItemForPart,
+} from '@/shared/queue/queueSlice'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -247,15 +252,7 @@ export const useVideoInfo = () => {
         .filter(({ pi }) => pi.selected)
 
       for (const { idx } of selectedParts) {
-        // Find and clear completed items for this part index
-        const completedItem = state.queue.find((item) => {
-          const match = item.downloadId.match(/-p(\d+)$/)
-          return (
-            match &&
-            parseInt(match[1], 10) === idx + 1 &&
-            item.status === 'done'
-          )
-        })
+        const completedItem = findCompletedItemForPart(state, idx + 1)
         if (completedItem) {
           store.dispatch(clearQueueItem(completedItem.downloadId))
         }

--- a/src/shared/queue/queueSlice.ts
+++ b/src/shared/queue/queueSlice.ts
@@ -1,3 +1,4 @@
+import type { RootState } from '@/app/store'
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 
@@ -145,6 +146,28 @@ export const {
   clearQueueItem,
 } = queueSlice.actions
 export default queueSlice.reducer
+
+/**
+ * Finds a completed queue item for a specific part index.
+ *
+ * Extracts part index from downloadId using regex pattern `-p(\d+)$`.
+ * Returns the item if found, matches the part index, and has status 'done'.
+ *
+ * @param state - Redux root state
+ * @param partIndex - One-based part number (matches the number in downloadId)
+ * @returns Queue item if found and completed, undefined otherwise
+ */
+export function findCompletedItemForPart(
+  state: RootState,
+  partIndex: number,
+): QueueItem | undefined {
+  return state.queue.find((item) => {
+    const match = item.downloadId.match(/-p(\d+)$/)
+    return (
+      match && parseInt(match[1], 10) === partIndex && item.status === 'done'
+    )
+  })
+}
 
 /**
  * Selects download ID by part index from queue.


### PR DESCRIPTION
## Summary
Fixes a bug where the download completion UI from a previous video would remain visible when the user changes the URL to fetch a new video.

## Changes
- Add `clearQueue()` dispatch in `onValid1()` before fetching new video info
- This ensures that all queue items (pending, running, completed) are cleared when switching to a new video URL
- Code quality improvements via `/review-all`:
  - Extract `StageProgress` component to reduce duplication in `PartDownloadProgress`
  - Extract `QualityRadioGroup` component to reduce duplication in `VideoPartCard`
  - Add `findCompletedItemForPart` utility to `queueSlice` for code reuse
  - Simplify stage checking logic in `ListenerContext`

## Test Plan
1. Load video URL A and start a download
2. Wait for download to complete (completion UI should be visible)
3. Change URL to video B
4. Verify that the completion UI from video A is no longer displayed
5. Verify that the new video B information loads correctly without stale UI states

---
🤖 Generated with [Claude Code](https://claude.ai/code)