### PR TITLE
fix: correct history file size and use user-specified title

### DIFF
--- a/src/features/history/ui/HistoryItem.tsx
+++ b/src/features/history/ui/HistoryItem.tsx
@@ -33,9 +33,9 @@ function formatDate(dateString: string, locale: string): string {
 
 function formatFileSize(bytes?: number): string {
   if (!bytes) return '-'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes < 1000) return `${bytes} B`
+  if (bytes < 1000 * 1000) return `${(bytes / 1000).toFixed(1)} KB`
+  return `${(bytes / (1000 * 1000)).toFixed(1)} MB`
 }
 
 const ThumbnailPlaceholder = () => (

--- a/src/features/settings/api/settingApi.ts
+++ b/src/features/settings/api/settingApi.ts
@@ -15,11 +15,8 @@ import { invoke } from '@tauri-apps/api/core'
  * console.log(settings.language) // 'en', 'ja', etc.
  * ```
  */
-export const callGetSettings = async () => {
-  const res = await invoke<Settings>('get_settings')
-
-  return res
-}
+export const callGetSettings = async (): Promise<Settings> =>
+  invoke<Settings>('get_settings')
 
 /**
  * Persists application settings to the Tauri backend.
@@ -36,11 +33,8 @@ export const callGetSettings = async () => {
  * await callSetSettings({ dlOutputPath: '/downloads', language: 'en' })
  * ```
  */
-export const callSetSettings = async (settings: Settings) => {
-  const res = await invoke('set_settings', { settings })
-
-  return res
-}
+export const callSetSettings = async (settings: Settings): Promise<void> =>
+  invoke('set_settings', { settings })
 
 /**
  * Updates the library storage path and moves ffmpeg to the new location.
@@ -59,11 +53,8 @@ export const callSetSettings = async (settings: Settings) => {
  * // This will move ffmpeg to '/Volumes/ExternalDrive/MyLib/lib/'
  * ```
  */
-export const callUpdateLibPath = async (newPath: string) => {
-  const res = await invoke('update_lib_path', { newPath })
-
-  return res
-}
+export const callUpdateLibPath = async (newPath: string): Promise<void> =>
+  invoke('update_lib_path', { newPath })
 
 /**
  * Retrieves the current library path.
@@ -79,8 +70,5 @@ export const callUpdateLibPath = async (newPath: string) => {
  * console.log(libPath) // '/Users/xxx/Library/Application Support/com.bilibili.downloader/lib'
  * ```
  */
-export const callGetCurrentLibPath = async () => {
-  const res = await invoke<string>('get_current_lib_path')
-
-  return res
-}
+export const callGetCurrentLibPath = async (): Promise<string> =>
+  invoke<string>('get_current_lib_path')


### PR DESCRIPTION
## Summary

- **Fix file size**: Use actual merged file size instead of incorrect HEAD request values (e.g., 292B)
- **Fix title**: Use user-specified filename (without extension) instead of Bilibili API title
- **Add HTTP status check**: Ignore non-200 responses in HEAD requests for disk space validation
- **Change to decimal base**: File size display now uses 1 MB = 1,000,000 bytes (matches Finder/Explorer)
- **Code simplification**: Extract `build_ffmpeg_bin_path` helper to reduce duplication in ffmpeg.rs

## Problem

History entries were showing incorrect file sizes (292B, 146B) instead of actual sizes (14.9MB). The root cause was that `head_content_length()` was returning error response sizes from HEAD requests (403 Forbidden).

Additionally, history titles were using Bilibili API titles instead of the user-specified filename.

## Solution

1. **File size**: Get actual file size using `std::fs::metadata()` after merge completes
2. **Title**: Pass user-specified filename (without extension) to history entry
3. **HTTP validation**: Check response status before reading `Content-Length` header
4. **Display format**: Use decimal base (1000) instead of binary base (1024) for consistency with OS file managers
5. **Code quality**: Refactored ffmpeg.rs and settingApi.ts to reduce duplication

## Test plan

- [x] Download a video and verify file size matches Finder/Explorer
- [x] Verify history title matches user-specified filename
- [x] Check that 403 errors in HEAD requests are logged but don't affect downloads
- [x] Run `/review-all` - code review, simplification, and formatting completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)