### PR TITLE
refactor: remove configurable download speed threshold

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -158,12 +158,7 @@ pub async fn download_video(
         return Err("ERR::COOKIE_MISSING".into());
     }
 
-    // 3. 設定から速度閾値を取得
-    let min_speed_threshold = settings::get_settings(app)
-        .await?
-        .download_speed_threshold_mbps;
-
-    // 4. 動画詳細取得 (選択品質のURL抽出)
+    // 3. 動画詳細取得 (選択品質のURL抽出)
     let details = fetch_video_details(&cookies, bvid, cid).await?;
 
     let dash_data = details
@@ -213,7 +208,6 @@ pub async fn download_video(
                 cookie.clone(),
                 true,
                 Some(download_id.clone()),
-                Some(min_speed_threshold),
             )
         }),
         retry_download(|| {
@@ -224,7 +218,6 @@ pub async fn download_video(
                 cookie.clone(),
                 true,
                 Some(download_id.clone()),
-                Some(min_speed_threshold),
             )
         }),
     ) {

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -112,7 +112,6 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         None,
         true,
         None,
-        None, // No speed check for small files
     )
     .await
     .is_err()

--- a/src-tauri/src/handlers/settings.rs
+++ b/src-tauri/src/handlers/settings.rs
@@ -144,7 +144,6 @@ async fn validate_settings(app: &AppHandle, filepath: &PathBuf) -> Result<bool> 
         .and_then(|p| p.to_str().map(|s| s.to_string()));
     let default_settings = Settings {
         dl_output_path: default_dl_path,
-        download_speed_threshold_mbps: 1.0, // Default 1 MB/s
         ..Default::default()
     };
     let json = serde_json::to_string_pretty(&default_settings)?;

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -21,26 +21,9 @@ pub struct Settings {
     /// a different drive or location with more storage space.
     #[serde(rename = "libPath")]
     pub lib_path: Option<String>,
-    /// Download speed threshold in MB/s for initial speed check.
-    ///
-    /// If the initial download speed (measured over SPEED_CHECK_SIZE bytes)
-    /// falls below this threshold, the connection will be dropped and retried
-    /// to get a different CDN node.
-    ///
-    /// Defaults to 1.0 MB/s if not specified in settings.json.
-    #[serde(
-        rename = "downloadSpeedThresholdMbps",
-        default = "default_speed_threshold"
-    )]
-    pub download_speed_threshold_mbps: f64,
     //
     // TODO: 現状は利用していない
     // pub theme: Theme,
-}
-
-/// Default speed threshold of 1.0 MB/s.
-fn default_speed_threshold() -> f64 {
-    1.0
 }
 
 /// Supported UI languages.

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -125,7 +125,6 @@ function SettingsForm() {
     defaultValues: {
       dlOutputPath: settings.dlOutputPath || '',
       language: settings.language || 'en',
-      downloadSpeedThresholdMbps: settings.downloadSpeedThresholdMbps ?? 1.0,
     },
     mode: 'onBlur',
   })
@@ -135,19 +134,13 @@ function SettingsForm() {
     form.reset({
       dlOutputPath: settings.dlOutputPath || '',
       language: settings.language || 'en',
-      downloadSpeedThresholdMbps: settings.downloadSpeedThresholdMbps ?? 1.0,
     })
-  }, [
-    form,
-    settings.dlOutputPath,
-    settings.language,
-    settings.downloadSpeedThresholdMbps,
-  ])
+  }, [form, settings.dlOutputPath, settings.language])
 
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
-    const changedKeys = (
-      ['dlOutputPath', 'language', 'downloadSpeedThresholdMbps'] as const
-    ).filter((key) => data[key] !== settings[key])
+    const changedKeys = (['dlOutputPath', 'language'] as const).filter(
+      (key) => data[key] !== settings[key],
+    )
 
     if (changedKeys.length === 0) return
 
@@ -237,39 +230,6 @@ function SettingsForm() {
               </div>
               <FormDescription>
                 {t('settings.output_dir_description')}
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <Separator />
-        <FormField
-          control={form.control}
-          name="downloadSpeedThresholdMbps"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>{t('settings.speed_threshold_label')}</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  step="0.1"
-                  min="0.1"
-                  max="100"
-                  placeholder="1.0"
-                  {...field}
-                  value={field.value ?? 1.0}
-                  onChange={(e) => {
-                    const num = parseFloat(e.target.value)
-                    field.onChange(isNaN(num) ? 1.0 : num)
-                  }}
-                  onBlur={() => {
-                    field.onBlur()
-                    form.handleSubmit(onSubmit)()
-                  }}
-                />
-              </FormControl>
-              <FormDescription>
-                {t('settings.speed_threshold_description')}
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/src/features/settings/dialog/formSchema.ts
+++ b/src/features/settings/dialog/formSchema.ts
@@ -108,15 +108,6 @@ export const buildSettingsFormSchema = (t: TFunction) =>
     language: z.enum(['en', 'ja', 'fr', 'es', 'zh', 'ko'] as const, {
       message: t('validation.language.required'),
     }),
-    downloadSpeedThresholdMbps: z
-      .number()
-      .min(0.1, {
-        message: t('validation.speed_threshold.too_low'),
-      })
-      .max(100, {
-        message: t('validation.speed_threshold.too_high'),
-      })
-      .optional(),
     libPath: z
       .string()
       .max(1024, {

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -16,15 +16,6 @@ export interface Settings {
    * a different drive or location with more storage space.
    */
   libPath?: string
-  /**
-   * Download speed threshold in MB/s for initial speed check.
-   *
-   * If the initial download speed (measured over 1MB) falls below this threshold,
-   * the connection will be dropped and retried to get a different CDN node.
-   *
-   * @default 1.0
-   */
-  downloadSpeedThresholdMbps?: number
   // Frontendのみの管理につき、localStorageでのみ保存している
   // TODO: themeをjson管理
   // theme: 'light' | 'dark'

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -138,8 +138,6 @@
     "output_dir_button": "Select",
     "output_dir_changing": "Selecting...",
     "output_dir_dialog_title": "Select Output Directory",
-    "speed_threshold_label": "Speed Threshold (MB/s)",
-    "speed_threshold_description": "If initial download speed is below this threshold, the connection will be retried to get a faster CDN node. Default: 1.0 MB/s.",
     "auto_save_note": "Changes are saved automatically.",
     "dialog_title": "Settings",
     "save_success": "Settings saved",
@@ -175,10 +173,6 @@
     },
     "language": {
       "required": "Please select a language."
-    },
-    "speed_threshold": {
-      "too_low": "Speed threshold must be at least 0.1 MB/s.",
-      "too_high": "Speed threshold must be at most 100 MB/s."
     },
     "video": {
       "url": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -134,8 +134,6 @@
     "output_dir_button": "Seleccionar",
     "output_dir_changing": "Seleccionando...",
     "output_dir_dialog_title": "Seleccionar directorio de salida",
-    "speed_threshold_label": "Umbral de velocidad (MB/s)",
-    "speed_threshold_description": "Si la velocidad de descarga inicial está por debajo de este umbral, se volverá a intentar la conexión para obtener un nodo CDN más rápido. Predeterminado: 1.0 MB/s.",
     "auto_save_note": "Los cambios se guardan automáticamente.",
     "dialog_title": "Configuración",
     "save_success": "Configuración guardada",
@@ -170,10 +168,6 @@
       }
     },
     "language": { "required": "Selecciona un idioma." },
-    "speed_threshold": {
-      "too_low": "El umbral de velocidad debe ser al menos 0.1 MB/s.",
-      "too_high": "El umbral de velocidad no debe exceder 100 MB/s."
-    },
     "video": {
       "url": {
         "min": "La URL debe tener al menos 2 caracteres.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -134,8 +134,6 @@
     "output_dir_button": "Sélectionner",
     "output_dir_changing": "Sélection...",
     "output_dir_dialog_title": "Sélectionner le répertoire de sortie",
-    "speed_threshold_label": "Seuil de vitesse (Mo/s)",
-    "speed_threshold_description": "Si la vitesse de téléchargement initiale est inférieure à ce seuil, la connexion sera réessayée pour obtenir un nœud CDN plus rapide. Par défaut : 1.0 Mo/s.",
     "auto_save_note": "Les modifications sont enregistrées automatiquement.",
     "dialog_title": "Paramètres",
     "save_success": "Paramètres enregistrés",
@@ -170,10 +168,6 @@
       }
     },
     "language": { "required": "Veuillez sélectionner une langue." },
-    "speed_threshold": {
-      "too_low": "Le seuil de vitesse doit être d'au moins 0,1 Mo/s.",
-      "too_high": "Le seuil de vitesse ne doit pas dépasser 100 Mo/s."
-    },
     "video": {
       "url": {
         "min": "L'URL doit contenir au moins 2 caractères.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -138,8 +138,6 @@
     "output_dir_button": "選択",
     "output_dir_changing": "選択中...",
     "output_dir_dialog_title": "出力ディレクトリを選択",
-    "speed_threshold_label": "速度閾値 (MB/s)",
-    "speed_threshold_description": "初速ダウンロード速度がこの閾値を下回る場合、より高速なCDNノードを取得するために再接続します。デフォルト: 1.0 MB/s。",
     "auto_save_note": "変更は自動的に保存されます。",
     "dialog_title": "設定",
     "save_success": "設定を保存しました",
@@ -175,10 +173,6 @@
     },
     "language": {
       "required": "言語を選択してください。"
-    },
-    "speed_threshold": {
-      "too_low": "速度閾値は 0.1 MB/s 以上で設定してください。",
-      "too_high": "速度閾値は 100 MB/s 以下で設定してください。"
     },
     "video": {
       "url": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -134,8 +134,6 @@
     "output_dir_button": "선택",
     "output_dir_changing": "선택 중...",
     "output_dir_dialog_title": "출력 디렉터리 선택",
-    "speed_threshold_label": "속도 임계값 (MB/s)",
-    "speed_threshold_description": "초기 다운로드 속도가 이 임계값보다 낮으면 더 빠른 CDN 노드를 얻기 위해 연결이 다시 시도됩니다. 기본값: 1.0 MB/s.",
     "auto_save_note": "변경 사항은 자동 저장됩니다.",
     "dialog_title": "설정",
     "save_success": "설정을 저장했습니다",
@@ -170,10 +168,6 @@
       }
     },
     "language": { "required": "언어를 선택하세요." },
-    "speed_threshold": {
-      "too_low": "속도 임계값은 최소 0.1 MB/s여야 합니다.",
-      "too_high": "속도 임계값은 최대 100 MB/s여야 합니다."
-    },
     "video": {
       "url": {
         "min": "URL은 최소 2자여야 합니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -134,8 +134,6 @@
     "output_dir_button": "选择",
     "output_dir_changing": "选择中...",
     "output_dir_dialog_title": "选择输出目录",
-    "speed_threshold_label": "速度阈值 (MB/s)",
-    "speed_threshold_description": "如果初始下载速度低于此阈值，将重试连接以获取更快的 CDN 节点。默认值：1.0 MB/s。",
     "auto_save_note": "更改会自动保存。",
     "dialog_title": "设置",
     "save_success": "设置已保存",
@@ -170,10 +168,6 @@
       }
     },
     "language": { "required": "请选择语言。" },
-    "speed_threshold": {
-      "too_low": "速度阈值至少为 0.1 MB/s。",
-      "too_high": "速度阈值不能超过 100 MB/s。"
-    },
     "video": {
       "url": {
         "min": "链接至少需要 2 个字符。",


### PR DESCRIPTION
## Summary
- Remove configurable `download_speed_threshold_mbps` setting from backend and frontend
- Use fixed `MIN_SPEED_THRESHOLD` constant (100 KB/s) instead
- Simplify settings UI by removing speed threshold input field
- Remove speed threshold translation keys from all i18n files

## Test plan
- [x] Run `npm run tauri dev` to verify settings dialog loads correctly
- [x] Verify download still works with fixed speed threshold
- [x] Test video download functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)