### PR TITLE
style: remove shadow from sidebar trigger

### DIFF
--- a/src/shared/layout/PageLayout.tsx
+++ b/src/shared/layout/PageLayout.tsx
@@ -111,10 +111,10 @@ export function PageLayout({
         </Sidebar>
         <SidebarInset>
           <div className="flex h-full w-full flex-col">
-            <header className="bg-accent flex">
+            <header className="bg-accent flex shadow-md">
               <SidebarTrigger
                 size="lg"
-                className="h-full shrink-0 cursor-pointer shadow-md"
+                className="h-full shrink-0 cursor-pointer"
               />
               <AppBar user={user} theme={theme} setTheme={setTheme} />
             </header>

--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -56,7 +56,7 @@ function AppBar({ user, theme, setTheme }: Props) {
   const maskedUserName = isLoggedIn ? maskUserName(userName) : ''
 
   return (
-    <div className="bg-accent box-border flex h-9 w-full items-center justify-between px-3 shadow-md sm:mx-auto sm:max-w-7xl sm:px-6">
+    <div className="bg-accent box-border flex h-9 w-full items-center justify-between px-3 sm:mx-auto sm:max-w-7xl sm:px-6">
       <div>
         <span className="text-muted-foreground">
           {t('app.logged_in_user')}:


### PR DESCRIPTION
## Summary
- Move `shadow-md` class from `SidebarTrigger` to parent `<header>` element to centralize shadow styling
- Remove redundant `shadow-md` from `AppBar.tsx` since the header now handles the shadow

## Changes
- **PageLayout.tsx**: Move shadow styling from component to container level
- **AppBar.tsx**: Remove duplicate shadow class

## Test plan
- [x] Visual verification of shadow appearance on header
- [x] Sidebar trigger button no longer has individual shadow
- [x] Code review passed (/review-all executed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)