### PR TITLE
feat: add GitHub downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
 ![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
 
 Windows and macOS Bilibili video downloader GUI. Frontend is built with React + Vite; the desktop app is powered by Tauri (Rust).
 


### PR DESCRIPTION
## Summary

- Add total downloads count badge using Shields.io to demonstrate user adoption and provide social proof
- Badge displays cumulative download count across all releases
- Helps users understand project's adoption rate

## Test plan

- [x] Badge renders correctly in README
- [x] Shields.io endpoint returns valid data
- [x] Verify badge displays actual download count after GitHub App authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)