### PR TITLE
chore: update release workflow based on tauri2-react-starter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest' # Intel
             args: '--target x86_64-apple-darwin'
+          # Uncomment to enable Linux builds
+          # - platform: 'ubuntu-22.04'
+          #   args: ''
           - platform: 'windows-latest'
             args: ''
 
@@ -120,6 +123,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # Uncomment to enable Linux builds
+      # - name: Install dependencies (Ubuntu only)
+      #   if: matrix.platform == 'ubuntu-22.04'
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
       - name: Install frontend dependencies (npm ci)
         if: ${{ hashFiles('package-lock.json') != '' }}
         run: npm ci
@@ -133,8 +143,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          GA_API_SECRET: ${{ secrets.GA_API_SECRET }}
-          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'


### PR DESCRIPTION
## Summary

Update the GitHub Actions release workflow (`.github/workflows/release.yml`) based on the modern patterns from `tauri2-react-starter` repository.

## Changes

- **Remove GA4 environment variables**: Remove `GA_API_SECRET` and `GA_MEASUREMENT_ID` (analytics no longer needed)
- **Add Ubuntu build configuration (commented out)**: Prepare for Linux builds - see #110 for future implementation
- **Keep Node.js 20.x**: Maintain stability with pinned version instead of `lts/*`
- **Modern reference**: Align workflow structure with `tauri2-react-starter`

## Related Issues

- #110 - Enable Linux builds in CI/CD (Ubuntu config prepared but commented out)

## Test Plan

- [x] Workflow syntax is valid
- [x] GA4 removal doesn't break existing builds
- [x] Ubuntu build configuration is ready for future #110 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)