### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- MINOR version bump (1.2.1 → 1.3.0) for GitHub release notes integration
- Update notification UI improvements (new feature, not breaking change)
- Rust type errors fix (updater module)

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Chore (version bump)

## Test plan

- [x] Build verification: `npm run build` passed
- [x] Linter check: `npm run lint` passed
- [x] Type check: `npm run typecheck` passed
- N/A (configuration change only)

## Breaking Changes

None

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)