### PR TITLE
feat: Replace login user label with user icon and add tooltip

### DIFF
--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/shared/animate-ui/radix/tooltip'
 import { Button } from '@/shared/ui/button'
 import { UserRound } from 'lucide-react'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -53,14 +52,10 @@ type Props = {
  * ```
  */
 function AppBar({ user, theme, setTheme }: Props) {
-  const userName = user.data.uname
-  const isLoggedIn = user.data.isLogin
   const { t } = useTranslation()
   const { updateOpenDialog } = useSettings()
-  const [hover, setHover] = useState(false)
 
-  // Mask last 3 characters of the user ID for display
-  const maskedUserName = isLoggedIn ? maskUserName(userName) : ''
+  const maskedUserName = user.data.isLogin ? maskUserName(user.data.uname) : ''
 
   return (
     <div className="bg-accent box-border flex h-9 w-full items-center justify-between px-3 sm:mx-auto sm:max-w-7xl sm:px-6">
@@ -76,9 +71,9 @@ function AppBar({ user, theme, setTheme }: Props) {
                 {maskedUserName || t('user.not_logged_in')}
               </span>
             </TooltipTrigger>
-            {isLoggedIn && userName && (
+            {user.data.isLogin && user.data.uname && (
               <TooltipContent>
-                <p>{userName}</p>
+                <p>{user.data.uname}</p>
               </TooltipContent>
             )}
           </Tooltip>
@@ -91,12 +86,10 @@ function AppBar({ user, theme, setTheme }: Props) {
           variant="ghost"
           size="icon"
           className="size-7"
-          onMouseEnter={() => setHover(true)}
-          onMouseLeave={() => setHover(false)}
           onClick={() => updateOpenDialog(true)}
           aria-label={t('settings.open_dialog')}
         >
-          <Settings animate={hover} size={18} />
+          <Settings animateOnHover size={18} />
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replace the "Logged-in user:" text label with a user icon and add an animated tooltip to show the full username on hover.

## Changes

- **User Icon**: Replace the text label "Logged-in user:" with a `UserRound` icon from lucide-react
  - Icon size: 16px (size-4) with muted foreground color
  - Marked as decorative with `aria-hidden="true"`
- **Tooltip**: Add animated tooltip using radix-ui components
  - Shows full username on hover (masked username displayed by default)
  - Only displays when logged in with a valid username
  - Includes `cursor-help` class to indicate hover functionality
- **Layout**: Update user info section to use flexbox with gap-2 for proper alignment
- **Formatting**: Prettier applied (import order and className property order)

## Benefits

- **Improved Visual Design**: User icon provides better visual separation and modern look
- **Space Saving**: Removes text label, making the AppBar more compact
- **Better UX**: Animated tooltip reveals full username on hover while maintaining privacy masking
- **i18n Simplification**: No need to translate "Logged-in user:" text label

## Test Plan

- [x] Linter passes (ESLint)
- [x] Type checking passes (TypeScript)
- [x] Build succeeds
- [x] Manual testing: Start app with `npm run tauri dev` and verify:
  - User icon appears next to masked username
  - Hovering over username shows tooltip with full username
  - No tooltip appears when not logged in

## Related Issues

None

---
🤖 Generated with [Claude Code](https://claude.ai/code)