### PR TITLE
remove: AppBarの設定ボタンを削除

### DIFF
--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -1,14 +1,11 @@
 import ToggleThemeButton from '@/features/preference/ui/ToggleThemeButton'
-import { useSettings } from '@/features/settings/useSettings'
 import type { User } from '@/features/user'
-import { Settings } from '@/shared/animate-ui/icons/settings'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
-import { Button } from '@/shared/ui/button'
 import { UserRound } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -41,7 +38,6 @@ type Props = {
  *
  * Displays:
  * - Logged-in username (masked for privacy)
- * - Settings button (opens settings dialog)
  * - Theme toggle button
  *
  * @param props - Component props
@@ -53,7 +49,6 @@ type Props = {
  */
 function AppBar({ user, theme, setTheme }: Props) {
   const { t } = useTranslation()
-  const { updateOpenDialog } = useSettings()
 
   const maskedUserName = user.data.isLogin ? maskUserName(user.data.uname) : ''
 
@@ -81,16 +76,6 @@ function AppBar({ user, theme, setTheme }: Props) {
       </div>
       <div className="flex items-center">
         <ToggleThemeButton theme={theme} setTheme={setTheme} />
-        <div className="mx-1.5" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={() => updateOpenDialog(true)}
-          aria-label={t('settings.open_dialog')}
-        >
-          <Settings animateOnHover size={18} />
-        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要

AppBarから設定ボタンを削除しました。

## 変更内容

- AppBarの設定ボタンを削除
- 不要なインポートを削除 (`useSettings`, `Settings`, `Button`)
- JSDocコメントを更新

## 理由

設定ボタンはサイドバーのフッターに既に存在するため、AppBarからの重複した設定ボタンを削除しました。

## テスト計画

- [x] 設定ダイアログがサイドバーのフッターから開けることを確認
- [x] AppBarが正常に表示されることを確認
- [x] テーマ切替ボタンが正常に動作することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)