### PR TITLE
Fix history item title truncation timing

### DIFF
--- a/src/features/history/ui/HistoryItem.tsx
+++ b/src/features/history/ui/HistoryItem.tsx
@@ -144,7 +144,9 @@ function HistoryItem({ entry, onDelete }: Props) {
 
       <div className="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
         <div className="flex items-center gap-2">
-          <h3 className="line-clamp-1 font-semibold">{entry.title}</h3>
+          <h3 className="min-w-0 flex-1 truncate font-semibold">
+            {entry.title}
+          </h3>
           <span
             className={cn(
               'rounded-full px-2 py-0.5 text-xs font-medium',

--- a/src/shared/animate-ui/effects/motion-highlight.tsx
+++ b/src/shared/animate-ui/effects/motion-highlight.tsx
@@ -367,14 +367,10 @@ function getNonOverridingDataAttributes(
   element: React.ReactElement,
   dataAttributes: Record<string, unknown>,
 ): Record<string, unknown> {
-  return Object.keys(dataAttributes).reduce<Record<string, unknown>>(
-    (acc, key) => {
-      if ((element.props as Record<string, unknown>)[key] === undefined) {
-        acc[key] = dataAttributes[key]
-      }
-      return acc
-    },
-    {},
+  return Object.fromEntries(
+    Object.entries(dataAttributes).filter(
+      ([key]) => (element.props as Record<string, unknown>)[key] === undefined,
+    ),
   )
 }
 

--- a/src/shared/animate-ui/icons/icon.tsx
+++ b/src/shared/animate-ui/icons/icon.tsx
@@ -369,13 +369,10 @@ function getVariants<
 
   if (animationType in staticAnimations) {
     const variant = staticAnimations[animationType as StaticAnimations]
+    const skipGroup = animationType === 'path' || animationType === 'path-loop'
     result = {} as T
     for (const key in animations.default) {
-      if (
-        (animationType === 'path' || animationType === 'path-loop') &&
-        key.includes('group')
-      )
-        continue
+      if (skipGroup && key.includes('group')) continue
       result[key] = variant as T[Extract<keyof T, string>]
     }
   } else {
@@ -389,6 +386,12 @@ function getVariants<
       const transition = state.animate?.transition
       if (!transition) continue
 
+      const loopTransition = {
+        repeat: Infinity,
+        repeatType: 'loop' as const,
+        repeatDelay: loopDelay,
+      }
+
       const hasNestedKeys = Object.values(transition).some(
         (v) =>
           typeof v === 'object' &&
@@ -400,21 +403,11 @@ function getVariants<
         for (const prop in transition) {
           const subTrans = transition[prop]
           if (typeof subTrans === 'object' && subTrans !== null) {
-            transition[prop] = {
-              ...subTrans,
-              repeat: Infinity,
-              repeatType: 'loop',
-              repeatDelay: loopDelay,
-            }
+            transition[prop] = { ...subTrans, ...loopTransition }
           }
         }
       } else {
-        state.animate.transition = {
-          ...transition,
-          repeat: Infinity,
-          repeatType: 'loop',
-          repeatDelay: loopDelay,
-        }
+        state.animate.transition = { ...transition, ...loopTransition }
       }
     }
   }

--- a/src/shared/layout/PageLayout.tsx
+++ b/src/shared/layout/PageLayout.tsx
@@ -79,10 +79,10 @@ function EnhancedSidebarTrigger({ className }: { className?: string }) {
   const { t } = useTranslation()
 
   const isExpanded = state === 'expanded'
-  const icon = isExpanded ? <PanelLeftClose /> : <PanelLeft />
   const label = isExpanded
     ? t('nav.aria.closeSidebar') || 'Close sidebar'
     : t('nav.aria.openSidebar') || 'Open sidebar'
+  const Icon = isExpanded ? PanelLeftClose : PanelLeft
 
   return (
     <Tooltip>
@@ -94,7 +94,7 @@ function EnhancedSidebarTrigger({ className }: { className?: string }) {
           onClick={toggleSidebar}
           aria-label={label}
         >
-          {icon}
+          <Icon />
           <span className="sr-only">{label}</span>
         </Button>
       </TooltipTrigger>

--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -57,6 +57,8 @@ function AppBar({ user, theme, setTheme }: Props) {
 
   const maskedUserName = user.data.isLogin ? maskUserName(user.data.uname) : ''
 
+  const showTooltip = user.data.isLogin && user.data.uname
+
   return (
     <div className="bg-accent box-border flex h-9 w-full items-center justify-between px-3 sm:mx-auto sm:max-w-7xl sm:px-6">
       <div className="flex items-center gap-2">
@@ -71,7 +73,7 @@ function AppBar({ user, theme, setTheme }: Props) {
                 {maskedUserName || t('user.not_logged_in')}
               </span>
             </TooltipTrigger>
-            {user.data.isLogin && user.data.uname && (
+            {showTooltip && (
               <TooltipContent>
                 <p>{user.data.uname}</p>
               </TooltipContent>


### PR DESCRIPTION
## Summary
Fix the timing of title text truncation in history items to prevent status badges from stacking vertically when titles are long.

## Changes
- **HistoryItem.tsx**: Added `min-w-0` and `flex-1` classes to the title element to enable proper text truncation within flexbox
- **Code quality improvements**: Simplified 4 additional files via /review-all:
  - AppBar.tsx: Extracted `showTooltip` variable to reduce duplicated conditional checks
  - PageLayout.tsx: Simplified component structure
  - motion-highlight.tsx: Simplified `getNonOverridingDataAttributes` function
  - icon.tsx: Extracted conditions and objects to reduce duplication

## Test Plan
- View history items with long titles
- Verify status badges (success/failed) remain horizontally aligned next to truncated titles
- Confirm "..." ellipsis appears earlier to prevent vertical badge stacking

---
🤖 Generated with [Claude Code](https://claude.ai/code)