### PR TITLE
chore(release): bump version to 1.4.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Bump version to 1.4.1 for the patch release.

## Changes
- Updated version from 1.4.0 to 1.4.1 in `src-tauri/tauri.conf.json`

## Test Plan
- Version number correctly updated in configuration file

---
🤖 Generated with [Claude Code](https://claude.ai/code)