### PR TITLE
feat: Implement Redux-based sidebar state management to persist state across page navigations

### DIFF
--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -1,16 +1,9 @@
-/**
- * Redux store configuration module.
- *
- * Centralizes all Redux reducers and provides typed hooks for the
- * application.
- * @module app/store
- */
-
 import countReducer from '@/features/count/model/countSlice'
 import historyReducer from '@/features/history/model/historySlice'
 import thumbnailCacheReducer from '@/features/history/model/thumbnailSlice'
 import initReducer from '@/features/init/model/initSlice'
 import settingReducer from '@/features/settings/settingsSlice'
+import { sidebarReducer } from '@/features/sidebar'
 import updaterReducer from '@/features/updater/model/updaterSlice'
 import userReducer from '@/features/user/userSlice'
 import inputReducer from '@/features/video/model/inputSlice'
@@ -26,53 +19,39 @@ import {
 } from 'react-redux'
 
 /**
- * The Redux store instance containing all application state.
+ * Configured Redux store with all application reducers.
  *
- * Combines all feature and shared slices into a single store.
- * Redux DevTools are enabled in non-production environments.
+ * Combines feature slices (video, history, settings, etc.) and shared
+ * utilities (progress, queue, download status) into a single state tree.
+ * DevTools enabled in non-production environments.
  */
 export const store = configureStore({
   reducer: {
     count: countReducer,
-    init: initReducer,
-    user: userReducer,
-    progress: progressReducer,
-    input: inputReducer,
-    video: videoReducer,
-    settings: settingReducer,
-    queue: queueReducer,
     downloadStatus: downloadStatusReducer,
     history: historyReducer,
+    init: initReducer,
+    input: inputReducer,
+    progress: progressReducer,
+    queue: queueReducer,
+    settings: settingReducer,
+    sidebar: sidebarReducer,
     thumbnailCache: thumbnailCacheReducer,
     updater: updaterReducer,
+    user: userReducer,
+    video: videoReducer,
   },
   devTools: process.env.NODE_ENV !== 'production',
 })
 
-/**
- * Root state type derived from the store.
- *
- * Use this type for typing selector functions and accessing global state.
- */
+/** Type representing the entire Redux state tree. */
 export type RootState = ReturnType<typeof store.getState>
 
-/**
- * App dispatch type including thunk middleware.
- *
- * Use this type for dispatching actions with full TypeScript support.
- */
+/** Type representing the Redux dispatch function with typed actions. */
 export type AppDispatch = typeof store.dispatch
 
-/**
- * Typed version of the `useSelector` hook.
- *
- * Automatically infers RootState type for better TypeScript experience.
- */
-export const useSelector: TypedUseSelectorHook<RootState> = rawUseSelector
-
-/**
- * Typed version of the `useDispatch` hook.
- *
- * Returns a dispatch function with full AppDispatch typing.
- */
+/** Typed hook to dispatch actions with proper type inference. */
 export const useAppDispatch: () => AppDispatch = useDispatch
+
+/** Typed hook to select from the Redux store with proper type inference. */
+export const useSelector: TypedUseSelectorHook<RootState> = rawUseSelector

--- a/src/features/sidebar/index.ts
+++ b/src/features/sidebar/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Sidebar feature - Public API
+ *
+ * Manages sidebar state using Redux to persist the open/closed state
+ * across page navigations.
+ */
+
+export { setSidebarOpen, default as sidebarReducer } from './model/sidebarSlice'
+export type { SidebarState } from './model/sidebarSlice'

--- a/src/features/sidebar/model/sidebarSlice.ts
+++ b/src/features/sidebar/model/sidebarSlice.ts
@@ -1,0 +1,59 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+
+const COOKIE_NAME = 'sidebar_state'
+
+/**
+ * Reads the initial sidebar state from browser cookies.
+ *
+ * Falls back to true (open) if document is unavailable (SSR) or
+ * cookie is not set/invalid.
+ *
+ * @returns The initial open state of the sidebar
+ */
+function readInitialState(): boolean {
+  if (typeof document === 'undefined') return true
+
+  const match =
+    document.cookie
+      .split(';')
+      .find((c) => c.trim().startsWith(`${COOKIE_NAME}=`))
+      ?.split('=')[1]
+      ?.trim() ?? ''
+
+  return match === 'true'
+}
+
+/** Sidebar state shape managed by Redux. */
+export type SidebarState = {
+  sidebarOpen: boolean
+}
+
+const initialState: SidebarState = {
+  sidebarOpen: readInitialState(),
+}
+
+/**
+ * Redux slice for managing sidebar open/closed state.
+ *
+ * Provides action creator to update sidebar state. The state is
+ * persisted via cookies by the SidebarProvider component.
+ *
+ * @example
+ * ```ts
+ * import { setSidebarOpen } from '@/features/sidebar'
+ * dispatch(setSidebarOpen(true))
+ * ```
+ */
+export const sidebarSlice = createSlice({
+  name: 'sidebar',
+  initialState,
+  reducers: {
+    setSidebarOpen: (state, action: PayloadAction<boolean>) => {
+      state.sidebarOpen = action.payload
+    },
+  },
+})
+
+export const { setSidebarOpen } = sidebarSlice.actions
+export default sidebarSlice.reducer


### PR DESCRIPTION
## Summary
Fixed issue where sidebar open/closed state was reset when navigating between pages by implementing Redux-based state management.

## Changes
- Added new Redux slice (sidebarSlice) for sidebar state
- Integrated sidebarReducer into Redux store
- Updated sidebar.tsx to reference and update Redux state
- Implemented cookie reading logic in sidebarSlice
- Code quality improvements via /review-all

## Test Plan
1. Toggle sidebar open/closed (Ctrl/Cmd + B or trigger button)
2. Navigate between pages (Home ↔ History)
3. Verify sidebar open/closed state persists across navigation

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)