### PR TITLE
feat: add update check button in settings dialog

### DIFF
--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -11,6 +11,7 @@ import {
   formSchema,
 } from '@/features/settings/dialog/formSchema'
 import { languages } from '@/features/settings/language/languages'
+import { UpdateCheckButton } from '@/features/settings/ui/UpdateCheckButton'
 import { useSettings } from '@/features/settings/useSettings'
 import {
   RadioGroup,
@@ -293,6 +294,11 @@ function SettingsForm() {
           <FormDescription>
             {t('settings.lib_path_description')}
           </FormDescription>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <Label>{t('settings.app_section_label')}</Label>
+          <UpdateCheckButton />
         </div>
       </form>
     </Form>

--- a/src/features/settings/ui/UpdateCheckButton.tsx
+++ b/src/features/settings/ui/UpdateCheckButton.tsx
@@ -1,0 +1,205 @@
+import { useAppDispatch, useSelector } from '@/app/store'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  setError,
+  setUpdateAvailable,
+} from '@/features/updater/model/updaterSlice'
+import { cn } from '@/shared/lib/utils'
+import { getVersion } from '@tauri-apps/api/app'
+import { check as checkUpdate } from '@tauri-apps/plugin-updater'
+import { RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+const isDevMode = import.meta.env.DEV
+
+/**
+ * Update check button component for settings dialog.
+ *
+ * A React component that provides manual update checking functionality for the Bilibili Downloader GUI.
+ * Displays current application version, interactive check button, and real-time status indicators.
+ *
+ * Features:
+ * - Version display with fallback for unknown versions
+ * - Manual update trigger with loading state
+ * - Status badges for update availability and latest version
+ * - Full accessibility support with ARIA attributes
+ * - Development mode protection
+ *
+ * State Management:
+ * - Local state: update status, application version
+ * - Global state: update availability (via Redux updaterSlice)
+ *
+ * Component States:
+ * - idle: Button ready for user interaction
+ * - checking: Update check in progress (button disabled, spinning icon)
+ * - done: Check completed (shows result badge)
+ *
+ * Accessibility:
+ * - Button with aria-busy attribute for screen readers
+ * - Status region with aria-live announcement
+ * - Group role with descriptive aria-label
+ *
+ * @example
+ * // Basic usage in settings dialog
+ * <UpdateCheckButton />
+ *
+ * @returns {JSX.Element} - Fully accessible update check interface
+ */
+export function UpdateCheckButton() {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const updater = useSelector((s) => s.updater)
+
+  const [status, setStatus] = useState<'idle' | 'checking' | 'done'>('idle')
+  const [appVersion, setAppVersion] = useState<string>('')
+
+  // Get current app version on mount
+  useEffect(() => {
+    const fetchAppVersion = async () => {
+      try {
+        setAppVersion(await getVersion())
+      } catch (e) {
+        console.error('Failed to get app version:', e)
+        setAppVersion(t('settings.update_check.unknown_version'))
+      }
+    }
+    fetchAppVersion()
+  }, [t])
+
+  /**
+   * Handles manual update check button click.
+   *
+   * Triggers an asynchronous update check using Tauri's updater plugin.
+   * Manages component state transitions and error handling.
+   * Integrates with global Redux state via updaterSlice.
+   * Function is disabled in development mode for performance reasons.
+   *
+   * State Flow:
+   * 1. Sets status to 'checking' and clears previous errors
+   * 2. Calls Tauri's checkUpdate() API
+   * 3. On success: Dispatches updateAvailable action and updates version display
+   * 4. On failure: Dispatches error action and resets to idle state
+   * 5. Sets status to 'done' on successful completion
+   *
+   * @throws {Error} - Wrapped and handled by try-catch block, dispatched to Redux state
+   *
+   * @remarks - Disabled in development mode (import.meta.env.DEV)
+   *            Updates appVersion from updater API response when available
+   */
+  const handleCheck = useCallback(async () => {
+    if (isDevMode) {
+      console.warn('Update check is disabled in development mode')
+      return
+    }
+
+    setStatus('checking')
+    dispatch(setError(null))
+
+    try {
+      const update = await checkUpdate()
+      if (update) {
+        dispatch(
+          setUpdateAvailable({
+            available: true,
+            latestVersion: update.version || null,
+            currentVersion: update.currentVersion || null,
+          }),
+        )
+        if (update.currentVersion && !appVersion) {
+          setAppVersion(update.currentVersion)
+        }
+      } else if (!appVersion) {
+        setAppVersion(t('settings.update_check.unknown_version'))
+      }
+      setStatus('done')
+    } catch (e) {
+      console.error('Update check failed:', e)
+      dispatch(setError(t('settings.update_check.error')))
+      setStatus('idle')
+    }
+  }, [dispatch, t, appVersion])
+
+  /**
+   * Renders the appropriate status badge based on current state and update availability.
+   *
+   * This function determines which badge to display based on:
+   * - Current update check status (idle, checking, done)
+   * - Global update availability from updater slice
+   * - Application version information
+   *
+   * @returns JSX.Element | null - Status badge component or null if no badge should be shown
+   *
+   * Badge Display Logic:
+   * - idle: No badge (returns null)
+   * - updateAvailable: Green badge with version info
+   * - done: Gray badge with current version info
+   * - checking: Handled by button state, not this function
+   */
+  const getStatusBadge = () => {
+    if (status === 'idle') return null
+
+    if (updater.updateAvailable) {
+      return (
+        <Badge variant="default" className="shrink-0">
+          {t('settings.update_check.available', {
+            version: updater.latestVersion,
+          })}
+        </Badge>
+      )
+    }
+
+    if (status === 'done') {
+      return (
+        <Badge variant="secondary" className="shrink-0">
+          {t('settings.update_check.latest', { version: appVersion })}
+        </Badge>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Current version display */}
+      <div className="text-muted-foreground text-sm">
+        {t('settings.current_version', { version: appVersion || '-' })}
+      </div>
+
+      {/* Update check button and status */}
+      <div
+        className="flex items-center gap-2"
+        role="group"
+        aria-label={t('settings.update_check.aria_label')}
+      >
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleCheck}
+          disabled={status === 'checking' || isDevMode}
+          aria-describedby="update-status"
+          aria-busy={status === 'checking'}
+        >
+          <RefreshCw
+            className={cn(
+              'mr-2 size-4',
+              status === 'checking' && 'animate-spin',
+            )}
+          />
+          {t(`settings.update_check.button_${status}`)}
+        </Button>
+
+        <div
+          id="update-status"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {getStatusBadge()}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -169,7 +169,20 @@
     "lib_path_dialog_title": "Select Library Directory",
     "lib_path_error": "Failed to get path",
     "lib_path_change_success": "Library storage location updated successfully",
-    "lib_path_change_error": "Failed to change library storage location"
+    "lib_path_change_error": "Failed to change library storage location",
+    "app_section_label": "Application",
+    "current_version": "Current version: {{version}}",
+    "update_check": {
+      "aria_label": "Update check",
+      "button_idle": "Check for updates",
+      "button_checking": "Checking...",
+      "button_done": "Check again",
+      "available": "{{version}} available",
+      "latest": "Latest version ({{version}})",
+      "error": "Check failed",
+      "unknown_version": "Unknown",
+      "dev_mode_disabled": "Update check disabled in development mode"
+    }
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -165,7 +165,20 @@
     "lib_path_dialog_title": "Seleccionar directorio de biblioteca",
     "lib_path_error": "Error al obtener la ruta",
     "lib_path_change_success": "Ubicación de almacenamiento de biblioteca actualizada correctamente",
-    "lib_path_change_error": "Error al cambiar la ubicación de almacenamiento de biblioteca"
+    "lib_path_change_error": "Error al cambiar la ubicación de almacenamiento de biblioteca",
+    "app_section_label": "Aplicación",
+    "current_version": "Versión actual: {{version}}",
+    "update_check": {
+      "aria_label": "Verificación de actualizaciones",
+      "button_idle": "Buscar actualizaciones",
+      "button_checking": "Verificando...",
+      "button_done": "Verificar de nuevo",
+      "available": "{{version}} disponible",
+      "latest": "Versión más reciente ({{version}})",
+      "error": "Error en la verificación",
+      "unknown_version": "Desconocido",
+      "dev_mode_disabled": "La verificación de actualizaciones está deshabilitada en modo desarrollo"
+    }
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -165,7 +165,20 @@
     "lib_path_dialog_title": "Sélectionner le répertoire de la bibliothèque",
     "lib_path_error": "Échec de l'obtention du chemin",
     "lib_path_change_success": "Emplacement de stockage de la bibliothèque mis à jour avec succès",
-    "lib_path_change_error": "Échec de la modification de l'emplacement de stockage de la bibliothèque"
+    "lib_path_change_error": "Échec de la modification de l'emplacement de stockage de la bibliothèque",
+    "app_section_label": "Application",
+    "current_version": "Version actuelle : {{version}}",
+    "update_check": {
+      "aria_label": "Vérification des mises à jour",
+      "button_idle": "Vérifier les mises à jour",
+      "button_checking": "Vérification...",
+      "button_done": "Vérifier à nouveau",
+      "available": "{{version}} disponible",
+      "latest": "Dernière version ({{version}})",
+      "error": "Échec de la vérification",
+      "unknown_version": "Inconnu",
+      "dev_mode_disabled": "La vérification des mises à jour est désactivée en mode développement"
+    }
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -169,7 +169,20 @@
     "lib_path_dialog_title": "ライブラリディレクトリを選択",
     "lib_path_error": "パスの取得に失敗しました",
     "lib_path_change_success": "ライブラリ保存先を変更しました",
-    "lib_path_change_error": "ライブラリ保存先の変更に失敗しました"
+    "lib_path_change_error": "ライブラリ保存先の変更に失敗しました",
+    "app_section_label": "アプリケーション",
+    "current_version": "現在のバージョン: {{version}}",
+    "update_check": {
+      "aria_label": "アップデート確認",
+      "button_idle": "アップデートを確認",
+      "button_checking": "確認中...",
+      "button_done": "再確認",
+      "available": "{{version}} が利用可能です",
+      "latest": "最新版です ({{version}})",
+      "error": "確認に失敗しました",
+      "unknown_version": "不明",
+      "dev_mode_disabled": "開発モードではアップデート確認は無効です"
+    }
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -165,7 +165,20 @@
     "lib_path_dialog_title": "라이브러리 디렉터리 선택",
     "lib_path_error": "경로를 가져오지 못했습니다",
     "lib_path_change_success": "라이브러리 저장 위치가 성공적으로 업데이트되었습니다",
-    "lib_path_change_error": "라이브러리 저장 위치 변경 실패"
+    "lib_path_change_error": "라이브러리 저장 위치 변경 실패",
+    "app_section_label": "애플리케이션",
+    "current_version": "현재 버전: {{version}}",
+    "update_check": {
+      "aria_label": "업데이트 확인",
+      "button_idle": "업데이트 확인",
+      "button_checking": "확인 중...",
+      "button_done": "다시 확인",
+      "available": "{{version}} 사용 가능",
+      "latest": "최신 버전 ({{version}})",
+      "error": "확인 실패",
+      "unknown_version": "알 수 없음",
+      "dev_mode_disabled": "개발 모드에서는 업데이트 확인이 비활성화됩니다"
+    }
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -165,7 +165,20 @@
     "lib_path_dialog_title": "选择库目录",
     "lib_path_error": "获取路径失败",
     "lib_path_change_success": "库存储位置已成功更新",
-    "lib_path_change_error": "更改库存储位置失败"
+    "lib_path_change_error": "更改库存储位置失败",
+    "app_section_label": "应用程序",
+    "current_version": "当前版本: {{version}}",
+    "update_check": {
+      "aria_label": "更新检查",
+      "button_idle": "检查更新",
+      "button_checking": "检查中...",
+      "button_done": "再次检查",
+      "available": "{{version}} 可用",
+      "latest": "已是最新版本 ({{version}})",
+      "error": "检查失败",
+      "unknown_version": "未知",
+      "dev_mode_disabled": "开发模式下更新检查已禁用"
+    }
   },
   "validation": {
     "path": {


### PR DESCRIPTION
## Summary
Add a manual update check button to the settings dialog's application section. Users can now check for updates directly from the settings UI.

## Changes
- Add `UpdateCheckButton` component with current version display
- Disable update check in development mode to prevent confusion
- Integrate with existing `updaterSlice` for state management
- Add i18n translations for all supported languages (en/ja/zh/ko/es/fr)
- Display current app version using Tauri's `getVersion()` API
- Show update status badge (available/latest)

## UI Changes
The update check button is placed in a new "Application" section at the bottom of the settings form. The UI follows the existing pattern:
- Outline button with RefreshCw icon
- Status badge showing check results
- Consistent with existing directory picker buttons

## Development Mode
The update check button is automatically disabled in development mode, preventing confusion when the updater plugin returns `null`. This is implemented using `import.meta.env.DEV`.

## Test Plan
- [x] Button displays current version correctly
- [x] Button is disabled in development mode (`npm run tauri dev`)
- [x] Button triggers update check in production builds
- [x] Status badge displays correctly (checking/latest/update available)
- [x] All i18n translations included for 6 languages

---
🤖 Generated with [Claude Code](https://claude.ai/code)