### PR TITLE
fix: memoize Redux selectors to prevent unnecessary rerenders

### DIFF
--- a/src/features/video/hooks/usePartDownloadStatus.ts
+++ b/src/features/video/hooks/usePartDownloadStatus.ts
@@ -1,7 +1,13 @@
-import type { RootState } from '@/app/store'
-import { selectDownloadIdByPartIndex } from '@/shared/queue/queueSlice'
-import type { Progress } from '@/shared/ui/Progress'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
+
+import type { RootState } from '@/app/store'
+import { selectProgressEntriesByDownloadId } from '@/shared/progress/progressSlice'
+import {
+  selectDownloadIdByPartIndex,
+  selectQueueItemByDownloadId,
+} from '@/shared/queue/queueSlice'
+import type { Progress } from '@/shared/ui/Progress'
 
 /**
  * Result of part download status hook.
@@ -45,13 +51,17 @@ export const usePartDownloadStatus = (
     selectDownloadIdByPartIndex(state, partIndex),
   )
 
-  const queueItem = useSelector((state: RootState) =>
-    state.queue.find((q) => q.downloadId === downloadId),
+  const selectQueueItem = useMemo(
+    () => selectQueueItemByDownloadId(downloadId ?? ''),
+    [downloadId],
   )
+  const queueItem = useSelector(selectQueueItem)
 
-  const progressEntries = useSelector((state: RootState) =>
-    state.progress.filter((p) => p.downloadId === downloadId),
+  const selectProgressEntries = useMemo(
+    () => selectProgressEntriesByDownloadId(downloadId ?? ''),
+    [downloadId],
   )
+  const progressEntries = useSelector(selectProgressEntries)
 
   const isComplete = progressEntries.some((p) => p.stage === 'complete')
 


### PR DESCRIPTION
## Summary

Fixes Redux warnings about selectors returning different results with the same parameters by replacing inline selectors with memoized selectors using `createSelector`.

## Problem

When fetching video information, the following warning appeared in the console:

```
Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
```

This was caused by inline arrow functions in `usePartDownloadStatus` hook creating new function references on every render, preventing Redux from properly memoizing selector results.

## Changes

- **queueSlice.ts**: Add `selectQueueItemByDownloadId` memoized selector factory
- **progressSlice.ts**: Add `selectProgressEntriesByDownloadId` memoized selector factory
- **usePartDownloadStatus.ts**: Use `useMemo` with memoized selectors to provide stable references

## Technical Details

The solution uses the selector factory pattern with `createSelector`:
- Each factory takes a parameter (e.g., `downloadId`) and returns a memoized selector
- `useMemo` ensures the selector is only recreated when dependencies change
- This allows Redux Toolkit's internal memoization to work correctly

## Test Plan

1. Start the app with `npm run tauri dev`
2. Enter a video URL and fetch video information
3. Verify no Redux warnings appear in the console
4. Confirm download progress displays correctly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)