### PR TITLE
feat: minimize progress display by showing icons only for audio/video stages

### DIFF
--- a/src/features/video/ui/DownloadingDialog.tsx
+++ b/src/features/video/ui/DownloadingDialog.tsx
@@ -196,18 +196,24 @@ function DownloadingDialog() {
                     )
                     const key = p.internalId || `${p.downloadId}:${p.stage}`
                     if (!p.stage || p.stage === 'complete') return null
+                    const ariaLabel =
+                      typeof barLabel === 'string' ? barLabel : undefined
                     return (
                       <div
                         key={key}
                         className="text-accent-foreground box-border w-full px-2"
                       >
                         <div className="mb-2 flex items-center">
-                          <span className="mr-2">{barIcon}</span>
-                          <span className="font-medium">{barLabel}</span>
+                          <span className="mr-2" aria-label={ariaLabel}>
+                            {barIcon}
+                          </span>
                         </div>
                         <div className="px-2">
                           {p.stage === 'merge' ? (
-                            <div className="flex items-center justify-between py-1 text-sm">
+                            <div
+                              className="flex items-center justify-between py-1 text-sm"
+                              aria-label={t('video.bar_merge')}
+                            >
                               <span>{t('video.bar_merge')}</span>
                               {!p.isComplete && <CircleIndicator r={10} />}
                               {p.isComplete && (

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -46,19 +46,23 @@ function StageProgress({
   waitingLabel,
 }: StageProgressProps) {
   const progress = progressEntries.find((p) => p.stage === stageName)
+  const stageLabel = t(labelKey)
 
   if (!progress) {
     return (
-      <div className="flex min-h-[33px] items-center">
-        {icon} {t(labelKey)}: {waitingLabel ?? t('video.stage_waiting')}
+      <div
+        className="flex min-h-[33px] items-center"
+        aria-label={`${stageLabel}: ${waitingLabel ?? t('video.stage_waiting')}`}
+      >
+        {icon}
       </div>
     )
   }
 
   return (
     <div className="flex min-h-[33px] items-center gap-1">
-      <span className="font-medium">
-        {icon} {t(labelKey)}
+      <span className="font-medium" aria-label={stageLabel}>
+        {icon}
       </span>
       <span>{progress.percentage.toFixed(0)}%</span>
       <span>{formatTransferRate(progress.transferRate || 0)}</span>
@@ -213,7 +217,7 @@ export function PartDownloadProgress({
 
       {/* Running View - third priority */}
       {isDownloading && (
-        <div className="text-muted-foreground grid min-h-[33px] grid-cols-1 gap-x-2 gap-y-1 text-xs sm:grid-cols-2 lg:grid-cols-3">
+        <div className="text-muted-foreground grid min-h-[33px] grid-cols-[4fr_4fr_2fr] gap-x-2 gap-y-1 text-xs">
           <StageProgress
             icon="🔊"
             labelKey="video.stage_audio"
@@ -241,13 +245,15 @@ export function PartDownloadProgress({
             const videoProgress = progressEntries.find(
               (p) => p.stage === 'video',
             )
+            const mergeLabel = t('video.stage_merge')
 
             if (mergeProgress) {
               return (
-                <div className="flex min-h-[33px] items-center gap-1">
-                  <span className="font-medium">
-                    🔄 {t('video.stage_merge')}
-                  </span>
+                <div
+                  className="flex min-h-[33px] items-center gap-1"
+                  aria-label={`${mergeLabel}: ${mergeProgress.percentage.toFixed(0)}%`}
+                >
+                  <span className="font-medium">🔄 {mergeLabel}</span>
                   <span>{mergeProgress.percentage.toFixed(0)}%</span>
                 </div>
               )
@@ -261,10 +267,11 @@ export function PartDownloadProgress({
 
             if (bothComplete) {
               return (
-                <div className="flex min-h-[33px] items-center gap-1">
-                  <span className="font-medium">
-                    🔄 {t('video.stage_merge')}
-                  </span>
+                <div
+                  className="flex min-h-[33px] items-center gap-1"
+                  aria-label={`${mergeLabel}: ${t('video.stage_merging')}`}
+                >
+                  <span className="font-medium">🔄 {mergeLabel}</span>
                   <span>{t('video.stage_merging')}</span>
                 </div>
               )
@@ -272,8 +279,11 @@ export function PartDownloadProgress({
 
             if (audioProgress || videoProgress) {
               return (
-                <div className="flex min-h-[33px] items-center">
-                  🔄 {t('video.stage_merge')}: {t('video.stage_waiting')}
+                <div
+                  className="flex min-h-[33px] items-center"
+                  aria-label={`${mergeLabel}: ${t('video.stage_waiting')}`}
+                >
+                  🔄 {mergeLabel}: {t('video.stage_waiting')}
                 </div>
               )
             }


### PR DESCRIPTION
## Summary

- Remove text labels from audio/video progress indicators (icons only)
- Maintain text labels for merge stage to preserve clarity
- Add aria-label attributes for accessibility (screen reader support)
- Set fixed 3-column layout with 4:4:2 ratio for better space utilization
- Improve visual consistency across download progress UI

## Changes

### DownloadingDialog.tsx
- Audio/video stages: Display icon only without text label
- Merge stage: Keep text label for clarity
- Add `aria-label` attributes for accessibility

### PartDownloadProgress.tsx
- Change from responsive grid (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`) to fixed 3-column layout
- Set column width ratio to 4:4:2 (audio: 40%, video: 40%, merge: 20%)
- Audio/video stages: Icon only display
- Merge stage: Maintain text label display

## Test Plan

- Verify download progress displays correctly in modal
- Check accessibility with screen reader
- Confirm responsive layout works on various screen sizes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)