### PR TITLE
feat: disable UI controls during active downloads

### DIFF
--- a/src/features/video/ui/DownloadButton.tsx
+++ b/src/features/video/ui/DownloadButton.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { RootState } from '@/app/store'
 import { useVideoInfo } from '@/features/video/hooks/useVideoInfo'
 import { RippleButton } from '@/shared/animate-ui/buttons/ripple'
 import {
@@ -8,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
+import { selectHasActiveDownloads } from '@/shared/queue'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -34,10 +34,7 @@ function DownloadButton() {
   } = useVideoInfo()
   const { t } = useTranslation()
 
-  // Check if any download is running or pending
-  const hasActiveDownloads = useSelector((state: RootState) =>
-    state.queue.some((q) => q.status === 'running' || q.status === 'pending'),
-  )
+  const hasActiveDownloads = useSelector(selectHasActiveDownloads)
 
   const disabled = !(isForm1Valid && isForm2ValidAll) || hasActiveDownloads
   let reason: string | null = null

--- a/src/features/video/ui/VideoForm1.tsx
+++ b/src/features/video/ui/VideoForm1.tsx
@@ -4,6 +4,7 @@ import {
   buildVideoFormSchema1,
   formSchema1,
 } from '@/features/video/lib/formSchema'
+import { selectHasActiveDownloads } from '@/shared/queue'
 import { Alert, AlertDescription, AlertTitle } from '@/shared/ui/alert'
 import {
   Form,
@@ -38,6 +39,7 @@ function VideoForm1() {
   const { input, onValid1, isFetching } = useVideoInfo()
   const { t } = useTranslation()
   const user = useSelector((state: RootState) => state.user)
+  const hasActiveDownloads = useSelector(selectHasActiveDownloads)
   const [lastFetchedUrl, setLastFetchedUrl] = useState<string>('')
 
   const schema1 = buildVideoFormSchema1(t)
@@ -136,23 +138,28 @@ function VideoForm1() {
                     type="url"
                     required
                     placeholder={placeholder}
-                    disabled={isFetching}
+                    disabled={isFetching || hasActiveDownloads}
                     {...field}
                   />
-                  {isFetching ? (
+                  {isFetching || hasActiveDownloads ? (
                     <div className="absolute top-1/2 right-3 -translate-y-1/2">
                       <Loader2 className="text-muted-foreground size-4 animate-spin" />
                     </div>
                   ) : field.value ? (
                     <button
                       type="button"
+                      disabled={hasActiveDownloads}
                       onClick={(e) => {
                         preventEventDefaults(e)
                         form.setValue('url', '', { shouldValidate: true })
                         field.onChange('')
                         setLastFetchedUrl('')
                       }}
-                      className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+                      className={`text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors ${
+                        hasActiveDownloads
+                          ? 'cursor-not-allowed opacity-50'
+                          : ''
+                      }`}
                     >
                       <CircleX className="size-4" />
                     </button>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -8,8 +8,15 @@ import {
   VideoForm1,
 } from '@/features/video'
 import VideoPartCard from '@/features/video/ui/VideoPartCard'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/animate-ui/radix/tooltip'
 import { useIsMobile } from '@/shared/hooks/use-mobile'
 import { PageLayout } from '@/shared/layout'
+import { selectHasActiveDownloads } from '@/shared/queue'
 import { Button } from '@/shared/ui/button'
 import {
   Card,
@@ -21,6 +28,7 @@ import {
 import { Separator } from '@/shared/ui/separator'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
 
 /**
@@ -48,6 +56,7 @@ function HomePage() {
   const { video, duplicateIndices } = useVideoInfo()
   const { t } = useTranslation()
   const isMobile = useIsMobile()
+  const hasActiveDownloads = useSelector(selectHasActiveDownloads)
 
   // Collapsed parts state for mobile (parts 3+ are collapsed by default on mobile)
   const [collapsedParts, setCollapsedParts] = useState<Set<number>>(new Set())
@@ -111,12 +120,48 @@ function HomePage() {
                 {t('video.step2_title')}
               </CardTitle>
               <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleSelectAll}>
-                  {t('video.select_all')}
-                </Button>
-                <Button variant="outline" size="sm" onClick={handleDeselectAll}>
-                  {t('video.deselect_all')}
-                </Button>
+                <TooltipProvider delayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleSelectAll}
+                          disabled={hasActiveDownloads}
+                        >
+                          {t('video.select_all')}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {hasActiveDownloads && (
+                      <TooltipContent side="top" arrow>
+                        {t('video.download_in_progress')}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </TooltipProvider>
+                <TooltipProvider delayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleDeselectAll}
+                          disabled={hasActiveDownloads}
+                        >
+                          {t('video.deselect_all')}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {hasActiveDownloads && (
+                      <TooltipContent side="top" arrow>
+                        {t('video.download_in_progress')}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </TooltipProvider>
               </div>
             </div>
           </CardHeader>

--- a/src/shared/queue/index.ts
+++ b/src/shared/queue/index.ts
@@ -1,0 +1,19 @@
+export {
+  clearQueue,
+  clearQueueItem,
+  // Default export
+  default,
+  dequeue,
+  // Actions
+  enqueue,
+  // Utilities
+  findCompletedItemForPart,
+  selectDownloadIdByPartIndex,
+  // Selectors
+  selectHasActiveDownloads,
+  selectQueueItemByDownloadId,
+  updateQueueItem,
+  updateQueueStatus,
+  // Types
+  type QueueItem,
+} from './queueSlice'

--- a/src/shared/queue/queueSlice.ts
+++ b/src/shared/queue/queueSlice.ts
@@ -221,3 +221,18 @@ export const selectQueueItemByDownloadId = (downloadId: string) =>
   createSelector([(state: RootState) => state.queue], (queue) =>
     queue.find((q) => q.downloadId === downloadId),
   )
+
+/**
+ * Memoized selector to check if any downloads are active.
+ *
+ * Returns true if any queue item has status 'running' or 'pending'.
+ * Used to disable UI controls during active downloads.
+ *
+ * @param state - Redux root state
+ * @returns true if any downloads are running or pending
+ */
+export const selectHasActiveDownloads = createSelector(
+  [(state: RootState) => state.queue],
+  (queue) =>
+    queue.some((q) => q.status === 'running' || q.status === 'pending'),
+)


### PR DESCRIPTION
## Summary
- Add `selectHasActiveDownloads` selector to check for active downloads
- Disable URL input field when downloads are running or pending
- Disable select/deselect all buttons during active downloads
- Refactor `DownloadButton` to use shared selector instead of inline logic

## Changes
- **src/shared/queue/queueSlice.ts**: Add `selectHasActiveDownloads` memoized selector
- **src/shared/queue/index.ts**: Create Public API for queue module
- **src/features/video/ui/VideoForm1.tsx**: Disable URL input and clear button during downloads
- **src/features/video/ui/DownloadButton.tsx**: Refactor to use shared selector
- **src/pages/home/index.tsx**: Disable select/deselect all buttons with tooltip during downloads

## Test Plan
1. Enter video URL and display parts
2. Start download
3. Verify URL input is disabled
4. Verify "Select All" and "Deselect All" buttons are disabled
5. Verify tooltip shows on hover
6. After download completes, verify controls are re-enabled

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)