### PR TITLE
fix: widen ffmpeg installation progress indicator

### DIFF
--- a/src/pages/init/index.tsx
+++ b/src/pages/init/index.tsx
@@ -62,13 +62,11 @@ function InitPage() {
         </div>
         <div className="text-muted-foreground text-sm">{processingFnc}</div>
         {progress.length > 0 &&
-          progress.map((p) => {
-            return (
-              <div key={p.downloadId} className="w-full max-w-[20rem] p-3">
-                <ProgressStatusBar progress={p} />
-              </div>
-            )
-          })}
+          progress.map((p) => (
+            <div key={p.downloadId} className="w-full max-w-[26rem] p-3">
+              <ProgressStatusBar progress={p} />
+            </div>
+          ))}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Widen the ffmpeg installation progress indicator to prevent text overflow during download.

## Changes

- Increase `max-width` from `20rem` (320px) to `26rem` (416px) in the init page progress indicator
- Simplify arrow function to use implicit return pattern

## Test Plan

1. Remove or rename ffmpeg binary to trigger auto-download
2. Launch the app
3. Verify the progress indicator displays download speed, elapsed time, and file size without text overflow

---

🤖 Generated with [Claude Code](https://claude.ai/code)