### PR TITLE
feat: add orphaned temp file cleanup on app init

### DIFF
--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -1,0 +1,111 @@
+//! Temp File Cleanup Handler
+//!
+//! Cleans up orphaned temporary files left from interrupted downloads.
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use tauri::AppHandle;
+
+use crate::utils::paths::get_lib_path;
+
+/// Default age threshold in hours (24 hours = 1 day)
+const DEFAULT_MAX_AGE_HOURS: u64 = 24;
+
+/// Result of cleanup operation.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct CleanupResult {
+    /// Number of files successfully deleted
+    pub deleted_count: u32,
+    /// Number of files that failed to delete
+    pub failed_count: u32,
+}
+
+/// Cleans up orphaned temporary files older than 24 hours.
+///
+/// Scans the lib directory for temp files matching:
+/// - `temp_video_*.m4s`
+/// - `temp_audio_*.m4s`
+///
+/// Files older than 24 hours are deleted.
+pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> CleanupResult {
+    let lib_path = get_lib_path(app);
+    let max_age = max_age_hours.unwrap_or(DEFAULT_MAX_AGE_HOURS);
+    let threshold = SystemTime::now() - Duration::from_secs(max_age * 60 * 60);
+
+    let mut result = CleanupResult::default();
+
+    if !lib_path.exists() {
+        return result;
+    }
+
+    match fs::read_dir(&lib_path) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if is_temp_file(&path) {
+                    if let Ok(metadata) = entry.metadata() {
+                        if let Ok(modified) = metadata.modified() {
+                            if modified < threshold {
+                                match fs::remove_file(&path) {
+                                    Ok(()) => {
+                                        println!("[Cleanup] Deleted temp file: {:?}", path);
+                                        result.deleted_count += 1;
+                                    }
+                                    Err(e) => {
+                                        eprintln!(
+                                            "[Cleanup] Failed to delete temp file {:?}: {}",
+                                            path, e
+                                        );
+                                        result.failed_count += 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("[Cleanup] Failed to read lib directory: {}", e);
+        }
+    }
+
+    result
+}
+
+/// Checks if a file is a temp download file.
+///
+/// # Temp File Pattern
+///
+/// Matches files with the following naming conventions:
+/// - `temp_video_*.m4s` - Temporary video segments
+/// - `temp_audio_*.m4s` - Temporary audio segments
+///
+/// # Arguments
+///
+/// * `path` - Path to the file to check
+///
+/// # Returns
+///
+/// `true` if the file matches the temp file pattern, `false` otherwise
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::Path;
+/// # use crate::handlers::cleanup::is_temp_file;
+/// assert!(is_temp_file(Path::new("temp_video_123.m4s")));
+/// assert!(is_temp_file(Path::new("temp_audio_456.m4s")));
+/// assert!(!is_temp_file(Path::new("final_video.mp4")));
+/// ```
+fn is_temp_file(path: &Path) -> bool {
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+
+    (file_name.starts_with("temp_video_") || file_name.starts_with("temp_audio_"))
+        && file_name.ends_with(".m4s")
+}

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Organized by functionality:
 //! - **bilibili**: Video info retrieval and download operations
+//! - **cleanup**: Orphaned temp file cleanup on app init
 //! - **concurrency**: Semaphore management for parallel downloads
 //! - **cookie**: Firefox cookie extraction and caching
 //! - **favorites**: Bilibili favorite folder and video retrieval
@@ -11,6 +12,7 @@
 //! - **updater**: GitHub release notes fetching
 
 pub mod bilibili;
+pub mod cleanup;
 pub mod concurrency;
 pub mod cookie;
 pub mod favorites;


### PR DESCRIPTION
## Summary

Add automatic cleanup of orphaned temporary files that remain from interrupted downloads. Files older than 24 hours (`temp_video_*.m4s`, `temp_audio_*.m4s`) are deleted during app initialization.

## Changes

- **Add** `cleanup` handler module (`src-tauri/src/handlers/cleanup.rs`)
  - Scans lib directory for temp files matching patterns
  - Deletes files older than 24 hours
  - Returns count of deleted and failed files

- **Register** `cleanup_temp_files` Tauri command in `lib.rs`
  - Follows existing project patterns with `Result<T, String>` return type

- **Integrate** cleanup into frontend init hook (`useInit.tsx`)
  - Fire-and-forget operation (non-blocking)
  - Logs both successful deletions and failures to console

## Test Plan

1. Create test temp files in the lib directory:
   ```bash
   touch ~/Library/Application\ Support/com.bilibili-downloader-gui.app/lib/temp_video_test.m4s
   touch -t 202502010000 ~/Library/Application\ Support/com.bilibili-downloader-gui.app/lib/temp_audio_old.m4s
   ```

2. Launch the app

3. Verify console output:
   - Old file (Feb 1) should be deleted
   - New file should remain
   - Console should log: `Cleaned up N orphaned temp files`

4. Verify both `deletedCount` and `failedCount` are logged appropriately

---

🤖 Generated with [Claude Code](https://claude.ai/code)