### PR TITLE
feat: sync Tauri window theme with app theme

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-set-theme",
     "process:default",
     "opener:default",
     "shell:allow-open",


### PR DESCRIPTION
## Summary
Sync Tauri window theme (title bar) with the app's internal theme setting.

## Changes
- Add Tauri `setTheme()` API call to sync window theme with app theme
- Add `core:window:allow-set-theme` permission to capabilities
- Refactor theme logic for better readability (if/else instead of nested ternary)
- Remove unused props spread in ThemeProvider
- Extract `setThemeAndPersist` function for clarity

## Test Plan
- [x] Run `npm run tauri dev` on macOS
- [x] Toggle theme from dark to light
- [x] Verify title bar (traffic light area) changes color accordingly
- [x] Verify theme persists after app restart

---
🤖 Generated with [Claude Code](https://claude.ai/code)