### PR TITLE
feat: add download animation to home icon during active downloads

### DIFF
--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from '@/app/store'
+import { Download } from '@/shared/animate-ui/icons/download'
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -11,6 +12,7 @@ import {
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
 import { cn } from '@/shared/lib/utils'
+import { selectHasActiveDownloads } from '@/shared/queue'
 import { Eye, Home, Star } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
@@ -42,8 +44,7 @@ export function NavigationSidebarHeader({
   const location = useLocation()
   const user = useSelector((state) => state.user)
   const isLoggedIn = user.hasCookie && user.data?.isLogin
-
-  const currentPath = location.pathname
+  const hasActiveDownloads = useSelector(selectHasActiveDownloads)
 
   const menuItems = [
     {
@@ -78,8 +79,9 @@ export function NavigationSidebarHeader({
         <SidebarMenu>
           {menuItems.map((item) => {
             const Icon = item.icon
-            const isActive = currentPath === item.path
+            const isActive = location.pathname === item.path
             const isDisabled = item.requiresAuth && !isLoggedIn
+            const isHome = item.path === '/home'
 
             const button = (
               <SidebarMenuButton
@@ -93,7 +95,16 @@ export function NavigationSidebarHeader({
                   isDisabled ? 'cursor-not-allowed opacity-50' : undefined
                 }
               >
-                <Icon />
+                {isHome && hasActiveDownloads ? (
+                  <Download
+                    animate={true}
+                    animation="default-loop"
+                    loop={true}
+                    size={16}
+                  />
+                ) : (
+                  <Icon />
+                )}
                 <span>{item.label}</span>
               </SidebarMenuButton>
             )


### PR DESCRIPTION
## Summary
- Replace Home icon with animated Download icon when downloads are active
- Use `selectHasActiveDownloads` selector to detect download state
- Animated icon provides visual feedback for active downloads across all pages

## Changes
- `src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx`:
  - Add `Download` icon import from `@/shared/animate-ui/icons/download`
  - Add `selectHasActiveDownloads` selector import from `@/shared/queue`
  - Add `hasActiveDownloads` state via `useSelector`
  - Conditionally render animated Download icon for Home menu item when downloads are active
  - Simplify code by using `location.pathname` directly

## Test Plan
1. Start app: `npm run tauri dev`
2. Enter video URL on home page and start download
3. Verify sidebar home icon changes to download animation
4. Navigate to other pages (history, etc.) and verify animation continues
5. Complete/cancel download and verify home icon returns to normal

---
🤖 Generated with [Claude Code](https://claude.ai/code)