### PR TITLE
refactor(video): migrate useVideoInfo hook to Context Provider pattern

### DIFF
--- a/src/features/video/index.ts
+++ b/src/features/video/index.ts
@@ -12,8 +12,9 @@
 export { downloadVideo } from './api/downloadVideo'
 export { fetchVideoInfo } from './api/fetchVideoInfo'
 
-// Hooks
-export { useVideoInfo } from './hooks/useVideoInfo'
+// Context
+export { VideoInfoProvider, useVideoInfo } from './context/VideoInfoContext'
+export type { VideoInfoContextValue } from './context/VideoInfoContext'
 
 // Redux slices and actions
 export {

--- a/src/features/video/ui/DownloadButton.tsx
+++ b/src/features/video/ui/DownloadButton.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useVideoInfo } from '@/features/video/hooks/useVideoInfo'
+import { useVideoInfo } from '@/features/video'
 import { RippleButton } from '@/shared/animate-ui/buttons/ripple'
 import {
   Tooltip,
@@ -12,12 +12,13 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 /**
- * Download button with validation tooltip.
+ * ダウンロードボタンコンポーネント。
  *
- * Displays a download button that is disabled until all validation passes.
- * Shows a tooltip with the reason why the button is disabled (invalid URL,
- * duplicate titles, no parts selected, etc.).
- * Also disabled when any download is in progress.
+ * すべてのバリデーションが通過するまで無効化されたダウンロードボタンを表示します。
+ * 無効な状態の場合、その理由（無効なURL、重複タイトル、パート未選択など）を
+ * ツールチップで表示します。
+ *
+ * また、ダウンロード進行中も無効化されます。
  *
  * @example
  * ```tsx
@@ -37,12 +38,22 @@ function DownloadButton() {
   const hasActiveDownloads = useSelector(selectHasActiveDownloads)
 
   const disabled = !(isForm1Valid && isForm2ValidAll) || hasActiveDownloads
-  let reason: string | null = null
-  if (!isForm1Valid) reason = t('validation.video.url.invalid')
-  else if (duplicateIndices.length > 0) reason = t('video.duplicate_titles')
-  else if (selectedCount === 0) reason = t('video.no_parts_selected')
-  else if (!isForm2ValidAll) reason = t('validation.video.title.required')
-  else if (hasActiveDownloads) reason = t('video.download_in_progress')
+
+  function getDisabledReason(): string | null {
+    if (!isForm1Valid) return t('validation.video.url.invalid')
+    if (duplicateIndices.length > 0) return t('video.duplicate_titles')
+    if (selectedCount === 0) return t('video.no_parts_selected')
+    if (!isForm2ValidAll) return t('validation.video.title.required')
+    if (hasActiveDownloads) return t('video.download_in_progress')
+    return null
+  }
+
+  const reason = getDisabledReason()
+
+  function getButtonText(): string {
+    if (hasActiveDownloads) return t('video.downloading')
+    return t('actions.download')
+  }
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -50,9 +61,7 @@ function DownloadButton() {
         <TooltipTrigger asChild>
           <span>
             <RippleButton onClick={download} disabled={disabled}>
-              {hasActiveDownloads
-                ? t('video.downloading')
-                : t('actions.download')}
+              {getButtonText()}
             </RippleButton>
           </span>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary

Migrate `useVideoInfo` from a custom hook to a Context Provider pattern to prevent duplicate API calls when multiple components need access to video information.

## Changes

- Create `VideoInfoContext` with `VideoInfoProvider` component
- Move all video info logic from `useVideoInfo` hook to context provider
- Update all consumers (`HomeContent`, `VideoForm1`, `VideoPartCard`, `DownloadButton`, `DownloadingDialog`) to use context via `useVideoInfo` hook
- Delete old `useVideoInfo.ts` hook file
- Add JSDoc documentation to all affected files
- Simplify code with extracted helper functions

## Problem Solved

Previously, `useVideoInfo` was called independently in 4 components:
- `HomeContent`
- `VideoForm1`
- `VideoPartCard` (per part)
- `DownloadButton`

This caused duplicate API fetches (up to 4 times) when navigating from watch history or favorites, triggering 429 rate limit errors.

Now, `VideoInfoProvider` wraps `HomeContentInner`, and all child components access the same context instance, ensuring the video info fetch logic runs only once.

## Test Plan

- [x] Navigate from watch history to home page and verify single API call
- [x] Navigate from favorites to home page and verify single API call
- [x] Verify download functionality still works correctly
- [x] Verify multi-part video selection works correctly

---
🤖 Generated with [Claude Code](https://claude.ai/code)