### PR TITLE
feat: show skeleton UI while fetching video info

### DIFF
--- a/src/features/video/ui/VideoPartCardSkeleton.tsx
+++ b/src/features/video/ui/VideoPartCardSkeleton.tsx
@@ -1,0 +1,64 @@
+import { Skeleton } from '@/shared/ui/skeleton'
+
+/**
+ * Skeleton component for VideoPartCard.
+ *
+ * Displayed while video info is being fetched.
+ * Mimics the layout of VideoPartCard with placeholder elements.
+ */
+function VideoPartCardSkeleton() {
+  return (
+    <div className="p-3 md:p-4">
+      <div>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-6 rounded" />
+          <Skeleton className="h-16 w-24 rounded-lg md:h-20 md:w-32" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-[52px] w-full rounded-md" />
+          </div>
+        </div>
+        <div
+          className="mt-1.5 flex items-center gap-2"
+          style={{ marginLeft: '2.25rem' }}
+        >
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-4 rounded-full" />
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center space-x-2">
+                <Skeleton className="size-4 rounded-full" />
+                <Skeleton className="h-4 w-12" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-4 rounded-full" />
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center space-x-2">
+                <Skeleton className="size-4 rounded-full" />
+                <Skeleton className="h-4 w-10" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default VideoPartCardSkeleton


### PR DESCRIPTION
## Summary

Add skeleton UI to improve user experience during video info fetch. When a user enters a new URL while previous video data is displayed, the skeleton placeholder is now shown instead of the stale data.

## Changes

- **VideoPartCardSkeleton**: New component mimicking VideoPartCard layout with skeleton placeholders
- **HomeContent**: Display skeleton when `isFetching` is true
- Hide "Select All/Deselect All" buttons and "Download" button during fetch
- Simplified arrow functions and removed unnecessary function wrapper

## Test Plan

- [x] Enter a video URL and wait for video info to load
- [x] Enter a different video URL
- [x] Verify skeleton UI is displayed while fetching (not the previous video's data)
- [x] Verify "Select All/Deselect All" buttons are hidden during fetch
- [x] Verify "Download" button is hidden during fetch
- [x] Verify actual video card is displayed after fetch completes
- [x] Verify all functions work normally after fetch

---
🤖 Generated with [Claude Code](https://claude.ai/code)