### PR TITLE
fix: prevent validation error on initial app load

### DIFF
--- a/src/features/video/ui/VideoForm1.tsx
+++ b/src/features/video/ui/VideoForm1.tsx
@@ -50,9 +50,18 @@ function VideoForm1() {
 
   useEffect(() => {
     const trimmedUrl = input.url.trim()
-    form.setValue('url', trimmedUrl, { shouldValidate: true })
+    // 空文字の場合はバリデーションをスキップ（初期表示時のエラー防止）
+    form.setValue('url', trimmedUrl, { shouldValidate: trimmedUrl.length > 0 })
   }, [form, input.url])
 
+  /**
+   * Handles form submission with URL validation.
+   *
+   * Triggers video info fetch if the submitted URL differs from the
+   * last fetched URL to prevent redundant API calls.
+   *
+   * @param data - The form data containing the URL field
+   */
   function onSubmit(data: z.infer<typeof formSchema1>): void {
     const trimmedUrl = data.url.trim()
     if (trimmedUrl === lastFetchedUrl) return
@@ -61,36 +70,51 @@ function VideoForm1() {
   }
 
   const placeholder =
-    t('video.url_placeholder_example') ??
+    t('video.url_placeholder_example') ||
     'e.g. https://www.bilibili.com/video/BV1xxxxxx'
 
+  /**
+   * Clears the URL input field and resets validation state.
+   *
+   * Resets the form value, calls the onChange handler, and clears
+   * the last fetched URL to allow re-fetching the same URL.
+   *
+   * @param onChange - The field onChange callback from react-hook-form
+   */
+  function handleClear(onChange: (value: string) => void): void {
+    form.setValue('url', '', { shouldValidate: true })
+    onChange('')
+    setLastFetchedUrl('')
+  }
+
+  /**
+   * Renders the appropriate icon for the URL input field.
+   *
+   * Shows a loading spinner when fetching video info, or a clear button
+   * when the input has a value. Returns null when the input is empty.
+   *
+   * @param value - The current URL input value
+   * @param onChange - The field onChange callback from react-hook-form
+   * @returns A React node containing either a loader, clear button, or null
+   */
   function renderInputIcon(
     value: string,
     onChange: (value: string) => void,
   ): React.ReactNode {
     if (isFetching) {
       return (
-        <div className="absolute top-1/2 right-3 -translate-y-1/2">
-          <Loader2 className="text-muted-foreground size-4 animate-spin" />
-        </div>
+        <Loader2 className="text-muted-foreground absolute top-1/2 right-3 size-4 -translate-y-1/2 animate-spin" />
       )
     }
-
     if (!value) return null
-
-    function handleClear(): void {
-      form.setValue('url', '', { shouldValidate: true })
-      onChange('')
-      setLastFetchedUrl('')
-    }
 
     return (
       <button
         type="button"
         disabled={hasActiveDownloads}
-        onClick={handleClear}
+        onClick={() => handleClear(onChange)}
         className={cn(
-          'text-muted-foreground hover:bg-muted hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2 rounded-full p-1 transition-colors',
+          'text-muted-foreground hover:bg-muted hover:text-foreground absolute top-1/2 right-2 size-8 -translate-y-1/2 rounded-full p-1 transition-colors',
           hasActiveDownloads && 'cursor-not-allowed opacity-50',
         )}
       >


### PR DESCRIPTION
## Summary

Fix the issue where a validation error message ("URL must be at least 2 characters") was displayed immediately when the app starts, even before the user enters any input.

## Changes

- **VideoForm1.tsx**: Skip validation when URL input is empty on initial render (`shouldValidate: trimmedUrl.length > 0`)
- **Code simplification**: Extract `handleClear` function, simplify `renderInputIcon`, remove unnecessary wrapper div
- **Documentation**: Add JSDoc comments for improved code clarity

## Test Plan

- [x] Start the app and verify no validation error is shown on initial load
- [x] Enter a valid Bilibili URL and verify video info is fetched successfully
- [x] Clear the URL input and verify the validation error appears (as expected for non-empty invalid input)
- [x] Enter an invalid URL and verify appropriate error message is displayed

---
🤖 Generated with [Claude Code](https://claude.ai/code)