### PR TITLE
feat: add CDN URL rotation for faster downloads

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -31,7 +31,7 @@ pub const SPEED_CHECK_SIZE: u64 = 1024 * 1024; // 1 MiB
 /// If the initial download speed is below this threshold, the connection
 /// is considered slow and will be reconnected to attempt getting a faster
 /// CDN node.
-pub const MIN_SPEED_THRESHOLD: u64 = 1024 * 1024; // 1MB/s
+pub const MIN_SPEED_THRESHOLD: u64 = 3 * 1024 * 1024; // 3MB/s
 
 /// Maximum number of reconnect attempts for slow connections.
 ///

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -53,12 +53,12 @@ pub fn validate_ffmpeg(app: &AppHandle) -> bool {
     true
 }
 
-/// Removes the ffmpeg root directory if it exists.
+/// Removes the ffmpeg root directory or file if it exists.
 fn cleanup_ffmpeg_dir(ffmpeg_root: &PathBuf) {
     if ffmpeg_root.is_dir() {
-        fs::remove_dir_all(ffmpeg_root).ok();
+        let _ = fs::remove_dir_all(ffmpeg_root);
     } else if ffmpeg_root.is_file() {
-        fs::remove_file(ffmpeg_root).ok();
+        let _ = fs::remove_file(ffmpeg_root);
     }
 }
 
@@ -110,9 +110,17 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
     };
     // ~/bilibili-downloader-gui/src-tauri/target/debug/lib/ffmpeg
     let archive_path = ffmpeg_root.join(filename);
-    if download_url(app, url.to_string(), archive_path.clone(), None, true, None)
-        .await
-        .is_err()
+    if download_url(
+        app,
+        url.to_string(),
+        None,
+        archive_path.clone(),
+        None,
+        true,
+        None,
+    )
+    .await
+    .is_err()
     {
         return Ok(false);
     }

--- a/src-tauri/src/models/bilibili_api.rs
+++ b/src-tauri/src/models/bilibili_api.rs
@@ -107,6 +107,9 @@ pub struct XPlayerApiResponseVideo {
     pub height: i16,
     #[serde(rename = "baseUrl")]
     pub base_url: String,
+    /// Backup CDN URLs for fallback when primary URL is slow.
+    #[serde(default, rename = "backupUrl")]
+    pub backup_urls: Option<Vec<String>>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Add CDN URL rotation to improve download speeds by automatically switching to backup CDN URLs when the primary connection is slow.

## Changes

- **XPlayerApiResponseVideo**: Add `backup_urls` field to capture backup CDN URLs from API
- **download_url**: Implement CDN rotation with looping - cycles through primary and backup URLs
- **MIN_SPEED_THRESHOLD**: Increase from 1MB/s to 3MB/s for faster CDN detection
- **select_stream_url**: Return backup URLs along with primary URL

## Technical Details

When download speed drops below the threshold (3MB/s), the system automatically rotates to the next CDN URL. If all backup URLs are exhausted, it loops back to the primary URL to retry. This helps handle cases where CDN performance varies over time.

Console output when rotating:
```
[CDN] Segment 0: rotating CDN #0 → #1
```

## Test Plan

- [x] Download a video and verify CDN rotation works when speed is slow
- [x] Verify console logs show CDN switches
- [x] Verify download completes successfully with rotation

---
🤖 Generated with [Claude Code](https://claude.ai/code)