### PR TITLE
docs: add multi-language README support

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,279 @@
+# BILIBILI-DOWNLOADER-GUI
+
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
+![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+
+<table width="100%">
+  <tr>
+    <td width="80%">
+      <p><strong>Interfaz gráfica de descarga de videos de Bilibili para Windows y macOS.</strong></p>
+      <p>El frontend está construido con React + Vite; la aplicación de escritorio está impulsada por Tauri (Rust).</p>
+    </td>
+    <td width="20%">
+      <img src="public/icon.png" alt="App Icon" width="128">
+    </td>
+  </tr>
+</table>
+
+> Aviso: Esta aplicación está destinada a uso educativo y personal. Respeta los términos de servicio y las leyes de derechos de autor. No descargues ni redistribuyas contenido sin permiso de los titulares de derechos.
+
+![Imagen de la aplicación](public/app-image_es.png)
+
+## ⭐ Dale una estrella a este repositorio para mantenerme motivado
+
+Desarrollo esto en mi tiempo libre. ¡Cada estrella muestra que mi trabajo es valorado y me mantiene adelante!
+
+![Star](docs/images/star-github.gif)
+
+## 🎯 Características
+
+- Obtener información de videos de Bilibili y asistir en la descarga
+- Aplicación de escritorio ligera y rápida construida con Tauri
+- Alternancia de tema claro/oscuro (basado en shadcn/ui)
+- Indicador de progreso y notificaciones toast
+- Interfaz multiidioma (English / 日本語 / Français / Español / 中文 / 한국어)
+
+## 💻 Instalación
+
+Descarga desde el [último lanzamiento](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest).
+
+### macOS
+
+- **Apple Silicon**: `bilibili-downloader-gui_<version>_aarch64.dmg`
+- **Intel x64**: `bilibili-downloader-gui_<version>_x64.dmg`
+
+### Windows
+
+- **Instalador** (recomendado): `bilibili-downloader-gui_<version>_x64-setup.exe`
+- **MSI** (alternativo): `bilibili-downloader-gui_<version>_x64_en-US.msi`
+
+> **Nota**: Las compilaciones de macOS no están firmadas. En el primer inicio, haz clic derecho en la aplicación → Abrir → Abrir, o ejecuta:
+>
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+> ```
+
+## 🍎 macOS: Primer inicio de compilaciones no firmadas
+
+Si ejecutas una compilación que no está notariada/firmada con un certificado de Apple Developer (por ejemplo, artefactos de CI), es posible que macOS Gatekeeper bloquee la aplicación. Puedes:
+
+- Hacer clic derecho en la aplicación → Abrir → Abrir, o
+- Eliminar los atributos de cuarentena/extendidos:
+
+```bash
+# Reemplaza la ruta con el nombre/ubicación real de tu aplicación instalada
+xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+# o borra todos los atributos extendidos
+xattr -c "/Applications/bilibili-downloader-gui.app"
+```
+
+Si instalaste la aplicación fuera de /Applications, ajusta la ruta en consecuencia.
+
+---
+
+## 👨‍💻 Para desarrolladores
+
+Las siguientes secciones están destinadas a desarrolladores que quieren compilar, modificar o contribuir a este proyecto.
+
+## 📦 Requisitos
+
+- Node.js 18+ (LTS recomendado)
+- Rust (stable)
+- Toolchain requerido por las compilaciones de Tauri (por ejemplo, Xcode Command Line Tools en macOS)
+
+Ver: [Documentación oficial de Tauri](https://tauri.app/)
+
+## 💻 Sistemas operativos compatibles
+
+- Windows 10/11
+- macOS 12+ (Intel y Apple Silicon)
+
+## 🚀 Inicio rápido (Desarrollo)
+
+1. Instalar dependencias
+   - `npm i`
+2. Iniciar el servidor de desarrollo de Tauri
+   - `npm run tauri dev`
+
+## 🔨 Compilación (Binarios distribuibles)
+
+- `npm run tauri build`
+  - Los artefactos generalmente se generan en `src-tauri/target/release/` (varía según el SO).
+
+## Estructura de directorios (Co-location)
+
+Usamos una estrategia de carpetas **basada en funcionalidades y co-ubicadas**.
+
+```txt
+src/
+  ├── app/                      # Configuración de la aplicación
+  │   ├── providers/            # Proveedores globales (Theme, Listener)
+  │   └── store/                # Configuración de Redux store
+  ├── pages/                    # Pantallas a nivel de ruta
+  │   ├── home/
+  │   │   └── index.tsx
+  │   ├── init/
+  │   │   └── index.tsx
+  │   └── error/
+  │       └── index.tsx
+  ├── features/                 # Módulos de funcionalidad
+  │   ├── video/
+  │   │   ├── ui/               # VideoForm1, VideoForm2, DownloadButton, etc.
+  │   │   ├── model/            # videoSlice, inputSlice, selectors
+  │   │   ├── hooks/            # useVideoInfo
+  │   │   ├── api/              # fetchVideoInfo, downloadVideo
+  │   │   ├── lib/              # utils, formSchema, constants
+  │   │   ├── types.ts
+  │   │   └── index.ts          # Public API
+  │   ├── init/
+  │   │   ├── model/            # initSlice
+  │   │   ├── hooks/            # useInit
+  │   │   └── index.ts
+  │   ├── settings/
+  │   │   ├── ui/               # SettingsDialog, LanguagesDropdown
+  │   │   ├── model/            # settingsSlice
+  │   │   ├── api/              # settingApi
+  │   │   └── index.ts
+  │   ├── user/
+  │   │   ├── model/            # userSlice
+  │   │   ├── hooks/            # useUser
+  │   │   ├── api/              # fetchUser
+  │   │   └── index.ts
+  │   └── preference/
+  │       ├── ui/               # ToggleThemeButton
+  │       └── index.ts
+  ├── shared/                   # Recursos compartidos
+  │   ├── ui/                   # Componentes shadcn/ui, AppBar, Progress
+  │   ├── animate-ui/           # Componentes de UI animados
+  │   ├── hooks/                # useIsMobile, etc.
+  │   ├── lib/                  # cn(), utilidades
+  │   ├── progress/             # Gestión del estado de progreso
+  │   ├── downloadStatus/       # Estado de descarga
+  │   ├── queue/                # Estado de cola
+  │   └── os/                   # API de detección de SO
+  ├── i18n/                     # Internacionalización
+  │   └── locales/              # Archivos de traducción
+  ├── styles/                   # Estilos globales
+  └── assets/                   # Activos estáticos
+```
+
+### Responsabilidades de los directorios
+
+#### `src/app/`
+
+Configuración de la aplicación a nivel raíz. Aquí es donde se ensambla la aplicación: proveedores globales y configuración del store.
+
+#### `src/pages/`
+
+Pantallas a nivel de ruta. Las páginas deben principalmente **componer** funcionalidades y UI compartida. Mantén la lógica de negocio/estado dentro de `features/`.
+
+#### `src/features/`
+
+Funcionalidades de producto reutilizables (comportamiento orientado al usuario). Cada funcionalidad co-ubica su lógica Redux, llamadas API y UI.
+
+Una carpeta de funcionalidad típica contiene:
+
+- `ui/` — Componentes de UI específicos de la funcionalidad
+- `model/` — Redux Toolkit slice, selectors
+- `hooks/` — Hooks de la funcionalidad
+- `api/` — Funciones API específicas de la funcionalidad
+- `lib/` — Utilidades internas de la funcionalidad
+- `types.ts` — Tipos locales de la funcionalidad
+- `index.ts` — **Public API** de la funcionalidad (punto de entrada recomendado para importaciones)
+
+#### `src/shared/`
+
+Bloques de construcción reutilizables no específicos de dominio utilizados en toda la aplicación.
+
+- `shared/ui/` — Primitivas de UI reutilizables en toda la aplicación (shadcn/ui, componentes personalizados)
+- `shared/animate-ui/` — Componentes de UI animados
+- `shared/lib/` — Utilidades genéricas (por ejemplo, `cn()`)
+- `shared/hooks/` — React hooks reutilizables
+
+### Reglas de importación
+
+- `pages` puede importar desde `features` y `shared`.
+- `features` no debe importar desde `pages`.
+- Evita importar directamente desde otros `features`. Prefiere la composición en `pages`.
+- Prefiere importar desde el `index.ts` de una funcionalidad (Public API) en lugar de rutas profundas.
+
+### Alias de ruta
+
+- `@/app/*`
+- `@/pages/*`
+- `@/features/*`
+- `@/shared/*`
+
+### Backend (Tauri / Rust)
+
+```txt
+src-tauri/src/
+  main.rs            ← Punto de entrada (mantenido simple)
+  lib.rs             ← Módulo raíz de la app / definiciones de comandos
+  handlers/          ← Implementaciones de comandos
+  models/            ← Estructuras de datos (solicitudes/respuestas, etc.)
+  utils/             ← Utilidades
+```
+
+## ⚙️ Scripts
+
+- Desarrollo: `npm run tauri dev`
+- Compilación: `npm run tauri build`
+
+## 🛠️ Stack tecnológico
+
+- Frontend: React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
+- Desktop: Tauri (Rust)
+
+## ❌ Códigos de error
+
+Códigos de error devueltos (mapeados a i18n en el frontend):
+
+- `ERR::COOKIE_MISSING` Cookie faltante o inválida
+- `ERR::QUALITY_NOT_FOUND` ID de calidad solicitado no disponible
+- `ERR::DISK_FULL` Espacio libre en disco insuficiente
+- `ERR::FILE_EXISTS` Conflicto de archivo no resoluble automáticamente
+- `ERR::NETWORK::<detail>` Fallo de red después de reintentos
+- `ERR::MERGE_FAILED` Proceso de fusión ffmpeg fallido
+
+## 🔮 Futuro
+
+- [ ] Seleccionar destino de descarga
+- [ ] Permitir sobrescribir archivos existentes
+- [ ] Cola de múltiples elementos para descarga
+- [ ] Retención del historial de descargas
+- [ ] Lanzamiento de instancia única de la app (evitar múltiples lanzamientos concurrentes)
+
+## 🌍 Localización (i18n)
+
+Idiomas actualmente soportados:
+
+- English (en)
+- 日本語 (ja)
+- Français (fr)
+- Español (es)
+- 中文 (zh)
+- 한국어 (ko)
+
+Se agradecen contribuciones para idiomas adicionales. Si encuentras una frase antinatural o incómoda, por favor abre un Pull Request.
+
+## 🤝 Contribuir
+
+Se agradecen Issues y PRs. Para cambios grandes, por favor inicia una discusión en un Issue primero. Las correcciones pequeñas (documentación, erratas, ajustes menores de UI) son apreciadas.
+
+## 📜 Licencia
+
+MIT License — ver [LICENSE](./LICENSE) para más detalles.
+
+## 🙏 Agradecimientos
+
+- El equipo y la comunidad de Tauri
+- OSS como shadcn/ui, Radix UI, sonner
+
+---
+
+Si encuentras este proyecto útil, por favor considera darle una estrella al repositorio — realmente ayuda a motivar el desarrollo continuo.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,279 @@
+# BILIBILI-DOWNLOADER-GUI
+
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
+![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+
+<table width="100%">
+  <tr>
+    <td width="80%">
+      <p><strong>Interface graphique de téléchargement de vidéos Bilibili pour Windows et macOS.</strong></p>
+      <p>Le frontend est construit avec React + Vite ; l'application de bureau est propulsée par Tauri (Rust).</p>
+    </td>
+    <td width="20%">
+      <img src="public/icon.png" alt="App Icon" width="128">
+    </td>
+  </tr>
+</table>
+
+> Remarque : Cette application est destinée à un usage éducatif et personnel. Respectez les conditions d'utilisation et les lois sur le droit d'auteur. Ne téléchargez ni ne redistribuez de contenu sans l'autorisation des détenteurs de droits.
+
+![Image de l'application](public/app-image_fr.png)
+
+## ⭐ Mettez une étoile à ce dépôt pour me motiver
+
+Je développe ceci sur mon temps libre. Chaque étoile montre que mon travail est apprécié et me encourage à continuer !
+
+![Star](docs/images/star-github.gif)
+
+## 🎯 Fonctionnalités
+
+- Récupérer les informations des vidéos Bilibili et assister au téléchargement
+- Application de bureau légère et rapide construite avec Tauri
+- Basculement thème clair/sombre (basé sur shadcn/ui)
+- Indicateur de progression et notifications toast
+- Interface multilingue (English / 日本語 / Français / Español / 中文 / 한국어)
+
+## 💻 Installation
+
+Téléchargez depuis la [dernière version](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest).
+
+### macOS
+
+- **Apple Silicon** : `bilibili-downloader-gui_<version>_aarch64.dmg`
+- **Intel x64** : `bilibili-downloader-gui_<version>_x64.dmg`
+
+### Windows
+
+- **Installateur** (recommandé) : `bilibili-downloader-gui_<version>_x64-setup.exe`
+- **MSI** (alternative) : `bilibili-downloader-gui_<version>_x64_en-US.msi`
+
+> **Note** : Les builds macOS ne sont pas signés. Au premier lancement, faites un clic droit sur l'application → Ouvrir → Ouvrir, ou exécutez :
+>
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+> ```
+
+## 🍎 macOS : Premier lancement des builds non signés
+
+Si vous exécutez un build qui n'est pas notarisé/signé avec un certificat Apple Developer (par ex., artefacts CI), macOS Gatekeeper peut bloquer l'application. Vous pouvez :
+
+- Faire un clic droit sur l'application → Ouvrir → Ouvrir, ou
+- Supprimer les attributs de quarantaine/étendus :
+
+```bash
+# Remplacez le chemin par le nom/emplacement réel de votre application installée
+xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+# ou effacez tous les attributs étendus
+xattr -c "/Applications/bilibili-downloader-gui.app"
+```
+
+Si vous avez installé l'application en dehors de /Applications, ajustez le chemin en conséquence.
+
+---
+
+## 👨‍💻 Pour les développeurs
+
+Les sections suivantes sont destinées aux développeurs qui souhaitent compiler, modifier ou contribuer à ce projet.
+
+## 📦 Prérequis
+
+- Node.js 18+ (LTS recommandé)
+- Rust (stable)
+- Toolchain requis par les builds Tauri (par ex., Xcode Command Line Tools sur macOS)
+
+Voir : [Documentation officielle de Tauri](https://tauri.app/)
+
+## 💻 Systèmes d'exploitation pris en charge
+
+- Windows 10/11
+- macOS 12+ (Intel et Apple Silicon)
+
+## 🚀 Démarrage rapide (Développement)
+
+1. Installer les dépendances
+   - `npm i`
+2. Démarrer le serveur de développement Tauri
+   - `npm run tauri dev`
+
+## 🔨 Compilation (Binaires distribuables)
+
+- `npm run tauri build`
+  - Les artefacts sont généralement générés dans `src-tauri/target/release/` (varie selon le système d'exploitation).
+
+## Structure des répertoires (Co-location)
+
+Nous utilisons une stratégie de dossier **basée sur les fonctionnalités et co-localisée**.
+
+```txt
+src/
+  ├── app/                      # Configuration de l'application
+  │   ├── providers/            # Fournisseurs globaux (Theme, Listener)
+  │   └── store/                # Configuration du store Redux
+  ├── pages/                    # Écrans au niveau des routes
+  │   ├── home/
+  │   │   └── index.tsx
+  │   ├── init/
+  │   │   └── index.tsx
+  │   └── error/
+  │       └── index.tsx
+  ├── features/                 # Modules de fonctionnalités
+  │   ├── video/
+  │   │   ├── ui/               # VideoForm1, VideoForm2, DownloadButton, etc.
+  │   │   ├── model/            # videoSlice, inputSlice, selectors
+  │   │   ├── hooks/            # useVideoInfo
+  │   │   ├── api/              # fetchVideoInfo, downloadVideo
+  │   │   ├── lib/              # utils, formSchema, constants
+  │   │   ├── types.ts
+  │   │   └── index.ts          # Public API
+  │   ├── init/
+  │   │   ├── model/            # initSlice
+  │   │   ├── hooks/            # useInit
+  │   │   └── index.ts
+  │   ├── settings/
+  │   │   ├── ui/               # SettingsDialog, LanguagesDropdown
+  │   │   ├── model/            # settingsSlice
+  │   │   ├── api/              # settingApi
+  │   │   └── index.ts
+  │   ├── user/
+  │   │   ├── model/            # userSlice
+  │   │   ├── hooks/            # useUser
+  │   │   ├── api/              # fetchUser
+  │   │   └── index.ts
+  │   └── preference/
+  │       ├── ui/               # ToggleThemeButton
+  │       └── index.ts
+  ├── shared/                   # Ressources partagées
+  │   ├── ui/                   # Composants shadcn/ui, AppBar, Progress
+  │   ├── animate-ui/           # Composants UI animés
+  │   ├── hooks/                # useIsMobile, etc.
+  │   ├── lib/                  # cn(), utilitaires
+  │   ├── progress/             # Gestion de l'état de progression
+  │   ├── downloadStatus/       # État de téléchargement
+  │   ├── queue/                # État de la file d'attente
+  │   └── os/                   # API de détection du système d'exploitation
+  ├── i18n/                     # Internationalisation
+  │   └── locales/              # Fichiers de traduction
+  ├── styles/                   # Styles globaux
+  └── assets/                   # Ressources statiques
+```
+
+### Responsabilités des répertoires
+
+#### `src/app/`
+
+Configuration de l'application au niveau racine. C'est là que l'application est assemblée : fournisseurs globaux et configuration du store.
+
+#### `src/pages/`
+
+Écrans au niveau des routes. Les pages doivent principalement **composer** des fonctionnalités et de l'UI partagée. Gardez la logique métier/état à l'intérieur de `features/`.
+
+#### `src/features/`
+
+Fonctionnalités produit réutilisables (comportement orienté utilisateur). Chaque fonctionnalité co-localise sa logique Redux, ses appels API et son UI.
+
+Un dossier de fonctionnalité typique contient :
+
+- `ui/` — Composants UI spécifiques à la fonctionnalité
+- `model/` — Redux Toolkit slice, selectors
+- `hooks/` — Hooks de la fonctionnalité
+- `api/` — Fonctions API spécifiques à la fonctionnalité
+- `lib/` — Utilitaires internes de la fonctionnalité
+- `types.ts` — Types locaux de la fonctionnalité
+- `index.ts` — **Public API** de la fonctionnalité (point d'entrée recommandé pour les imports)
+
+#### `src/shared/`
+
+Blocs de construction réutilisables non spécifiques au domaine utilisés dans toute l'application.
+
+- `shared/ui/` — Primitives UI réutilisables dans toute l'application (shadcn/ui, composants personnalisés)
+- `shared/animate-ui/` — Composants UI animés
+- `shared/lib/` — Utilitaires génériques (par ex., `cn()`)
+- `shared/hooks/` — React hooks réutilisables
+
+### Règles d'importation
+
+- `pages` peut importer depuis `features` et `shared`.
+- `features` ne doit pas importer depuis `pages`.
+- Évitez d'importer directement depuis d'autres `features`. Préférez la composition dans `pages`.
+- Préférez importer depuis le `index.ts` d'une fonctionnalité (Public API) plutôt que des chemins profonds.
+
+### Alias de chemin
+
+- `@/app/*`
+- `@/pages/*`
+- `@/features/*`
+- `@/shared/*`
+
+### Backend (Tauri / Rust)
+
+```txt
+src-tauri/src/
+  main.rs            ← Point d'entrée (gardé simple)
+  lib.rs             ← Module racine de l'application / définitions des commandes
+  handlers/          ← Implémentations des commandes
+  models/            ← Structures de données (requêtes/réponses, etc.)
+  utils/             ← Utilitaires
+```
+
+## ⚙️ Scripts
+
+- Développement : `npm run tauri dev`
+- Compilation : `npm run tauri build`
+
+## 🛠️ Stack technique
+
+- Frontend : React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
+- Desktop : Tauri (Rust)
+
+## ❌ Codes d'erreur
+
+Codes d'erreur retournés (mappés à i18n dans le frontend) :
+
+- `ERR::COOKIE_MISSING` Cookie manquant ou invalide
+- `ERR::QUALITY_NOT_FOUND` ID de qualité demandé non disponible
+- `ERR::DISK_FULL` Espace disque libre insuffisant
+- `ERR::FILE_EXISTS` Conflit de fichier non résolvable automatiquement
+- `ERR::NETWORK::<detail>` Échec réseau après tentatives
+- `ERR::MERGE_FAILED` Échec du processus de fusion ffmpeg
+
+## 🔮 Futur
+
+- [ ] Sélectionner la destination de téléchargement
+- [ ] Autoriser l'écrasement des fichiers existants
+- [ ] Mise en file d'attente de plusieurs éléments pour téléchargement
+- [ ] Rétention de l'historique de téléchargement
+- [ ] Lancement en instance unique (empêcher les lancements simultanés multiples)
+
+## 🌍 Localisation (i18n)
+
+Langues actuellement prises en charge :
+
+- English (en)
+- 日本語 (ja)
+- Français (fr)
+- Español (es)
+- 中文 (zh)
+- 한국어 (ko)
+
+Les contributions pour des langues supplémentaires sont les bienvenues. Si vous trouvez une expression non naturelle ou maladroite, veuillez ouvrir une Pull Request.
+
+## 🤝 Contribuer
+
+Les Issues et PR sont les bienvenues. Pour les gros changements, veuillez d'abord lancer une discussion dans un Issue. Les petites corrections (documentation, coquilles, ajustements mineurs de l'UI) sont appréciées.
+
+## 📜 Licence
+
+MIT License — voir [LICENSE](./LICENSE) pour plus de détails.
+
+## 🙏 Remerciements
+
+- L'équipe et la communauté Tauri
+- Les OSS comme shadcn/ui, Radix UI, sonner
+
+---
+
+Si vous trouvez ce projet utile, veuillez envisager de mettre une étoile au dépôt — cela aide vraiment à motiver le développement continu.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,279 @@
+# BILIBILI-DOWNLOADER-GUI
+
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
+![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+
+<table width="100%">
+  <tr>
+    <td width="80%">
+      <p><strong>Windows / macOS対応のBilibili動画ダウンローダーGUIアプリ</strong></p>
+      <p>フロントエンドはReact + Vite、デスクトップアプリはTauri（Rust）で構築されています。</p>
+    </td>
+    <td width="20%">
+      <img src="public/icon.png" alt="App Icon" width="128">
+    </td>
+  </tr>
+</table>
+
+> 注意: このアプリは教育目的および個人利用を目的としています。利用規約と著作権法を遵守してください。権利者の許可なくコンテンツをダウンロードまたは再配布しないでください。
+
+![アプリ画像](public/app-image_ja.png)
+
+## ⭐ このリポジトリにスターをお願いします
+
+余暇に開発しています。スターをいただけるたびに、この開発が続けられるモチベーションになります！
+
+![Star](docs/images/star-github.gif)
+
+## 🎯 機能
+
+- Bilibili動画情報の取得とダウンロード支援
+- Tauriで構築された軽量・高速なデスクトップアプリ
+- ライト/ダークテーマ切り替え（shadcn/uiベース）
+- 進捗表示とトースト通知
+- 多言語UI対応（English / 日本語 / Français / Español / 中文 / 한국어）
+
+## 💻 インストール
+
+[最新リリース](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)からダウンロードしてください。
+
+### macOS
+
+- **Apple Silicon**: `bilibili-downloader-gui_<version>_aarch64.dmg`
+- **Intel x64**: `bilibili-downloader-gui_<version>_x64.dmg`
+
+### Windows
+
+- **インストーラー**（推奨）: `bilibili-downloader-gui_<version>_x64-setup.exe`
+- **MSI**（代替）: `bilibili-downloader-gui_<version>_x64_en-US.msi`
+
+> **注意**: macOSビルドは署名されていません。初回起動時は、アプリを右クリック → 開く → 開く を選択するか、以下を実行してください:
+>
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+> ```
+
+## 🍎 macOS: 署名されていないビルドの初回起動
+
+Apple Developer証明書で署名/公証されていないビルド（例: CIアーティファクト）を使用する場合、macOS Gatekeeperがアプリをブロックする可能性があります。以下のいずれかの方法で対処できます:
+
+- アプリを右クリック → 開く → 開く を選択
+- 検疫属性/拡張属性を削除:
+
+```bash
+# パスは実際のインストール済みアプリ名/場所に置き換えてください
+xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+# または、すべての拡張属性をクリア
+xattr -c "/Applications/bilibili-downloader-gui.app"
+```
+
+/Applications以外にインストールした場合は、パスを適宜調整してください。
+
+---
+
+## 👨‍💻 開発者向け
+
+以下のセクションは、このプロジェクトをビルド、変更、または貢献したい開発者向けです。
+
+## 📦 必要条件
+
+- Node.js 18以上（LTS推奨）
+- Rust（stable）
+- Tauriビルドに必要なツールチェーン（例: macOSではXcode Command Line Tools）
+
+詳細: [Tauri公式ドキュメント](https://tauri.app/)
+
+## 💻 対応OS
+
+- Windows 10/11
+- macOS 12以上（Intel および Apple Silicon）
+
+## 🚀 クイックスタート（開発）
+
+1. 依存関係をインストール
+   - `npm i`
+2. Tauri開発サーバーを起動
+   - `npm run tauri dev`
+
+## 🔨 ビルド（配布用バイナリ）
+
+- `npm run tauri build`
+  - 成果物は通常 `src-tauri/target/release/` に生成されます（OSにより異なります）。
+
+## ディレクトリ構造（Co-location）
+
+**フィーチャーベース・コロケーション**のフォルダ戦略を採用しています。
+
+```txt
+src/
+  ├── app/                      # アプリケーション設定
+  │   ├── providers/            # グローバルProvider (Theme, Listener)
+  │   └── store/                # Redux store設定
+  ├── pages/                    # ルートレベル画面
+  │   ├── home/
+  │   │   └── index.tsx
+  │   ├── init/
+  │   │   └── index.tsx
+  │   └── error/
+  │       └── index.tsx
+  ├── features/                 # 機能モジュール
+  │   ├── video/
+  │   │   ├── ui/               # VideoForm1, VideoForm2, DownloadButton等
+  │   │   ├── model/            # videoSlice, inputSlice, selectors
+  │   │   ├── hooks/            # useVideoInfo
+  │   │   ├── api/              # fetchVideoInfo, downloadVideo
+  │   │   ├── lib/              # utils, formSchema, constants
+  │   │   ├── types.ts
+  │   │   └── index.ts          # Public API
+  │   ├── init/
+  │   │   ├── model/            # initSlice
+  │   │   ├── hooks/            # useInit
+  │   │   └── index.ts
+  │   ├── settings/
+  │   │   ├── ui/               # SettingsDialog, LanguagesDropdown
+  │   │   ├── model/            # settingsSlice
+  │   │   ├── api/              # settingApi
+  │   │   └── index.ts
+  │   ├── user/
+  │   │   ├── model/            # userSlice
+  │   │   ├── hooks/            # useUser
+  │   │   ├── api/              # fetchUser
+  │   │   └── index.ts
+  │   └── preference/
+  │       ├── ui/               # ToggleThemeButton
+  │       └── index.ts
+  ├── shared/                   # 共通リソース
+  │   ├── ui/                   # shadcn/uiコンポーネント, AppBar, Progress
+  │   ├── animate-ui/           # アニメーションUIコンポーネント
+  │   ├── hooks/                # useIsMobile等
+  │   ├── lib/                  # cn(), ユーティリティ
+  │   ├── progress/             # 進捗状態管理
+  │   ├── downloadStatus/       # ダウンロード状態管理
+  │   ├── queue/                # キュー状態
+  │   └── os/                   # OS検出API
+  ├── i18n/                     # 国際化
+  │   └── locales/              # 翻訳ファイル
+  ├── styles/                   # グローバルスタイル
+  └── assets/                   # 静的アセット
+```
+
+### ディレクトリの役割
+
+#### `src/app/`
+
+ルートレベルのアプリケーション設定。グローバルプロバイダーとストアのセットアップを行います。
+
+#### `src/pages/`
+
+ルートレベルの画面。ページは主にフィーチャーと共有UIを**構成**します。ビジネスロジック/状態は `features/` 内に保持してください。
+
+#### `src/features/`
+
+再利用可能なプロダクトフィーチャー（ユーザー向け機能）。各フィーチャーはReduxロジック、APIコール、UIをコロケーションします。
+
+典型的なフィーチャーフォルダには以下が含まれます:
+
+- `ui/` — フィーチャー固有のUIコンポーネント
+- `model/` — Redux Toolkit slice、selectors
+- `hooks/` — フィーチャーフック
+- `api/` — フィーチャー固有のAPI関数
+- `lib/` — フィーチャー内部のユーティリティ
+- `types.ts` — フィーチャーローカル型
+- `index.ts` — フィーチャー**Public API**（インポートの推奨エントリーポイント）
+
+#### `src/shared/`
+
+アプリ全体で使用される再利用可能なドメイン非依存のビルディングブロック。
+
+- `shared/ui/` — アプリ全体で再利用可能なUIプリミティブ（shadcn/ui、カスタムコンポーネント）
+- `shared/animate-ui/` — アニメーションUIコンポーネント
+- `shared/lib/` — 汎用ユーティリティ（例: `cn()`）
+- `shared/hooks/` — 再利用可能なReactフック
+
+### インポートルール
+
+- `pages` → `features`、`shared` からインポート可能
+- `features` → `pages` からインポート禁止
+- 他の `features` から直接インポートは避ける。`pages` で構成することを推奨
+- フィーチャーの `index.ts`（Public API）からインポートすることを推奨（深いパスは避ける）
+
+### パスエイリアス
+
+- `@/app/*`
+- `@/pages/*`
+- `@/features/*`
+- `@/shared/*`
+
+### バックエンド（Tauri / Rust）
+
+```txt
+src-tauri/src/
+  main.rs            ← エントリーポイント（シンプルに保つ）
+  lib.rs             ← アプリのルートモジュール / コマンド定義
+  handlers/          ← コマンドの実装
+  models/            ← データ構造（リクエスト/レスポンス等）
+  utils/             ← ユーティリティ
+```
+
+## ⚙️ スクリプト
+
+- 開発: `npm run tauri dev`
+- ビルド: `npm run tauri build`
+
+## 🛠️ 技術スタック
+
+- フロントエンド: React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
+- デスクトップ: Tauri (Rust)
+
+## ❌ エラーコード
+
+返されるエラーコード（フロントエンドでi18nにマッピング）:
+
+- `ERR::COOKIE_MISSING` Cookieが見つからない、または無効
+- `ERR::QUALITY_NOT_FOUND` リクエストされた品質IDが利用できない
+- `ERR::DISK_FULL` ディスクの空き容量不足
+- `ERR::FILE_EXISTS` ファイル競合が自動解決できない
+- `ERR::NETWORK::<detail>` リトライ後もネットワークエラー
+- `ERR::MERGE_FAILED` ffmpegマージプロセスが失敗
+
+## 🔮 今後の予定
+
+- [ ] ダウンロード先の選択
+- [ ] 既存ファイルの上書き許可
+- [ ] 複数アイテムのキューダウンロード
+- [ ] ダウンロード履歴の保持
+- [ ] シングルインスタンス起動（複数同時起動の防止）
+
+## 🌍 ローカライゼーション（i18n）
+
+現在サポートされている言語:
+
+- English (en)
+- 日本語 (ja)
+- Français (fr)
+- Español (es)
+- 中文 (zh)
+- 한국어 (ko)
+
+追加言語の貢献を歓迎します。不自然な表現を見つけた場合は、Pull Requestを開いてください。
+
+## 🤝 コントリビュート
+
+IssueとPRを歓迎します。大きな変更がある場合は、まずIssueで議論を開始してください。小さな修正（ドキュメント、誤字、軽微なUI調整）も感謝します。
+
+## 📜 ライセンス
+
+MIT License — 詳細は[LICENSE](./LICENSE)を参照してください。
+
+## 🙏 謝辞
+
+- Tauriチームとコミュニティ
+- shadcn/ui、Radix UI、sonnerなどのOSS
+
+---
+
+このプロジェクトが役に立ったら、リポジトリにスターを付けていただけると、継続的な開発のモチベーションになります。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,279 @@
+# BILIBILI-DOWNLOADER-GUI
+
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
+![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+
+<table width="100%">
+  <tr>
+    <td width="80%">
+      <p><strong>Windows 및 macOS용 Bilibili 동영상 다운로더 GUI 애플리케이션</strong></p>
+      <p>프론트엔드는 React + Vite로 구축되었으며, 데스크톱 앱은 Tauri(Rust)로 구동됩니다.</p>
+    </td>
+    <td width="20%">
+      <img src="public/icon.png" alt="App Icon" width="128">
+    </td>
+  </tr>
+</table>
+
+> 참고: 이 앱은 교육 및 개인 사용 목적으로 제공됩니다. 이용 약관과 저작권법을 준수해 주세요. 저작권자의 허가 없이 콘텐츠를 다운로드하거나 재배포하지 마세요.
+
+![앱 이미지](public/app-image_ko.png)
+
+## ⭐ 이 저장소에 Star를 눌러주세요
+
+여가 시간에 개발하고 있습니다. 모든 Star는 제 작업이 가치 있음을 보여주며 개발을 계속하게 만듭니다!
+
+![Star](docs/images/star-github.gif)
+
+## 🎯 기능
+
+- Bilibili 동영상 정보 가져오기 및 다운로드 지원
+- Tauri로 구축된 가볍고 빠른 데스크톱 앱
+- 라이트/다크 테마 전환 (shadcn/ui 기반)
+- 진행 표시기 및 토스트 알림
+- 다국어 UI (English / 日本語 / Français / Español / 中文 / 한국어)
+
+## 💻 설치
+
+[최신 릴리스](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)에서 다운로드하세요.
+
+### macOS
+
+- **Apple Silicon**: `bilibili-downloader-gui_<version>_aarch64.dmg`
+- **Intel x64**: `bilibili-downloader-gui_<version>_x64.dmg`
+
+### Windows
+
+- **설치 프로그램** (권장): `bilibili-downloader-gui_<version>_x64-setup.exe`
+- **MSI** (대체): `bilibili-downloader-gui_<version>_x64_en-US.msi`
+
+> **참고**: macOS 빌드는 서명되지 않았습니다. 첫 실행 시, 앱을 우클릭 → 열기 → 열기를 선택하거나, 다음을 실행하세요:
+>
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+> ```
+
+## 🍎 macOS: 서명되지 않은 빌드의 첫 실행
+
+Apple Developer 인증서로 공증/서명되지 않은 빌드(예: CI 아티팩트)를 실행하면 macOS Gatekeeper가 앱을 차단할 수 있습니다. 다음 방법으로 해결할 수 있습니다:
+
+- 앱을 우클릭 → 열기 → 열기 선택, 또는
+- 격리/확장 속성 제거:
+
+```bash
+# 경로를 실제 설치된 앱 이름/위치로 변경하세요
+xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+# 또는 모든 확장 속성 지우기
+xattr -c "/Applications/bilibili-downloader-gui.app"
+```
+
+앱을 /Applications 외부에 설치한 경우, 경로를 적절히 조정하세요.
+
+---
+
+## 👨‍💻 개발자를 위한 안내
+
+다음 섹션은 이 프로젝트를 빌드, 수정 또는 기여하려는 개발자를 위한 것입니다.
+
+## 📦 요구 사항
+
+- Node.js 18+ (LTS 권장)
+- Rust (stable)
+- Tauri 빌드에 필요한 툴체인 (예: macOS의 Xcode Command Line Tools)
+
+참고: [Tauri 공식 문서](https://tauri.app/)
+
+## 💻 지원 OS
+
+- Windows 10/11
+- macOS 12+ (Intel 및 Apple Silicon)
+
+## 🚀 빠른 시작 (개발)
+
+1. 의존성 설치
+   - `npm i`
+2. Tauri 개발 서버 시작
+   - `npm run tauri dev`
+
+## 🔨 빌드 (배포용 바이너리)
+
+- `npm run tauri build`
+  - 아티팩트는 일반적으로 `src-tauri/target/release/`에 생성됩니다 (OS에 따라 다름).
+
+## 디렉토리 구조 (Co-location)
+
+**기능 기반 공동 배치** 폴더 전략을 사용합니다.
+
+```txt
+src/
+  ├── app/                      # 애플리케이션 구성
+  │   ├── providers/            # 전역 Provider (Theme, Listener)
+  │   └── store/                # Redux store 구성
+  ├── pages/                    # 라우트 수준 화면
+  │   ├── home/
+  │   │   └── index.tsx
+  │   ├── init/
+  │   │   └── index.tsx
+  │   └── error/
+  │       └── index.tsx
+  ├── features/                 # 기능 모듈
+  │   ├── video/
+  │   │   ├── ui/               # VideoForm1, VideoForm2, DownloadButton 등
+  │   │   ├── model/            # videoSlice, inputSlice, selectors
+  │   │   ├── hooks/            # useVideoInfo
+  │   │   ├── api/              # fetchVideoInfo, downloadVideo
+  │   │   ├── lib/              # utils, formSchema, constants
+  │   │   ├── types.ts
+  │   │   └── index.ts          # Public API
+  │   ├── init/
+  │   │   ├── model/            # initSlice
+  │   │   ├── hooks/            # useInit
+  │   │   └── index.ts
+  │   ├── settings/
+  │   │   ├── ui/               # SettingsDialog, LanguagesDropdown
+  │   │   ├── model/            # settingsSlice
+  │   │   ├── api/              # settingApi
+  │   │   └── index.ts
+  │   ├── user/
+  │   │   ├── model/            # userSlice
+  │   │   ├── hooks/            # useUser
+  │   │   ├── api/              # fetchUser
+  │   │   └── index.ts
+  │   └── preference/
+  │       ├── ui/               # ToggleThemeButton
+  │       └── index.ts
+  ├── shared/                   # 공유 리소스
+  │   ├── ui/                   # shadcn/ui 컴포넌트, AppBar, Progress
+  │   ├── animate-ui/           # 애니메이션 UI 컴포넌트
+  │   ├── hooks/                # useIsMobile 등
+  │   ├── lib/                  # cn(), 유틸리티
+  │   ├── progress/             # 진행 상태 관리
+  │   ├── downloadStatus/       # 다운로드 상태 관리
+  │   ├── queue/                # 큐 상태
+  │   └── os/                   # OS 감지 API
+  ├── i18n/                     # 국제화
+  │   └── locales/              # 번역 파일
+  ├── styles/                   # 전역 스타일
+  └── assets/                   # 정적 자산
+```
+
+### 디렉토리 책임
+
+#### `src/app/`
+
+루트 수준의 애플리케이션 구성. 전역 프로바이더와 스토어 설정이 위치합니다.
+
+#### `src/pages/`
+
+라우트 수준 화면. 페이지는 주로 기능과 공유 UI를 **구성**해야 합니다. 비즈니스 로직/상태는 `features/` 내에 유지하세요.
+
+#### `src/features/`
+
+재사용 가능한 제품 기능 (사용자 대면 동작). 각 기능은 Redux 로직, API 호출, UI를 공동 배치합니다.
+
+일반적인 기능 폴더에는 다음이 포함됩니다:
+
+- `ui/` — 기능별 UI 컴포넌트
+- `model/` — Redux Toolkit slice, selectors
+- `hooks/` — 기능 훅
+- `api/` — 기능별 API 함수
+- `lib/` — 기능 내부 유틸리티
+- `types.ts` — 기능 로컬 타입
+- `index.ts` — 기능 **Public API** (권장 가져오기 진입점)
+
+#### `src/shared/`
+
+앱 전체에서 사용되는 재사용 가능한 도메인 비특정 빌딩 블록.
+
+- `shared/ui/` — 앱 전체 재사용 가능 UI 프리미티브 (shadcn/ui, 커스텀 컴포넌트)
+- `shared/animate-ui/` — 애니메이션 UI 컴포넌트
+- `shared/lib/` — 범용 유틸리티 (예: `cn()`)
+- `shared/hooks/` — 재사용 가능한 React hooks
+
+### 가져오기 규칙
+
+- `pages` → `features`, `shared`에서 가져오기 가능
+- `features` → `pages`에서 가져오기 금지
+- 다른 `features`에서 직접 가져오기 피하기. `pages`에서 구성 권장
+- 기능의 `index.ts` (Public API)에서 가져오기 권장 (깊은 경로 피하기)
+
+### 경로 별칭
+
+- `@/app/*`
+- `@/pages/*`
+- `@/features/*`
+- `@/shared/*`
+
+### 백엔드 (Tauri / Rust)
+
+```txt
+src-tauri/src/
+  main.rs            ← 진입점 (간결하게 유지)
+  lib.rs             ← 앱 루트 모듈 / 명령 정의
+  handlers/          ← 명령 구현
+  models/            ← 데이터 구조 (요청/응답 등)
+  utils/             ← 유틸리티
+```
+
+## ⚙️ 스크립트
+
+- 개발: `npm run tauri dev`
+- 빌드: `npm run tauri build`
+
+## 🛠️ 기술 스택
+
+- 프론트엔드: React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
+- 데스크톱: Tauri (Rust)
+
+## ❌ 에러 코드
+
+반환되는 에러 코드 (프론트엔드에서 i18n으로 매핑):
+
+- `ERR::COOKIE_MISSING` Cookie가 없거나 유효하지 않음
+- `ERR::QUALITY_NOT_FOUND` 요청한 품질 ID를 사용할 수 없음
+- `ERR::DISK_FULL` 디스크 여유 공간 부족
+- `ERR::FILE_EXISTS` 파일 충돌을 자동으로 해결할 수 없음
+- `ERR::NETWORK::<detail>` 재시도 후 네트워크 실패
+- `ERR::MERGE_FAILED` ffmpeg 병합 프로세스 실패
+
+## 🔮 향후 계획
+
+- [ ] 다운로드 대상 선택
+- [ ] 기존 파일 덮어쓰기 허용
+- [ ] 여러 항목 큐잉 다운로드
+- [ ] 다운로드 기록 보존
+- [ ] 단일 인스턴스 앱 실행 (여러 동시 실행 방지)
+
+## 🌍 현지화 (i18n)
+
+현재 지원 언어:
+
+- English (en)
+- 日本語 (ja)
+- Français (fr)
+- Español (es)
+- 中文 (zh)
+- 한국어 (ko)
+
+추가 언어 기여를 환영합니다. 어색하거나 부자연스러운 표현을 발견하시면 Pull Request를 열어주세요.
+
+## 🤝 기여
+
+Issue와 PR을 환영합니다. 큰 변경이 있는 경우, 먼저 Issue에서 논의를 시작해 주세요. 작은 수정(문서, 오타, 사소한 UI 조정)도 감사합니다.
+
+## 📜 라이선스
+
+MIT License — 자세한 내용은 [LICENSE](./LICENSE)를 참조하세요.
+
+## 🙏 감사의 말
+
+- Tauri 팀과 커뮤니티
+- shadcn/ui, Radix UI, sonner 등 OSS
+
+---
+
+이 프로젝트가 유용하다고 생각되시면 저장소에 Star를 고려해 주세요 — 지속적인 개발에 큰 동기가 됩니다.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BILIBILI-DOWNLOADER-GUI
 
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
 ![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,279 @@
+# BILIBILI-DOWNLOADER-GUI
+
+[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
+![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
+![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+
+<table width="100%">
+  <tr>
+    <td width="80%">
+      <p><strong>Windows 和 macOS Bilibili 视频下载器图形界面应用</strong></p>
+      <p>前端使用 React + Vite 构建，桌面应用由 Tauri (Rust) 驱动。</p>
+    </td>
+    <td width="20%">
+      <img src="public/icon.png" alt="App Icon" width="128">
+    </td>
+  </tr>
+</table>
+
+> 注意：本应用仅供教育和个人使用。请遵守服务条款和版权法。未经版权所有者许可，请勿下载或重新分发内容。
+
+![应用截图](public/app-image_zh.png)
+
+## ⭐ 给这个仓库点个 Star 吧
+
+我在业余时间开发这个项目。每一个 Star 都表明我的工作受到重视，激励我继续前进！
+
+![Star](docs/images/star-github.gif)
+
+## 🎯 功能特性
+
+- 获取 Bilibili 视频信息并辅助下载
+- 基于 Tauri 构建的轻量级快速桌面应用
+- 亮色/暗色主题切换（基于 shadcn/ui）
+- 进度指示器和 Toast 通知
+- 多语言界面（English / 日本語 / Français / Español / 中文 / 한국어）
+
+## 💻 安装
+
+从[最新发布](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)下载。
+
+### macOS
+
+- **Apple Silicon**: `bilibili-downloader-gui_<version>_aarch64.dmg`
+- **Intel x64**: `bilibili-downloader-gui_<version>_x64.dmg`
+
+### Windows
+
+- **安装程序**（推荐）: `bilibili-downloader-gui_<version>_x64-setup.exe`
+- **MSI**（替代）: `bilibili-downloader-gui_<version>_x64_en-US.msi`
+
+> **注意**：macOS 构建未签名。首次启动时，右键点击应用 → 打开 → 打开，或运行：
+>
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+> ```
+
+## 🍎 macOS：未签名构建的首次启动
+
+如果您运行的是未经 Apple Developer 证书公证/签名的构建（例如 CI 构建产物），macOS Gatekeeper 可能会阻止该应用。您可以：
+
+- 右键点击应用 → 打开 → 打开，或
+- 移除隔离/扩展属性：
+
+```bash
+# 将路径替换为您实际安装的应用名称/位置
+xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
+# 或清除所有扩展属性
+xattr -c "/Applications/bilibili-downloader-gui.app"
+```
+
+如果您将应用安装在 /Applications 之外，请相应调整路径。
+
+---
+
+## 👨‍💻 开发者专区
+
+以下部分适用于想要构建、修改或为该项目做出贡献的开发者。
+
+## 📦 系统要求
+
+- Node.js 18+（推荐 LTS）
+- Rust（stable）
+- Tauri 构建所需的工具链（例如 macOS 上的 Xcode Command Line Tools）
+
+详见：[Tauri 官方文档](https://tauri.app/)
+
+## 💻 支持的操作系统
+
+- Windows 10/11
+- macOS 12+（Intel 和 Apple Silicon）
+
+## 🚀 快速开始（开发模式）
+
+1. 安装依赖
+   - `npm i`
+2. 启动 Tauri 开发服务器
+   - `npm run tauri dev`
+
+## 🔨 构建（可分发的二进制文件）
+
+- `npm run tauri build`
+  - 构建产物通常生成在 `src-tauri/target/release/`（因操作系统而异）。
+
+## 目录结构（Co-location）
+
+我们采用**基于功能的共置**文件夹策略。
+
+```txt
+src/
+  ├── app/                      # 应用程序配置
+  │   ├── providers/            # 全局 Provider (Theme, Listener)
+  │   └── store/                # Redux store 配置
+  ├── pages/                    # 路由级页面
+  │   ├── home/
+  │   │   └── index.tsx
+  │   ├── init/
+  │   │   └── index.tsx
+  │   └── error/
+  │       └── index.tsx
+  ├── features/                 # 功能模块
+  │   ├── video/
+  │   │   ├── ui/               # VideoForm1, VideoForm2, DownloadButton 等
+  │   │   ├── model/            # videoSlice, inputSlice, selectors
+  │   │   ├── hooks/            # useVideoInfo
+  │   │   ├── api/              # fetchVideoInfo, downloadVideo
+  │   │   ├── lib/              # utils, formSchema, constants
+  │   │   ├── types.ts
+  │   │   └── index.ts          # Public API
+  │   ├── init/
+  │   │   ├── model/            # initSlice
+  │   │   ├── hooks/            # useInit
+  │   │   └── index.ts
+  │   ├── settings/
+  │   │   ├── ui/               # SettingsDialog, LanguagesDropdown
+  │   │   ├── model/            # settingsSlice
+  │   │   ├── api/              # settingApi
+  │   │   └── index.ts
+  │   ├── user/
+  │   │   ├── model/            # userSlice
+  │   │   ├── hooks/            # useUser
+  │   │   ├── api/              # fetchUser
+  │   │   └── index.ts
+  │   └── preference/
+  │       ├── ui/               # ToggleThemeButton
+  │       └── index.ts
+  ├── shared/                   # 共享资源
+  │   ├── ui/                   # shadcn/ui 组件, AppBar, Progress
+  │   ├── animate-ui/           # 动画 UI 组件
+  │   ├── hooks/                # useIsMobile 等
+  │   ├── lib/                  # cn(), 工具函数
+  │   ├── progress/             # 进度状态管理
+  │   ├── downloadStatus/       # 下载状态管理
+  │   ├── queue/                # 队列状态
+  │   └── os/                   # OS 检测 API
+  ├── i18n/                     # 国际化
+  │   └── locales/              # 翻译文件
+  ├── styles/                   # 全局样式
+  └── assets/                   # 静态资源
+```
+
+### 目录职责
+
+#### `src/app/`
+
+根级别的应用程序配置。这是组装应用程序的地方：全局提供者和存储设置。
+
+#### `src/pages/`
+
+路由级页面。页面主要应该**组合**功能和共享 UI。将业务逻辑/状态保持在 `features/` 内。
+
+#### `src/features/`
+
+可复用的产品功能（面向用户的行为）。每个功能共置其 Redux 逻辑、API 调用和 UI。
+
+典型的功能文件夹包含：
+
+- `ui/` — 功能特定的 UI 组件
+- `model/` — Redux Toolkit slice、selectors
+- `hooks/` — 功能钩子
+- `api/` — 功能特定的 API 函数
+- `lib/` — 功能内部工具
+- `types.ts` — 功能本地类型
+- `index.ts` — 功能**Public API**（推荐的导入入口点）
+
+#### `src/shared/`
+
+在整个应用中使用的可复用、非领域特定的构建块。
+
+- `shared/ui/` — 应用范围的可复用 UI 原语（shadcn/ui、自定义组件）
+- `shared/animate-ui/` — 动画 UI 组件
+- `shared/lib/` — 通用工具（例如 `cn()`）
+- `shared/hooks/` — 可复用的 React hooks
+
+### 导入规则
+
+- `pages` 可以从 `features` 和 `shared` 导入
+- `features` 不能从 `pages` 导入
+- 避免直接从其他 `features` 导入。建议在 `pages` 中进行组合
+- 建议从功能的 `index.ts`（Public API）导入，而不是深层路径
+
+### 路径别名
+
+- `@/app/*`
+- `@/pages/*`
+- `@/features/*`
+- `@/shared/*`
+
+### 后端（Tauri / Rust）
+
+```txt
+src-tauri/src/
+  main.rs            ← 入口点（保持精简）
+  lib.rs             ← 应用根模块 / 命令定义
+  handlers/          ← 命令实现
+  models/            ← 数据结构（请求/响应等）
+  utils/             ← 工具函数
+```
+
+## ⚙️ 脚本
+
+- 开发: `npm run tauri dev`
+- 构建: `npm run tauri build`
+
+## 🛠️ 技术栈
+
+- 前端: React, Vite, TypeScript, Redux Toolkit, shadcn/ui, animate‑ui
+- 桌面: Tauri (Rust)
+
+## ❌ 错误代码
+
+返回的错误代码（在前端映射到 i18n）：
+
+- `ERR::COOKIE_MISSING` Cookie 缺失或无效
+- `ERR::QUALITY_NOT_FOUND` 请求的质量 ID 不可用
+- `ERR::DISK_FULL` 磁盘空间不足
+- `ERR::FILE_EXISTS` 文件冲突无法自动解决
+- `ERR::NETWORK::<detail>` 重试后网络失败
+- `ERR::MERGE_FAILED` ffmpeg 合并进程失败
+
+## 🔮 未来计划
+
+- [ ] 选择下载目标
+- [ ] 允许覆盖现有文件
+- [ ] 多项目队列下载
+- [ ] 下载历史记录保留
+- [ ] 单实例应用启动（防止多次并发启动）
+
+## 🌍 本地化（i18n）
+
+当前支持的语言：
+
+- English (en)
+- 日本語 (ja)
+- Français (fr)
+- Español (es)
+- 中文 (zh)
+- 한국어 (ko)
+
+欢迎贡献其他语言。如果您发现不自然或别扭的表达，请提交 Pull Request。
+
+## 🤝 贡献
+
+欢迎 Issue 和 PR。对于重大更改，请先在 Issue 中讨论。小的修复（文档、错别字、轻微 UI 调整）也非常感谢。
+
+## 📜 许可证
+
+MIT License — 详见 [LICENSE](./LICENSE)。
+
+## 🙏 致谢
+
+- Tauri 团队和社区
+- shadcn/ui、Radix UI、sonner 等开源项目
+
+---
+
+如果您觉得这个项目有用，请考虑给仓库点个 Star — 这真的能激励持续开发。


### PR DESCRIPTION
## Summary
Add multi-language README support to improve accessibility for non-English users. The app already supports 6 languages in the UI, so the documentation should match.

## Changes
- Add language selector navigation to README.md header
- Create README.ja.md (Japanese translation)
- Create README.zh.md (Chinese translation)
- Create README.ko.md (Korean translation)
- Create README.es.md (Spanish translation)
- Create README.fr.md (French translation)

## Test Plan
- [x] Verify all README files are properly formatted
- [x] Verify language selector links work correctly
- [x] Verify all translations are accurate and complete

---
🤖 Generated with [Claude Code](https://claude.ai/code)