### PR TITLE
perf: reduce CDN reconnect attempts from 5 to 2

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -38,4 +38,4 @@ pub const MIN_SPEED_THRESHOLD: u64 = 3 * 1024 * 1024; // 3MB/s
 /// When initial speed check fails (below MIN_SPEED_THRESHOLD), the system
 /// will reconnect up to this many times. After exceeding this limit,
 /// download continues even if slow to ensure completion.
-pub const MAX_RECONNECT_ATTEMPTS: u8 = 5;
+pub const MAX_RECONNECT_ATTEMPTS: u8 = 2;


### PR DESCRIPTION
## Summary
Reduce `MAX_RECONNECT_ATTEMPTS` from 5 to 2 to enable faster CDN fallback when encountering slow connections.

## Changes
- `src-tauri/src/constants.rs`: Changed `MAX_RECONNECT_ATTEMPTS` constant from `5` to `2`

## Rationale
- Each segment was retrying slow connections up to 5 times, which is excessive
- Backup CDNs typically number 2-3, so 2 attempts are sufficient to find a faster node
- Earlier fallback leads to faster overall download times

## Test Plan
- [x] Build the application: `cargo build --manifest-path src-tauri/Cargo.toml`
- [x] Download a video and observe CDN rotation in logs
- [x] Verify `[CDN] Segment X: rotating CDN #0 → #1` appears within 2 attempts for slow connections

🤖 Generated with [Claude Code](https://claude.ai/code)