### PR TITLE
docs: clean up README structure and remove emoji from section headers

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -31,7 +31,7 @@ Desarrollo esto como hobby. Sin estrellas, cerraré el proyecto 😄
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 Características
+## Características
 
 ### Descarga
 
@@ -52,7 +52,7 @@ Desarrollo esto como hobby. Sin estrellas, cerraré el proyecto 😄
 - **Detección automática de cookies de Firefox** - Descargas de alta calidad sin inicio de sesión manual
 - **Almacenamiento solo local** - Todos los datos se guardan solo en tu PC
 
-## 💻 Instalación
+## Instalación
 
 Descarga desde el [último lanzamiento](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest).
 
@@ -73,31 +73,17 @@ Descarga desde el [último lanzamiento](https://github.com/j4rviscmd/bilibili-do
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS: Primer inicio de compilaciones no firmadas
+## Contribuir
 
-Si usas una compilación que no está firmada/notarizada con un certificado de Apple Developer (por ejemplo, artefactos de CI), es posible que macOS Gatekeeper bloquee la aplicación. Puedes:
+Issues y PRs son bienvenidos.
 
-- Hacer clic derecho en la aplicación → Abrir → Abrir, o
-- Eliminar los atributos de cuarentena/extendidos:
+Las traducciones también son apreciadas — consulta [CONTRIBUTING.md](./CONTRIBUTING.md) para más detalles.
 
-```bash
-# Reemplaza la ruta con el nombre/ubicación real de tu aplicación instalada
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# o borra todos los atributos extendidos
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-Si instalaste la aplicación fuera de /Applications, ajusta la ruta en consecuencia.
-
-## 🤝 Contribuir
-
-Issues y PRs son bienvenidos. Las traducciones también son apreciadas — consulta [CONTRIBUTING.md](./CONTRIBUTING.md) para más detalles.
-
-## 📜 Licencia
-
-MIT License — consulta [LICENSE](./LICENSE) para más detalles.
-
-## 🙏 Agradecimientos
+## Agradecimientos
 
 - El equipo y la comunidad de Tauri
 - OSS como shadcn/ui, Radix UI, sonner
+
+## Licencia
+
+MIT License — consulta [LICENSE](./LICENSE) para más detalles.

--- a/README.fr.md
+++ b/README.fr.md
@@ -31,7 +31,7 @@ Je développe cela en tant que loisir. Sans étoiles, je fermerai le projet 😄
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 Fonctionnalités
+## Fonctionnalités
 
 ### Téléchargement
 
@@ -52,7 +52,7 @@ Je développe cela en tant que loisir. Sans étoiles, je fermerai le projet 😄
 - **Détection automatique des cookies Firefox** - Téléchargements haute qualité sans connexion manuelle
 - **Stockage local uniquement** - Toutes les données sont stockées uniquement sur votre PC
 
-## 💻 Installation
+## Installation
 
 Téléchargez depuis la [dernière version](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest).
 
@@ -73,31 +73,17 @@ Téléchargez depuis la [dernière version](https://github.com/j4rviscmd/bilibil
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS : Premier lancement des builds non signés
+## Contribuer
 
-Si vous utilisez un build qui n'est pas signé/notarié avec un certificat Apple Developer (par exemple, artefacts CI), macOS Gatekeeper peut bloquer l'application. Vous pouvez :
+Les Issues et PR sont les bienvenus.
 
-- Faire un clic droit sur l'application → Ouvrir → Ouvrir, ou
-- Supprimer les attributs de quarantaine/étendus :
+Les traductions sont également appréciées — consultez [CONTRIBUTING.md](./CONTRIBUTING.md) pour plus de détails.
 
-```bash
-# Remplacez le chemin par le nom/emplacement réel de votre application installée
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# ou effacez tous les attributs étendus
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-Si vous avez installé l'application en dehors de /Applications, ajustez le chemin en conséquence.
-
-## 🤝 Contribuer
-
-Les Issues et PR sont les bienvenus. Les traductions sont également appréciées — consultez [CONTRIBUTING.md](./CONTRIBUTING.md) pour plus de détails.
-
-## 📜 Licence
-
-MIT License — voir [LICENSE](./LICENSE) pour plus de détails.
-
-## 🙏 Remerciements
+## Remerciements
 
 - L'équipe et la communauté Tauri
 - OSS comme shadcn/ui, Radix UI, sonner
+
+## Licence
+
+MIT License — voir [LICENSE](./LICENSE) pour plus de détails.

--- a/README.ja.md
+++ b/README.ja.md
@@ -31,7 +31,7 @@
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 機能
+## 機能
 
 ### ダウンロード
 
@@ -52,7 +52,7 @@
 - **Firefox Cookie自動検出** - 手動ログイン作業なしで高画質ダウンロード可能
 - **ローカル完結** - すべてのデータはお使いのPCにのみ保存
 
-## 💻 インストール
+## インストール
 
 [最新リリース](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)からダウンロードしてください。
 
@@ -73,31 +73,17 @@
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS: 署名されていないビルドの初回起動
+## コントリビュート
 
-Apple Developer証明書で署名/公証されていないビルド（例: CIアーティファクト）を使用する場合、macOS Gatekeeperがアプリをブロックする可能性があります。以下のいずれかの方法で対処できます:
+IssueとPRを歓迎します。
 
-- アプリを右クリック → 開く → 開く を選択
-- 検疫属性/拡張属性を削除:
+翻訳の貢献も大歓迎です — 詳細は[CONTRIBUTING.md](./CONTRIBUTING.md)をご覧ください。
 
-```bash
-# パスは実際のインストール済みアプリ名/場所に置き換えてください
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# または、すべての拡張属性をクリア
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-/Applications以外にインストールした場合は、パスを適宜調整してください。
-
-## 🤝 コントリビュート
-
-IssueとPRを歓迎します。翻訳の貢献も大歓迎です — 詳細は[CONTRIBUTING.md](./CONTRIBUTING.md)をご覧ください。
-
-## 📜 ライセンス
-
-MIT License — 詳細は[LICENSE](./LICENSE)を参照してください。
-
-## 🙏 謝辞
+## 謝辞
 
 - Tauriチームとコミュニティ
 - shadcn/ui、Radix UI、sonnerなどのOSS
+
+## ライセンス
+
+MIT License — 詳細は[LICENSE](./LICENSE)を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -31,7 +31,7 @@
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 기능
+## 기능
 
 ### 다운로드
 
@@ -52,7 +52,7 @@
 - **Firefox 쿠키 자동 감지** - 수동 로그인 없이 고화질 다운로드 가능
 - **로컬 저장** - 모든 데이터는 사용자 PC에만 저장
 
-## 💻 설치
+## 설치
 
 [최신 릴리스](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)에서 다운로드하세요.
 
@@ -73,31 +73,17 @@
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS: 서명되지 않은 빌드의 첫 실행
+## 기여
 
-Apple Developer 인증서로 서명/공증되지 않은 빌드(예: CI 아티팩트)를 사용하는 경우 macOS Gatekeeper가 앱을 차단할 수 있습니다. 다음 방법 중 하나로 해결할 수 있습니다:
+Issue와 PR을 환영합니다.
 
-- 앱을 우클릭 → 열기 → 열기를 선택
-- 격리 속성/확장 속성 제거:
+번역 기여도 환영합니다 — 자세한 내용은 [CONTRIBUTING.md](./CONTRIBUTING.md)를 참조하세요.
 
-```bash
-# 경로를 실제 설치된 앱 이름/위치로 교체하세요
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# 또는 모든 확장 속성 지우기
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-/Applications 외부에 설치한 경우 경로를 적절히 조정하세요.
-
-## 🤝 기여
-
-Issue와 PR을 환영합니다. 번역 기여도 환영합니다 — 자세한 내용은 [CONTRIBUTING.md](./CONTRIBUTING.md)를 참조하세요.
-
-## 📜 라이선스
-
-MIT License — 자세한 내용은 [LICENSE](./LICENSE)를 참조하세요.
-
-## 🙏 감사의 말
+## 감사의 말
 
 - Tauri 팀과 커뮤니티
 - shadcn/ui, Radix UI, sonner 등 오픈소스 프로젝트
+
+## 라이선스
+
+MIT License — 자세한 내용은 [LICENSE](./LICENSE)를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I build this as a hobby. No stars, I'll shut it down 😄
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 Features
+## Features
 
 ### Download
 
@@ -52,7 +52,7 @@ I build this as a hobby. No stars, I'll shut it down 😄
 - **Firefox cookie auto-detection** - High-quality downloads without manual login
 - **Local-only storage** - All data stored only on your PC
 
-## 💻 Installation
+## Installation
 
 Download from the [latest release](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest).
 
@@ -73,31 +73,17 @@ Download from the [latest release](https://github.com/j4rviscmd/bilibili-downloa
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS: First Launch of Unsigned Builds
+## Contributing
 
-If you run a build that is not notarized/signed with an Apple Developer certificate (e.g., CI artifacts), macOS Gatekeeper may block the app. You can either:
+Issues and PRs are welcome.
 
-- Right-click the app → Open → Open, or
-- Remove the quarantine/extended attributes:
+Translations are also appreciated — see [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
 
-```bash
-# Replace the path with your actual installed app name/location
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# or clear all extended attributes
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-If you installed the app outside /Applications, adjust the path accordingly.
-
-## 🤝 Contributing
-
-Issues and PRs are welcome. Translations are also appreciated — see [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
-
-## 📜 License
-
-MIT License — see [LICENSE](./LICENSE) for details.
-
-## 🙏 Acknowledgements
+## Acknowledgements
 
 - The Tauri team and community
 - OSS such as shadcn/ui, Radix UI, sonner
+
+## License
+
+MIT License — see [LICENSE](./LICENSE) for details.

--- a/README.zh.md
+++ b/README.zh.md
@@ -31,7 +31,7 @@
 
 ![Star](docs/images/star-github.gif)
 
-## 🎯 功能特性
+## 功能特性
 
 ### 下载
 
@@ -52,7 +52,7 @@
 - **Firefox Cookie 自动检测** - 无需手动登录即可下载高清视频
 - **本地存储** - 所有数据仅保存在您的电脑上
 
-## 💻 安装
+## 安装
 
 从[最新发布](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)下载。
 
@@ -73,31 +73,17 @@
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
 > ```
 
-## 🍎 macOS: 未签名构建的首次启动
+## 贡献
 
-如果使用未经 Apple Developer 证书签名/公证的构建（例如 CI 构建产物），macOS Gatekeeper 可能会阻止应用。您可以：
+欢迎 Issue 和 PR。
 
-- 右键点击应用 → 打开 → 打开，或
-- 移除隔离属性/扩展属性：
+也欢迎翻译贡献 — 详情请参阅 [CONTRIBUTING.md](./CONTRIBUTING.md)。
 
-```bash
-# 将路径替换为您的实际安装应用名称/位置
-xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"
-# 或清除所有扩展属性
-xattr -c "/Applications/bilibili-downloader-gui.app"
-```
-
-如果安装到 /Applications 以外的位置，请相应调整路径。
-
-## 🤝 贡献
-
-欢迎 Issue 和 PR。也欢迎翻译贡献 — 详情请参阅 [CONTRIBUTING.md](./CONTRIBUTING.md)。
-
-## 📜 许可证
-
-MIT License — 详情请参阅 [LICENSE](./LICENSE)。
-
-## 🙏 致谢
+## 致谢
 
 - Tauri 团队和社区
 - shadcn/ui、Radix UI、sonner 等开源项目
+
+## 许可证
+
+MIT License — 详情请参阅 [LICENSE](./LICENSE)。


### PR DESCRIPTION
## Summary
Clean up README structure and remove emoji from section headers (keep star section emoji only).

## Changes
- Move License section to the bottom (after Acknowledgements)
- Remove duplicate "macOS: First Launch of Unsigned Builds" section (already covered in Installation)
- Add line breaks to Contributing section for better readability
- Remove emoji from section headers (Features, Installation, Contributing, Acknowledgements, License)

Applied to all 6 language versions (en, ja, zh, ko, es, fr).

## Test Plan
- [x] Verify README.md structure is correct
- [x] Verify all 6 language versions have consistent structure
- [x] Verify Star section still has emoji

---
🤖 Generated with [Claude Code](https://claude.ai/code)