### PR TITLE
docs: move warning below screenshots and update tagline for end-users

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Interfaz gráfica de descarga de videos de Bilibili para Windows y macOS.</strong></p>
-      <p>El frontend está construido con React + Vite; la aplicación de escritorio está impulsada por Tauri (Rust).</p>
+      <p>Sin configuración. Instala y comienza a descargar videos de inmediato.</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> Esta aplicación está destinada a uso educativo y personal. Respeta los términos de servicio y las leyes de derechos de autor. No descargues ni redistribuyas contenido sin permiso de los titulares de derechos.
-
 ![Imagen de la aplicación (búsqueda)](<public/app-image(searched)_en.png>)
 ![Imagen de la aplicación (fusionando)](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> Esta aplicación está destinada a uso educativo y personal. Respeta los términos de servicio y las leyes de derechos de autor. No descargues ni redistribuyas contenido sin permiso de los titulares de derechos.
 
 ## ⭐ Dale una estrella a este repositorio para mantenerme motivado
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Interface graphique de téléchargement de vidéos Bilibili pour Windows et macOS.</strong></p>
-      <p>Le frontend est construit avec React + Vite ; l'application de bureau est propulsée par Tauri (Rust).</p>
+      <p>Aucune configuration requise. Installez et commencez à télécharger des vidéos immédiatement.</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> Cette application est destinée à un usage éducatif et personnel. Respectez les conditions d'utilisation et les lois sur le droit d'auteur. Ne téléchargez ni ne redistribuez de contenu sans l'autorisation des détenteurs de droits.
-
 ![Image de l'application (recherche)](<public/app-image(searched)_en.png>)
 ![Image de l'application (fusion)](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> Cette application est destinée à un usage éducatif et personnel. Respectez les conditions d'utilisation et les lois sur le droit d'auteur. Ne téléchargez ni ne redistribuez de contenu sans l'autorisation des détenteurs de droits.
 
 ## ⭐ Mettez une étoile à ce dépôt pour me motiver
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Windows / macOS対応のBilibili動画ダウンローダーGUIアプリ</strong></p>
-      <p>フロントエンドはReact + Vite、デスクトップアプリはTauri（Rust）で構築されています。</p>
+      <p>設定不要。インストールするだけですぐ使える動画ダウンローダー</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> このアプリは教育目的および個人利用を目的としています。利用規約と著作権法を遵守してください。権利者の許可なくコンテンツをダウンロードまたは再配布しないでください。
-
 ![アプリ画像（検索）](<public/app-image(searched)_en.png>)
 ![アプリ画像（マージ中）](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> このアプリは教育目的および個人利用を目的としています。利用規約と著作権法を遵守してください。権利者の許可なくコンテンツをダウンロードまたは再配布しないでください。
 
 ## ⭐ このリポジトリにスターをお願いします
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Windows 및 macOS용 Bilibili 동영상 다운로더 GUI 애플리케이션</strong></p>
-      <p>프론트엔드는 React + Vite로 구축되었으며, 데스크톱 앱은 Tauri(Rust)로 구동됩니다.</p>
+      <p>설정 불필요. 설치 후 바로 동영상을 다운로드하세요.</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> 이 앱은 교육 및 개인 사용 목적으로 제공됩니다. 이용 약관과 저작권법을 준수해 주세요. 저작권자의 허가 없이 콘텐츠를 다운로드하거나 재배포하지 마세요.
-
 ![앱 이미지(검색)](<public/app-image(searched)_en.png>)
 ![앱 이미지(병합 중)](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> 이 앱은 교육 및 개인 사용 목적으로 제공됩니다. 이용 약관과 저작권법을 준수해 주세요. 저작권자의 허가 없이 콘텐츠를 다운로드하거나 재배포하지 마세요.
 
 ## ⭐ 이 저장소에 Star를 눌러주세요
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Windows and macOS Bilibili video downloader GUI.</strong></p>
-      <p>Frontend is built with React + Vite; the desktop app is powered by Tauri (Rust).</p>
+      <p>No configuration needed. Install and start downloading videos right away.</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> This app is intended for educational and personal use. Respect the terms of service and copyright laws. Do not download or redistribute content without permission from rights holders.
-
 ![App Image(searched)](<public/app-image(searched)_en.png>)
 ![App Image(merged)](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> This app is intended for educational and personal use. Respect the terms of service and copyright laws. Do not download or redistribute content without permission from rights holders.
 
 ## Star this repo to keep me motivated ⭐
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,7 @@
   <tr>
     <td width="80%">
       <p><strong>Windows 和 macOS Bilibili 视频下载器图形界面应用</strong></p>
-      <p>前端使用 React + Vite 构建，桌面应用由 Tauri (Rust) 驱动。</p>
+      <p>无需配置。安装后即可立即开始下载视频。</p>
     </td>
     <td width="20%">
       <img src="public/icon.png" alt="App Icon" width="128">
@@ -19,11 +19,11 @@
   </tr>
 </table>
 
-> [!WARNING]
-> 注意：本应用仅供教育和个人使用。请遵守服务条款和版权法。未经版权所有者许可，请勿下载或重新分发内容。
-
 ![应用截图（搜索）](<public/app-image(searched)_en.png>)
 ![应用截图（合并中）](<public/app-image(merging)_en.png>)
+
+> [!WARNING]
+> 注意：本应用仅供教育和个人使用。请遵守服务条款和版权法。未经版权所有者许可，请勿下载或重新分发内容。
 
 ## ⭐ 给这个仓库点个 Star 吧
 


### PR DESCRIPTION
## Summary
Move WARNING block below app screenshots and update tagline for end-users.

## Changes
- Move WARNING block below app screenshots (after images, before Star section)
- Replace technical stack description with user-friendly tagline:
  - EN: "No configuration needed. Install and start downloading videos right away."
  - JA: "設定不要。インストールするだけですぐ使える動画ダウンローダー"
  - Similar updates for zh, ko, es, fr

## Test Plan
- [x] Verify WARNING block appears after screenshots
- [x] Verify tagline is user-friendly (no technical jargon)
- [x] Verify all 6 language versions have consistent structure

---
🤖 Generated with [Claude Code](https://claude.ai/code)