### PR TITLE
docs(readme): add i18n support for shields badge labels

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-Compatible-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-Compatible-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square&label=Descargas)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=Último)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=Última%20actualización)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-Pris%20en%20charge-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-Pris%20en%20charge-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square&label=Téléchargements)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=Dernier)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=Dernière%20mise%20à%20jour)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-対応-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-対応-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square&label=ダウンロード)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=最新版)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=最終更新)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-지원-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-지원-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square&label=다운로드)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=최신)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=최종%20업데이트)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=Latest)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=Last%20Update)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,10 +2,13 @@
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri-24C8DB)
-![React + Vite + TS](https://img.shields.io/badge/React%20%2B%20Vite-TypeScript-2ea44f)
-![GitHub Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square)
+[![Windows](https://img.shields.io/badge/Windows-支持-0078D6?style=flat-square&logo=windows)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-支持-000000?style=flat-square&logo=apple)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=flat-square&label=下载)
+[![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=flat-square&label=最新版本)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
+[![CI](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml/badge.svg)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=flat-square&label=最后更新)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
 <table width="100%">
   <tr>


### PR DESCRIPTION
## Summary

Update README badges with localized labels for all 6 languages and optimize badge order for marketing/conversion.

## Changes

- Add i18n support for shields badge labels:
  - Japanese: 対応, 最新版, ダウンロード, 最終更新
  - Chinese: 支持, 最新版本, 下载, 最后更新
  - Korean: 지원, 최신, 다운로드, 최종 업데이트
  - Spanish: Compatible, Último, Descargas, Última actualización
  - French: Pris en charge, Dernier, Téléchargements, Dernière mise à jour

- Badge order optimized for marketing/conversion:
  `[Windows] [macOS] [Downloads] [Latest Release] [CI] [Last Commit] [License]`

- Add `Last Commit` badge showing last update timestamp

## Test Plan

- [x] Verify all 6 README files display correct localized badges
- [x] Verify badge order matches marketing optimization
- [x] Verify all badge links work correctly

---
🤖 Generated with [Claude Code](https://claude.ai/code)