### PR TITLE
feat(docs): add subtitle and bangumi feature cards to features section

### DIFF
--- a/docs/src/components/sections/Features.astro
+++ b/docs/src/components/sections/Features.astro
@@ -14,21 +14,23 @@ const lang = getLangFromUrl(url);
 const t = useTranslations(lang);
 
 /**
- * Feature keys mapped to their emoji icons.
+ * Feature configuration with icon and coming-soon status.
  */
-const featureIcons: Record<string, string> = {
-  download: "📥",
-  quality: "🎬",
-  cdn: "⚡",
-  batch: "📦",
-};
+const featureConfig = {
+  download: { icon: "📥" },
+  quality: { icon: "🎬" },
+  subtitle: { icon: "💬" },
+  cdn: { icon: "⚡" },
+  batch: { icon: "📦" },
+  bangumi: { icon: "📺", comingSoon: true },
+} as const;
 
-const featureKeys = ["download", "quality", "cdn", "batch"] as const;
-const features = featureKeys.map((key) => ({
+const features = Object.entries(featureConfig).map(([key, config]) => ({
   key,
-  icon: featureIcons[key],
+  icon: config.icon,
   title: t(`features.list.${key}`),
   description: t(`features.descriptions.${key}`),
+  comingSoon: config.comingSoon,
 }));
 ---
 

--- a/docs/src/components/sections/FeaturesSection.tsx
+++ b/docs/src/components/sections/FeaturesSection.tsx
@@ -15,6 +15,8 @@ interface Feature {
   title: string;
   /** Detailed description shown on hover */
   description: string;
+  /** Shows "Coming Soon" badge when true */
+  comingSoon?: boolean;
 }
 
 /**
@@ -51,6 +53,7 @@ export function FeaturesSection({
             title={feature.title}
             description={feature.description}
             hoverHint={hoverHint}
+            comingSoon={feature.comingSoon}
           />
         ))}
       </div>

--- a/docs/src/components/ui/FeatureCard.tsx
+++ b/docs/src/components/ui/FeatureCard.tsx
@@ -19,6 +19,19 @@ interface FeatureCardProps {
   description: string;
   /** Hint text shown below title (defaults to "Hover for details") */
   hoverHint?: string;
+  /** Shows "Coming Soon" badge when true */
+  comingSoon?: boolean;
+}
+
+/**
+ * Badge component for "Coming Soon" indicator.
+ */
+function ComingSoonBadge() {
+  return (
+    <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900 dark:text-amber-300">
+      Coming Soon
+    </span>
+  );
 }
 
 /**
@@ -33,20 +46,27 @@ export function FeatureCard({
   title,
   description,
   hoverHint = "Hover for details",
+  comingSoon = false,
 }: FeatureCardProps): React.ReactElement {
   return (
     <HoverCard openDelay={200} closeDelay={100}>
       <HoverCardTrigger asChild>
         <div className="cursor-pointer rounded-lg border bg-card p-6 text-center text-card-foreground shadow-sm transition-all hover:border-primary/50 hover:shadow-md">
           <div className="text-4xl">{icon}</div>
-          <h3 className="mt-4 font-semibold">{title}</h3>
+          <h3 className="mt-4 font-semibold">
+            {title}
+            {comingSoon && <ComingSoonBadge />}
+          </h3>
           <p className="mt-2 text-xs text-muted-foreground">{hoverHint}</p>
         </div>
       </HoverCardTrigger>
       <HoverCardContent className="w-72" sideOffset={8}>
         <div className="flex justify-between gap-4">
           <div className="space-y-1">
-            <h4 className="text-sm font-semibold">{title}</h4>
+            <h4 className="text-sm font-semibold">
+              {title}
+              {comingSoon && <ComingSoonBadge />}
+            </h4>
             <p className="text-sm text-muted-foreground">{description}</p>
           </div>
           <span className="shrink-0 text-2xl">{icon}</span>

--- a/docs/src/i18n/ui.ts
+++ b/docs/src/i18n/ui.ts
@@ -140,17 +140,23 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "Video & Audio Download",
         quality: "Multiple Quality Options",
+        subtitle: "Subtitle Download",
         cdn: "Fast & Stable Downloads",
         batch: "Batch Download",
+        bangumi: "Anime & Drama Support",
       },
       descriptions: {
         download:
           "Save your favorite videos and music from Bilibili to watch offline anytime, anywhere.",
         quality:
           "Choose from 360p to 4K quality. Pick the best quality for your device and internet speed.",
+        subtitle:
+          "Download subtitles in up to 15 languages. Choose soft subtitles as separate files or hard-burn them into the video.",
         cdn: "Automatically selects the fastest server for you. No more waiting on slow downloads.",
         batch:
           "Download multiple videos at once. Just paste multiple links and let the app do the rest.",
+        bangumi:
+          "Download official Bilibili content including anime, dramas, and variety shows.",
       },
     },
     download: {
@@ -181,17 +187,23 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "動画・音声ダウンロード",
         quality: "複数の画質オプション",
+        subtitle: "字幕ダウンロード",
         cdn: "高速・安定ダウンロード",
         batch: "一括ダウンロード",
+        bangumi: "アニメ・ドラマ対応",
       },
       descriptions: {
         download:
           "お気に入りの動画や音楽をBilibiliから保存して、いつでもどこでもオフラインで視聴できます。",
         quality:
           "360pから4Kまで選べる画質。端末やインターネット速度に合わせて最適な画質を選べます。",
+        subtitle:
+          "最大15言語の字幕をダウンロード。字幕別ファイル（soft）または動画埋め込み（hard）を選択可能。",
         cdn: "最も高速なサーバーを自動で選択。遅いダウンロードで待たされるストレスから解放されます。",
         batch:
           "複数の動画をまとめてダウンロード。リンクを複数貼り付けるだけで、あとはアプリにおまかせ。",
+        bangumi:
+          "Bilibiliの公式コンテンツ（アニメ、ドラマ、バラエティ番組など）をダウンロード。",
       },
     },
     download: {
@@ -222,14 +234,19 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "视频和音频下载",
         quality: "多种画质选项",
+        subtitle: "字幕下载",
         cdn: "高速稳定下载",
         batch: "批量下载",
+        bangumi: "番剧支持",
       },
       descriptions: {
         download: "从Bilibili保存您喜爱的视频和音乐，随时随地离线观看。",
         quality: "从360p到4K画质任您选择。根据您的设备和网络速度选择最佳画质。",
+        subtitle:
+          "支持最多15种语言的字幕下载。可选择软字幕（独立文件）或硬字幕（嵌入视频）。",
         cdn: "自动选择最快的下载服务器。告别漫长的等待。",
         batch: "批量下载多个视频。只需粘贴多个链接，剩下的交给应用即可。",
+        bangumi: "下载Bilibili番剧，包括动漫、电视剧和综艺等官方内容。",
       },
     },
     download: {
@@ -260,17 +277,23 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "비디오 및 오디오 다운로드",
         quality: "다양한 화질 옵션",
+        subtitle: "자막 다운로드",
         cdn: "빠르고 안정적인 다운로드",
         batch: "일괄 다운로드",
+        bangumi: "애니메이션・드라마 지원",
       },
       descriptions: {
         download:
           "Bilibili에서 좋아하는 비디오와 음악을 저장하여 언제 어디서나 오프라인으로 시청하세요.",
         quality:
           "360p부터 4K까지 선택 가능. 기기와 인터넷 속도에 맞는 최적의 화질을 선택하세요.",
+        subtitle:
+          "최대 15개 언어 자막을 다운로드하세요. 소프트 자막(별도 파일) 또는 하드 자막(비디오 내장) 선택 가능.",
         cdn: "가장 빠른 서버를 자동으로 선택해 드립니다. 느린 다운로드로 기다릴 필요가 없습니다.",
         batch:
           "여러 비디오를 한 번에 다운로드하세요. 여러 링크만 붙여넣으면 나머지는 앱이 알아서 처리합니다.",
+        bangumi:
+          "Bilibili 공식 콘텐츠(애니메이션, 드라마, 예능 프로그램 등)를 다운로드하세요.",
       },
     },
     download: {
@@ -301,17 +324,23 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "Descarga de video y audio",
         quality: "Múltiples opciones de calidad",
+        subtitle: "Descarga de subtítulos",
         cdn: "Descargas rápidas y estables",
         batch: "Descarga por lotes",
+        bangumi: "Soporte de anime y dramas",
       },
       descriptions: {
         download:
           "Guarda tus videos y música favoritos de Bilibili para verlos sin conexión en cualquier momento y lugar.",
         quality:
           "Elige entre calidad de 360p a 4K. Selecciona la mejor calidad para tu dispositivo y velocidad de internet.",
+        subtitle:
+          "Descarga subtítulos en hasta 15 idiomas. Elige entre subtítulos suaves (archivos separados) o duros (incrustados en el video).",
         cdn: "Selecciona automáticamente el servidor más rápido para ti. Olvídate de las descargas lentas.",
         batch:
           "Descarga múltiples videos a la vez. Solo pega varios enlaces y deja que la aplicación haga el resto.",
+        bangumi:
+          "Descarga contenido oficial de Bilibili, incluyendo anime, dramas y programas de variedades.",
       },
     },
     download: {
@@ -342,17 +371,23 @@ const translations: Record<Lang, Record<string, unknown>> = {
       list: {
         download: "Téléchargement vidéo et audio",
         quality: "Plusieurs options de qualité",
+        subtitle: "Téléchargement de sous-titres",
         cdn: "Téléchargements rapides et stables",
         batch: "Téléchargement par lots",
+        bangumi: "Support anime et dramas",
       },
       descriptions: {
         download:
           "Enregistrez vos vidéos et musiques préférées de Bilibili pour les regarder hors ligne quand vous voulez.",
         quality:
           "Choisissez parmi des qualités de 360p à 4K. Sélectionnez la meilleure qualité pour votre appareil et votre connexion.",
+        subtitle:
+          "Téléchargez des sous-titres dans jusqu'à 15 langues. Choisissez entre sous-titres soft (fichiers séparés) ou hard (incrustés dans la vidéo).",
         cdn: "Sélectionne automatiquement le serveur le plus rapide pour vous. Finis les téléchargements lents.",
         batch:
           "Téléchargez plusieurs vidéos à la fois. Collez simplement plusieurs liens et laissez l'application faire le reste.",
+        bangumi:
+          "Téléchargez du contenu officiel Bilibili, y compris anime, dramas et émissions de variétés.",
       },
     },
     download: {


### PR DESCRIPTION
## Summary
Add subtitle download and bangumi (anime/drama) support feature cards to the GitHub Pages features section.

## Changes
- Add subtitle download feature card with soft/hard mode support and up to 15 languages
- Add bangumi (anime/drama) support card with "Coming Soon" badge
- Implement reusable `ComingSoonBadge` component
- Add `comingSoon` property to Feature interface and FeatureCard component
- Refactor feature configuration into single `featureConfig` object for better maintainability
- Add translations for 6 languages (en, ja, zh, ko, es, fr)

## Test Plan
- [x] Verify docs site builds successfully: `cd docs && npm run build`
- [x] Verify features section displays 6 cards correctly
- [x] Verify "Coming Soon" badge appears on bangumi card
- [x] Verify hover cards show correct descriptions for all languages

---
🤖 Generated with [Claude Code](https://claude.ai/code)