### PR TITLE
feat: add specific error messages for unsupported Bilibili URL patterns

### DIFF
--- a/src/features/video/lib/formSchema.ts
+++ b/src/features/video/lib/formSchema.ts
@@ -3,11 +3,78 @@ import type { TFunction } from 'i18next'
 import z from 'zod'
 
 /**
+ * Detects unsupported Bilibili URL patterns and returns a specific error key.
+ *
+ * This function checks for known unsupported URL patterns and returns
+ * a specific translation key for better UX. Returns null if the pattern
+ * is not recognized as a known unsupported type.
+ *
+ * @param hostname - The URL hostname (e.g., "space.bilibili.com")
+ * @param pathname - The URL pathname (e.g., "/bangumi/media/md123")
+ * @param t - The translation function
+ * @returns A specific error message or null if not a known pattern
+ */
+const getUnsupportedUrlError = (
+  hostname: string,
+  pathname: string,
+  t: TFunction,
+): string | null => {
+  // Short URL service (b23.tv)
+  if (/^b23\.tv$/i.test(hostname)) {
+    return t('validation.video.url.short_url')
+  }
+
+  // User space / channel pages
+  if (/^space\.bilibili\.com$/i.test(hostname)) {
+    return t('validation.video.url.space')
+  }
+
+  // Member center
+  if (/^member\.bilibili\.com$/i.test(hostname)) {
+    return t('validation.video.url.member')
+  }
+
+  // Live streaming
+  if (/^live\.bilibili\.com$/i.test(hostname)) {
+    return t('validation.video.url.live')
+  }
+
+  // Bangumi list/media page (not episode page)
+  if (/^\/bangumi\/media\//i.test(pathname)) {
+    return t('validation.video.url.bangumi_list')
+  }
+
+  // Paid courses (cheese)
+  if (/^\/cheese\//i.test(pathname)) {
+    return t('validation.video.url.cheese')
+  }
+
+  // Audio / music (au.bilibili.com or /audio/)
+  if (/^au\.bilibili\.com$/i.test(hostname) || /^\/audio\//i.test(pathname)) {
+    return t('validation.video.url.audio')
+  }
+
+  // Article / read
+  if (/^\/read\//i.test(pathname)) {
+    return t('validation.video.url.article')
+  }
+
+  return null
+}
+
+/**
  * Regex pattern for invalid filename characters.
  *
  * Defaults to Windows superset, refined by OS detection.
+ * Initialized asynchronously by `initInvalidPattern()`.
  */
 let invalidCharsPattern: RegExp = /[\\/:*?"<>|]/ // default (Windows superset)
+
+/**
+ * Flag indicating whether OS-specific pattern initialization has occurred.
+ *
+ * Set to `true` after the first call to `initInvalidPattern()`.
+ */
 let initialized = false
 
 /**
@@ -68,8 +135,19 @@ export const buildVideoFormSchema1 = (t: TFunction) =>
       .superRefine((value, ctx) => {
         try {
           const { hostname, pathname } = new URL(value)
+
+          // Check for known unsupported patterns first (better UX)
+          const unsupportedError = getUnsupportedUrlError(hostname, pathname, t)
+          if (unsupportedError) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: unsupportedError,
+            })
+            return
+          }
+
           // bilibili.com 直下のみ許可（必要に応じてサブドメインも許可可能）
-          const ok = /^www.bilibili\.com$/i.test(hostname)
+          const ok = /^www\.bilibili\.com$/i.test(hostname)
           if (!ok) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
@@ -121,10 +199,10 @@ export const buildVideoFormSchema2 = (t: TFunction) =>
       .nonempty({ message: t('validation.video.title.required') })
       .superRefine((val, ctx) => {
         const pattern = getPatternSync()
+        const isWindows = invalidCharsPattern.source.includes(':*?"<>|')
+        const osChars = isWindows ? '\\ / : * ? " < > |' : '/'
+
         if (pattern.test(val) || /\0/.test(val)) {
-          const osChars = invalidCharsPattern.source.includes(':*?"<>|')
-            ? '\\ / : * ? " < > |' // windows
-            : '/'
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: t('validation.video.title.invalid_chars', {
@@ -132,14 +210,11 @@ export const buildVideoFormSchema2 = (t: TFunction) =>
             }),
           })
         }
-        if (
-          invalidCharsPattern.source.includes(':*?"<>|') &&
-          /[.\s]$/.test(val)
-        ) {
+        if (isWindows && /[.\s]$/.test(val)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: t('validation.video.title.invalid_chars', {
-              chars: '\\ / : * ? " < > |',
+              chars: osChars,
             }),
           })
         }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -259,7 +259,15 @@
         "max": "URL must be at most 1000 characters.",
         "invalid": "Please enter a valid URL.",
         "domain": "Only bilibili.com URLs are allowed.",
-        "format": "URL must be a video (/video/{id}) or bangumi (/bangumi/play/ep{id}) URL."
+        "format": "URL must be a video (/video/{id}) or bangumi (/bangumi/play/ep{id}) URL.",
+        "short_url": "Short URLs (b23.tv) are not supported. Please use the full video URL.",
+        "space": "User space URLs are not supported. Please use a video URL.",
+        "member": "Member center URLs are not supported. Please use a video URL.",
+        "live": "Live streams are not supported.",
+        "bangumi_list": "This is a bangumi list page. Please use an episode URL (/bangumi/play/ep{id}).",
+        "cheese": "Paid courses are not supported.",
+        "audio": "Audio/music content is not supported. Please use a video URL.",
+        "article": "Articles are not supported. Please use a video URL."
       },
       "title": {
         "min": "Title must be at least 2 characters.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -254,7 +254,15 @@
         "max": "La URL debe tener como máximo 1000 caracteres.",
         "invalid": "Introduce una URL válida.",
         "domain": "Solo se permiten URL de bilibili.com.",
-        "format": "La URL debe ser de video (/video/{id}) o bangumi (/bangumi/play/ep{id})."
+        "format": "La URL debe ser de video (/video/{id}) o bangumi (/bangumi/play/ep{id}).",
+        "short_url": "Las URL cortas (b23.tv) no son compatibles. Por favor, usa la URL completa del video.",
+        "space": "Las URL del espacio de usuario no son compatibles. Por favor, usa una URL de video.",
+        "member": "Las URL del centro de miembros no son compatibles. Por favor, usa una URL de video.",
+        "live": "Las transmisiones en vivo no son compatibles.",
+        "bangumi_list": "Esta es una página de lista de bangumi. Por favor, usa una URL de episodio (/bangumi/play/ep{id}).",
+        "cheese": "Los cursos de pago no son compatibles.",
+        "audio": "El contenido de audio/música no es compatible. Por favor, usa una URL de video.",
+        "article": "Los artículos no son compatibles. Por favor, usa una URL de video."
       },
       "title": {
         "min": "El título debe tener al menos 2 caracteres.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -254,7 +254,15 @@
         "max": "L'URL doit contenir au maximum 1000 caractères.",
         "invalid": "Veuillez saisir une URL valide.",
         "domain": "Seules les URL de bilibili.com sont autorisées.",
-        "format": "L'URL doit être un format vidéo (/video/{id}) ou bangumi (/bangumi/play/ep{id})."
+        "format": "L'URL doit être un format vidéo (/video/{id}) ou bangumi (/bangumi/play/ep{id}).",
+        "short_url": "Les URL courtes (b23.tv) ne sont pas prises en charge. Veuillez utiliser l'URL complète de la vidéo.",
+        "space": "Les URL d'espace utilisateur ne sont pas prises en charge. Veuillez utiliser une URL de vidéo.",
+        "member": "Les URL du centre des membres ne sont pas prises en charge. Veuillez utiliser une URL de vidéo.",
+        "live": "Les diffusions en direct ne sont pas prises en charge.",
+        "bangumi_list": "Ceci est une page de liste bangumi. Veuillez utiliser une URL d'épisode (/bangumi/play/ep{id}).",
+        "cheese": "Les cours payants ne sont pas pris en charge.",
+        "audio": "Le contenu audio/musique n'est pas pris en charge. Veuillez utiliser une URL de vidéo.",
+        "article": "Les articles ne sont pas pris en charge. Veuillez utiliser une URL de vidéo."
       },
       "title": {
         "min": "Le titre doit contenir au moins 2 caractères.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -259,7 +259,15 @@
         "max": "URLは1000文字以内で入力してください。",
         "invalid": "有効なURLを入力してください。",
         "domain": "bilibili.com のURLのみ有効です。",
-        "format": "URLは動画 (/video/{id}) またはバンガミ (/bangumi/play/ep{id}) の形式である必要があります。"
+        "format": "URLは動画 (/video/{id}) またはバンガミ (/bangumi/play/ep{id}) の形式である必要があります。",
+        "short_url": "短縮URL (b23.tv) は非対応です。完全な動画URLを入力してください。",
+        "space": "ユーザースペースのURLは非対応です。動画URLを入力してください。",
+        "member": "メンバーセンターのURLは非対応です。動画URLを入力してください。",
+        "live": "ライブ配信は非対応です。",
+        "bangumi_list": "これはバンガミ一覧ページです。エピソードURL (/bangumi/play/ep{id}) を入力してください。",
+        "cheese": "有料コースは非対応です。",
+        "audio": "音声・音楽コンテンツは非対応です。動画URLを入力してください。",
+        "article": "記事は非対応です。動画URLを入力してください。"
       },
       "title": {
         "min": "タイトルは2文字以上で入力してください。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -254,7 +254,15 @@
         "max": "URL은 최대 1000자여야 합니다.",
         "invalid": "유효한 URL을 입력하세요.",
         "domain": "bilibili.com URL만 허용됩니다.",
-        "format": "URL은 비디오 (/video/{id}) 또는 방구미 (/bangumi/play/ep{id}) 형식이어야 합니다."
+        "format": "URL은 비디오 (/video/{id}) 또는 방구미 (/bangumi/play/ep{id}) 형식이어야 합니다.",
+        "short_url": "단축 URL (b23.tv)은 지원되지 않습니다. 전체 비디오 URL을 입력하세요.",
+        "space": "사용자 공간 URL은 지원되지 않습니다. 비디오 URL을 입력하세요.",
+        "member": "회원 센터 URL은 지원되지 않습니다. 비디오 URL을 입력하세요.",
+        "live": "라이브 스트리밍은 지원되지 않습니다.",
+        "bangumi_list": "이것은 방구미 목록 페이지입니다. 에피소드 URL (/bangumi/play/ep{id})을 입력하세요.",
+        "cheese": "유료 강좌는 지원되지 않습니다.",
+        "audio": "오디오/음악 콘텐츠는 지원되지 않습니다. 비디오 URL을 입력하세요.",
+        "article": "칼럼 글은 지원되지 않습니다. 비디오 URL을 입력하세요."
       },
       "title": {
         "min": "제목은 최소 2자여야 합니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -254,7 +254,15 @@
         "max": "链接长度不能超过 1000 个字符。",
         "invalid": "请输入有效的链接。",
         "domain": "仅允许 bilibili.com 的链接。",
-        "format": "链接必须是视频 (/video/{id}) 或番剧 (/bangumi/play/ep{id}) 格式。"
+        "format": "链接必须是视频 (/video/{id}) 或番剧 (/bangumi/play/ep{id}) 格式。",
+        "short_url": "不支持短链接 (b23.tv)。请使用完整的视频链接。",
+        "space": "不支持用户空间链接。请使用视频链接。",
+        "member": "不支持会员中心链接。请使用视频链接。",
+        "live": "不支持直播链接。",
+        "bangumi_list": "这是番剧列表页面。请使用剧集链接 (/bangumi/play/ep{id})。",
+        "cheese": "不支持付费课程。",
+        "audio": "不支持音频/音乐内容。请使用视频链接。",
+        "article": "不支持专栏文章。请使用视频链接。"
       },
       "title": {
         "min": "标题至少需要 2 个字符。",


### PR DESCRIPTION
## Summary
Add specific error messages for unsupported Bilibili URL patterns to improve user experience.

## Changes
- Add `getUnsupportedUrlError` helper function to detect unsupported URL patterns
- Add 8 new translation keys across all 6 languages (en, ja, zh, ko, es, fr):
  - `short_url` - Short URLs (b23.tv)
  - `space` - User space URLs (space.bilibili.com)
  - `member` - Member center URLs (member.bilibili.com)
  - `live` - Live streams (live.bilibili.com)
  - `bangumi_list` - Bangumi list pages (/bangumi/media/)
  - `cheese` - Paid courses (/cheese/)
  - `audio` - Audio/music content (/audio/)
  - `article` - Articles (/read/)
- Minor refactoring in `buildVideoFormSchema2` to eliminate redundant computations

## Test Plan
- Test each unsupported URL pattern to verify specific error messages are displayed
- Verify all 6 language files have consistent translations
- Confirm normal video and bangumi URLs still work correctly

---
🤖 Generated with [Claude Code](https://claude.ai/code)