### PR TITLE
fix: support regular video download with WBI signature and durl format

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -322,11 +322,10 @@ name = "bilibili-downloader-gui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
  "chrono",
  "futures",
- "hmac",
  "libc",
+ "md5",
  "octocrab",
  "once_cell",
  "rand 0.8.5",
@@ -335,7 +334,6 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "serde_json",
- "sha2",
  "tar",
  "tauri",
  "tauri-build",
@@ -2412,6 +2410,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,12 +38,10 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 tauri-plugin-process = "2"
 futures = "0.3.31"
 once_cell = "1.18.0"
-base64 = "0.22.1"
 libc = "0.2"
 rand = "0.8"
 chrono = "0.4"
-sha2 = "0.10"
-hmac = "0.12"
+md5 = "0.7"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -112,48 +112,6 @@ fn check_http_status(status: reqwest::StatusCode) -> Result<(), String> {
     }
 }
 
-/// Downloads a Bilibili video with the specified quality settings.
-///
-/// This function orchestrates the entire download process:
-/// 1. Output path determination with auto-rename handling
-/// 2. Cookie presence validation
-/// 3. Video details and stream URL fetching
-/// 4. Pre-download disk space check
-/// 5. Parallel audio/video stream download with retry logic
-/// 6. Stream merging via ffmpeg
-///
-/// Sends progress updates to the frontend throughout the process.
-///
-/// # Parallel Download Strategy
-///
-/// Audio and video streams are downloaded concurrently to minimize total download time.
-/// A semaphore limits concurrency to protect system resources.
-///
-/// # Arguments
-///
-/// * `app` - Tauri application handle
-/// * `bvid` - Bilibili video ID (BV identifier)
-/// * `cid` - Content ID for the specific video part
-/// * `filename` - Output filename (extension optional, .mp4 added if missing)
-/// * `quality` - Video quality ID (falls back to highest quality if unavailable)
-/// * `audio_quality` - Audio quality ID (falls back to highest quality if unavailable)
-/// * `download_id` - Unique identifier to track this download
-/// * `_parent_id` - Parent download ID for multi-part videos (currently unused)
-///
-/// # Returns
-///
-/// On success, returns the output file path as `String`.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - Settings or output path cannot be obtained
-/// - Cookies are missing (`ERR::COOKIE_MISSING`)
-/// - Selected quality is unavailable (`ERR::QUALITY_NOT_FOUND`)
-/// - Insufficient disk space (`ERR::DISK_FULL`)
-/// - Download fails after retry attempts (`ERR::NETWORK`)
-/// - ffmpeg merge fails (`ERR::MERGE_FAILED`)
-///
 /// Downloads a bangumi episode using durl format (MP4 direct URL).
 /// This is used when DASH format is not available for bangumi content.
 ///
@@ -245,6 +203,37 @@ async fn download_bangumi_durl(
 
     Ok(output_path_str)
 }
+
+/// Downloads a Bilibili video with the specified quality settings.
+///
+/// This function orchestrates the entire download process:
+/// 1. Output path determination with auto-rename handling
+/// 2. Cookie presence validation
+/// 3. Video details and stream URL fetching
+/// 4. Pre-download disk space check
+/// 5. Parallel audio/video stream download with retry logic
+/// 6. Stream merging via ffmpeg (DASH) or direct save (durl)
+///
+/// Sends progress updates to the frontend throughout the process.
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle
+/// * `options` - Download options including bvid, cid, quality, filename, etc.
+///
+/// # Returns
+///
+/// On success, returns the output file path as `String`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Settings or output path cannot be obtained
+/// - Cookies are missing (`ERR::COOKIE_MISSING`)
+/// - Selected quality is unavailable (`ERR::QUALITY_NOT_FOUND`)
+/// - Insufficient disk space (`ERR::DISK_FULL`)
+/// - Download fails after retry attempts (`ERR::NETWORK`)
+/// - ffmpeg merge fails (`ERR::MERGE_FAILED`)
 /// - Download is cancelled (`ERR::CANCELLED`)
 pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Result<String, String> {
     use crate::handlers::concurrency::DOWNLOAD_CANCEL_REGISTRY;
@@ -285,15 +274,74 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         fetch_video_details(&cookies, &options.bvid, options.cid).await?
     };
 
-    let dash_data = details
-        .data
-        .ok_or_else(|| {
-            format!(
-                "XPlayerApi error (code {}): {} - no data field",
-                details.code, details.message
-            )
-        })?
-        .dash;
+    let data = details.data.ok_or_else(|| {
+        format!(
+            "XPlayerApi error (code {}): {} - no data field",
+            details.code, details.message
+        )
+    })?;
+
+    // 通常動画 durl 形式（音声が映像に埋め込まれているMP4）
+    if data.dash.is_none() {
+        if let Some(durl_segments) = &data.durl {
+            let durl_segment = durl_segments.first().ok_or("ERR::QUALITY_NOT_FOUND")?;
+            let video_url = durl_segment.url.clone();
+            let backup_urls = durl_segment
+                .backup_url
+                .as_ref()
+                .map(|urls| urls.iter().map(|s| s.to_string()).collect());
+
+            if let Some(vs) = head_content_length(&video_url, Some(&cookie_header)).await {
+                ensure_free_space(&output_path, vs + 5 * 1024 * 1024)?;
+            }
+
+            retry_download(|| {
+                download_url(
+                    app,
+                    video_url.clone(),
+                    backup_urls.clone(),
+                    output_path.to_path_buf(),
+                    Some(cookie_header.to_string()),
+                    true,
+                    Some(options.download_id.clone()),
+                    Some("video"),
+                    true,
+                )
+            })
+            .await?;
+
+            let output_path_str = output_path.to_string_lossy().to_string();
+            let actual_file_size = tokio::fs::metadata(&output_path)
+                .await
+                .ok()
+                .map(|m| m.len());
+            let app = app.clone();
+            let bvid = options.bvid.clone();
+            let filename = options.filename.clone();
+            let quality = options.quality;
+            let thumbnail_url = options.thumbnail_url.clone();
+            let page = options.page;
+            tokio::spawn(async move {
+                if let Err(e) = save_to_history(
+                    &app,
+                    &bvid,
+                    quality,
+                    actual_file_size,
+                    &filename,
+                    thumbnail_url,
+                    page,
+                )
+                .await
+                {
+                    eprintln!("Warning: Failed to save to history for {bvid}: {e}");
+                }
+            });
+            return Ok(output_path_str);
+        }
+        return Err("ERR::NO_STREAM".to_string());
+    }
+
+    let dash_data = data.dash.unwrap();
 
     // 選択品質が存在しなければフォールバック (先頭 = 最も高品質)
     let (video_url, video_backup_urls) = select_stream_url(&dash_data.video, options.quality)?;
@@ -863,6 +911,7 @@ fn convert_qualities(video: &[XPlayerApiResponseVideo]) -> Vec<Quality> {
         .map(|(id, v)| Quality {
             id,
             codecid: v.codecid,
+            quality: quality_to_string(&id),
         })
         .collect()
 }
@@ -940,7 +989,16 @@ async fn fetch_video_details(
     cid: i64,
 ) -> Result<XPlayerApiResponse, String> {
     let client = build_client()?;
-    let mixin_key = crate::utils::wbi::fetch_mixin_key(&client).await?;
+    let cookie_header = build_cookie_header(cookies);
+    let mixin_key = crate::utils::wbi::fetch_mixin_key(
+        &client,
+        if cookie_header.is_empty() {
+            None
+        } else {
+            Some(&cookie_header)
+        },
+    )
+    .await?;
 
     let mut params = BTreeMap::from([
         ("bvid".to_string(), bvid.to_string()),
@@ -951,22 +1009,24 @@ async fn fetch_video_details(
         ("fourk".to_string(), "1".to_string()),
     ]);
 
-    let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key)?;
+    let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
+
+    let query: Vec<(&str, String)> = params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .chain([
+            ("w_rid", signature.w_rid.clone()),
+            ("wts", signature.wts.clone()),
+        ])
+        .collect();
 
     let response = client
         .get("https://api.bilibili.com/x/player/wbi/playurl")
         .header(header::COOKIE, build_cookie_header(cookies))
         .header(header::REFERER, "https://www.bilibili.com")
-        .query(&[
-            ("bvid", bvid),
-            ("cid", &cid.to_string()),
-            ("qn", "116"),
-            ("fnval", "2064"),
-            ("fnver", "0"),
-            ("fourk", "1"),
-            ("w_rid", &signature.w_rid),
-            ("wts", &signature.wts),
-        ])
+        .query(&query)
         .send()
         .await
         .map_err(|e| format!("XPlayerApi Failed to fetch video info: {e}"))?;
@@ -1069,7 +1129,7 @@ async fn build_output_path(app: &AppHandle, filename: &str) -> Result<PathBuf, S
 ///
 /// Returns `Some(content_length)` on success, or `None` on failure.
 async fn head_content_length(url: &str, cookie: Option<&str>) -> Option<u64> {
-    let client = reqwest::Client::builder().build().ok()?;
+    let client = build_client().ok()?;
     let mut req = client.head(url);
     if let Some(c) = cookie {
         req = req.header(reqwest::header::COOKIE, c);
@@ -1131,7 +1191,7 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
             #[allow(clippy::unnecessary_cast)]
             #[allow(clippy::useless_conversion)]
             let free_bytes = u64::from(stat.f_bavail) * stat.f_frsize;
-            if free_bytes <= needed_bytes {
+            if free_bytes < needed_bytes {
                 return Err("ERR::DISK_FULL".into());
             }
         }
@@ -1366,7 +1426,17 @@ pub async fn fetch_subtitles(
     bvid: &str,
     cid: i64,
 ) -> Vec<SubtitleDto> {
-    let mixin_key = match crate::utils::wbi::fetch_mixin_key(client).await {
+    let cookie_header = build_cookie_header(cookies);
+    let mixin_key = match crate::utils::wbi::fetch_mixin_key(
+        client,
+        if cookie_header.is_empty() {
+            None
+        } else {
+            Some(&cookie_header)
+        },
+    )
+    .await
+    {
         Ok(key) => key,
         Err(_) => return Vec::new(),
     };
@@ -1376,10 +1446,7 @@ pub async fn fetch_subtitles(
         ("cid".to_string(), cid.to_string()),
     ]);
 
-    let signature = match crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key) {
-        Ok(sig) => sig,
-        Err(_) => return Vec::new(),
-    };
+    let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
 
     let response = match client
         .get("https://api.bilibili.com/x/player/wbi/v2")
@@ -1477,12 +1544,39 @@ pub async fn fetch_part_qualities(
 ) -> Result<(Vec<Quality>, Vec<Quality>), String> {
     let cookies = read_cookie(app)?.unwrap_or_default();
     let details = fetch_video_details(&cookies, bvid, cid).await?;
-    let dash_data = details.data.unwrap().dash;
+    let data = details.data.ok_or("ERR::NO_STREAM")?;
 
-    let video_qualities = convert_qualities(&dash_data.video);
-    let audio_qualities = convert_qualities(&dash_data.audio);
+    // DASH format: separate video and audio streams
+    if let Some(dash) = data.dash {
+        let video_qualities = convert_qualities(&dash.video);
+        let audio_qualities = convert_qualities(&dash.audio);
+        return Ok((video_qualities, audio_qualities));
+    }
 
-    Ok((video_qualities, audio_qualities))
+    // durl format: audio is embedded in video, derive qualities from
+    // support_formats
+    if let Some(formats) = data.support_formats {
+        let video_qualities: Vec<Quality> = formats
+            .iter()
+            .map(|f| Quality {
+                id: f.quality,
+                codecid: 0,
+                quality: if !f.new_description.is_empty() {
+                    f.new_description.clone()
+                } else if !f.display_desc.is_empty() {
+                    f.display_desc.clone()
+                } else if !f.description.is_empty() {
+                    f.description.clone()
+                } else {
+                    quality_to_string(&f.quality)
+                },
+            })
+            .collect();
+        // durl format has no separate audio stream
+        return Ok((video_qualities, vec![]));
+    }
+
+    Err("ERR::NO_STREAM".to_string())
 }
 
 /// Downloads a subtitle and saves it in SRT format.
@@ -1827,7 +1921,12 @@ async fn fetch_bangumi_details_for_download(
         Some(dash) => Ok(XPlayerApiResponse {
             code: 0,
             message: "success".to_string(),
-            data: Some(crate::models::bilibili_api::XPlayerApiResponseData { dash }),
+            data: Some(crate::models::bilibili_api::XPlayerApiResponseData {
+                dash: Some(dash),
+                durl: None,
+                support_formats: None,
+                quality: None,
+            }),
         }),
         None => {
             // durl format - not supported in current download flow
@@ -1874,6 +1973,7 @@ pub async fn fetch_bangumi_part_qualities(
             .map(|entry| Quality {
                 id: entry.quality,
                 codecid: 7, // AVC for MP4 format
+                quality: quality_to_string(&entry.quality),
             })
             .collect();
 

--- a/src-tauri/src/models/bilibili_api.rs
+++ b/src-tauri/src/models/bilibili_api.rs
@@ -77,12 +77,24 @@ pub struct XPlayerApiResponse {
     pub data: Option<XPlayerApiResponseData>,
 }
 
-/// DASH stream data from player API response.
+/// Player API response data containing stream information.
 ///
-/// Contains the actual video and audio streams available for download.
+/// Supports both DASH (adaptive streaming) and durl (direct URL) formats.
+/// Modern videos use DASH; older videos may use durl format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XPlayerApiResponseData {
-    pub dash: XPlayerApiResponseDash,
+    /// DASH stream data (absent for durl-format videos)
+    #[serde(default)]
+    pub dash: Option<XPlayerApiResponseDash>,
+    /// Direct URL format segments (for non-DASH videos)
+    #[serde(default)]
+    pub durl: Option<Vec<DurlSegment>>,
+    /// Supported quality formats with descriptions
+    #[serde(default)]
+    pub support_formats: Option<Vec<SupportFormat>>,
+    /// Current video quality code
+    #[serde(default)]
+    pub quality: Option<i32>,
 }
 
 /// DASH video and audio streams container.
@@ -510,6 +522,7 @@ pub struct DurlQualityEntry {
 pub struct SupportFormat {
     pub quality: i32,
     pub format: String,
+    #[serde(default)]
     pub description: String,
     #[serde(default)]
     pub new_description: String,

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -112,6 +112,8 @@ pub struct Quality {
     pub id: i32,
     /// Codec ID
     pub codecid: i16,
+    /// Human-readable quality label (e.g. "1080P 高清")
+    pub quality: String,
 }
 
 // ============================================================================

--- a/src-tauri/src/utils/wbi.rs
+++ b/src-tauri/src/utils/wbi.rs
@@ -6,24 +6,25 @@
 //!
 //! ## WBI Signature Process
 //!
-//! 1. Fetch MixinKey from wbi_img URL
+//! 1. Fetch MixinKey from wbi_img URL (apply MIXIN_KEY_ENC_TAB shuffle)
 //! 2. Add timestamp (wts) to request parameters
 //! 3. Sort parameters and concatenate them
-//! 4. Append MixinKey and compute HMAC-SHA256 hash
-//! 5. Use first 32 characters of base64-encoded hash as w_rid
+//! 4. Append MixinKey and compute MD5 hash
+//! 5. Use the 32-character hex MD5 digest as w_rid
 //!
 //! ## References
 //!
-//! - [Bilibili API Collect - WBI](https://github.com/pskdje/bilibili-API-collect/blob/main/docs/misc/sign/wbi.md)
-//! - [WBI Discussion](https://github.com/SocialSisterYi/bilibili-API-collect/discussions/920)
+//! - [Bilibili API Collect - WBI](https://github.com/SocialSisterYi/bilibili-API-collect/blob/main/docs/misc/sign/wbi.md)
 
-use base64::Engine;
-use hmac::digest::KeyInit;
-use hmac::Hmac;
-use hmac::Mac;
 use reqwest::Client;
-use sha2::Sha256;
 use std::collections::BTreeMap;
+
+/// Shuffle table used to derive MixinKey from img_key + sub_key.
+const MIXIN_KEY_ENC_TAB: [usize; 64] = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49, 33, 9, 42, 19, 29,
+    28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25,
+    54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+];
 
 /// WBI signature parameters for API requests.
 ///
@@ -31,10 +32,45 @@ use std::collections::BTreeMap;
 /// in query parameters when calling WBI-protected endpoints.
 #[derive(Debug, Clone)]
 pub struct WbiSignature {
-    /// The signature hash computed from parameters and MixinKey
+    /// The MD5 hex signature computed from parameters and MixinKey
     pub w_rid: String,
     /// Unix timestamp when the signature was generated
     pub wts: String,
+}
+
+/// Derives MixinKey from the combined img_key + sub_key string
+/// by applying the MIXIN_KEY_ENC_TAB shuffle and taking first 32 chars.
+fn derive_mixin_key(raw: &str) -> String {
+    let chars: Vec<char> = raw.chars().collect();
+    MIXIN_KEY_ENC_TAB
+        .iter()
+        .filter_map(|&i| chars.get(i))
+        .take(32)
+        .collect()
+}
+
+/// Computes WBI signature from sorted parameters and mixin key.
+///
+/// Internal helper that is deterministic for a given `wts` value,
+/// making it directly testable without time-dependent behaviour.
+///
+/// # Arguments
+///
+/// * `params` - Sorted request parameters (must already contain `wts`)
+/// * `mixin_key` - 32-character MixinKey
+///
+/// # Returns
+///
+/// 32-character lowercase MD5 hex digest.
+fn compute_wbi_rid(params: &BTreeMap<String, String>, mixin_key: &str) -> String {
+    let query_string = params
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("&");
+    let to_hash = format!("{}{}", query_string, mixin_key);
+    let digest = md5::compute(to_hash.as_bytes());
+    format!("{:x}", digest)
 }
 
 /// Generates WBI signature for API request parameters.
@@ -44,8 +80,7 @@ pub struct WbiSignature {
 /// 2. Sorts all parameters alphabetically
 /// 3. Concatenates them as `key1=value1&key2=value2`
 /// 4. Appends MixinKey to the concatenated string
-/// 5. Computes HMAC-SHA256 hash
-/// 6. Base64-encodes the hash and takes first 32 characters as w_rid
+/// 5. Computes MD5 hash and returns the 32-character hex digest as w_rid
 ///
 /// # Arguments
 ///
@@ -54,23 +89,20 @@ pub struct WbiSignature {
 ///
 /// # Returns
 ///
-/// `Ok(WbiSignature)` containing w_rid and wts on success.
-///
-/// # Errors
-///
-/// Returns an error if HMAC key creation fails (invalid key length).
+/// `WbiSignature` containing w_rid and wts.
 ///
 /// # Example
 ///
 /// ```no_run
 /// use std::collections::BTreeMap;
+/// use bilibili_downloader_gui_lib::wbi::generate_wbi_signature;
 ///
 /// let mut params = BTreeMap::new();
 /// params.insert("bvid".to_string(), "BV1234567890".to_string());
 /// params.insert("cid".to_string(), "123456".to_string());
 ///
-/// let mixin_key = "abcdefghijklmn123456789012";
-/// let signature = generate_wbi_signature(&mut params, mixin_key).unwrap();
+/// let mixin_key = "abcdefghijklmnopqrstuvwxyz123456";
+/// let signature = generate_wbi_signature(&mut params, mixin_key);
 ///
 /// println!("w_rid: {}", signature.w_rid);
 /// println!("wts: {}", signature.wts);
@@ -78,51 +110,33 @@ pub struct WbiSignature {
 pub fn generate_wbi_signature(
     params: &mut BTreeMap<String, String>,
     mixin_key: &str,
-) -> Result<WbiSignature, String> {
+) -> WbiSignature {
     let wts = chrono::Utc::now().timestamp();
     params.insert("wts".to_string(), wts.to_string());
-
-    // Sort parameters and concatenate
-    let query_string = params
-        .iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect::<Vec<_>>()
-        .join("&");
-
-    // Append MixinKey and create HMAC-SHA256 hash
-    let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(mixin_key.as_bytes())
-        .map_err(|e| format!("Failed to create HMAC: {e}"))?;
-    mac.update(query_string.as_bytes());
-    mac.update(mixin_key.as_bytes());
-    let hash = mac.finalize().into_bytes();
-
-    // Base64 encode and take first 32 characters
-    let w_rid = base64::engine::general_purpose::STANDARD
-        .encode(&hash[..])
-        .chars()
-        .take(32)
-        .collect();
-
-    Ok(WbiSignature {
+    let w_rid = compute_wbi_rid(params, mixin_key);
+    WbiSignature {
         w_rid,
         wts: wts.to_string(),
-    })
+    }
 }
 
 /// Fetches MixinKey from Bilibili wbi_img endpoint.
 ///
-/// The MixinKey is required for WBI signature generation and is obtained
-/// by parsing the wbi_img URL from the navigation endpoint. The MixinKey
-/// is constructed by concatenating the first 24 and last 24 characters
-/// from the wbi_img filename (total 48 characters).
+/// The MixinKey is derived by:
+/// 1. Extracting img_key and sub_key from the wbi_img URLs
+/// 2. Concatenating them (img_key + sub_key = 64 chars)
+/// 3. Applying MIXIN_KEY_ENC_TAB shuffle and taking the first 32 chars
 ///
 /// # Arguments
 ///
 /// * `client` - HTTP client for making the request
+/// * `cookie` - Optional cookie header value for authenticated requests.
+///   Providing a valid session cookie improves reliability since some
+///   Bilibili account tiers require authentication to return `wbi_img`.
 ///
 /// # Returns
 ///
-/// `Ok(String)` containing the 48-character MixinKey on success.
+/// `Ok(String)` containing the 32-character MixinKey on success.
 ///
 /// # Errors
 ///
@@ -130,23 +144,12 @@ pub fn generate_wbi_signature(
 /// - HTTP request fails
 /// - Response JSON cannot be parsed
 /// - wbi_img field is missing or invalid
-/// - MixinKey extraction fails
-///
-/// # Example
-///
-/// ```no_run
-/// use reqwest::Client;
-///
-/// # async fn example() -> Result<(), String> {
-/// let client = Client::new();
-/// let mixin_key = fetch_mixin_key(&client).await?;
-/// println!("MixinKey: {}", mixin_key);
-/// # Ok(())
-/// # }
-/// ```
-pub async fn fetch_mixin_key(client: &Client) -> Result<String, String> {
-    let resp = client
-        .get("https://api.bilibili.com/x/web-interface/nav")
+pub async fn fetch_mixin_key(client: &Client, cookie: Option<&str>) -> Result<String, String> {
+    let mut req = client.get("https://api.bilibili.com/x/web-interface/nav");
+    if let Some(c) = cookie {
+        req = req.header(reqwest::header::COOKIE, c);
+    }
+    let resp = req
         .send()
         .await
         .map_err(|e| format!("Failed to fetch wbi_img: {}", e))?;
@@ -171,35 +174,22 @@ pub async fn fetch_mixin_key(client: &Client) -> Result<String, String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| "sub_url not found".to_string())?;
 
-    // Extract filename from img_url
+    // Extract filename (without extension) from URL
     let img_key = img_url
         .rsplit('/')
         .next()
         .unwrap_or("")
         .trim_end_matches(".png");
 
-    // Extract filename from sub_url
     let sub_key = sub_url
         .rsplit('/')
         .next()
         .unwrap_or("")
         .trim_end_matches(".png");
 
-    // MixinKey format: img_url key[0..24] + sub_url key[8..32] (total 48)
-    // 取img_url的前24位 + sub_url的后24位
-    if img_key.len() < 24 || sub_key.len() < 24 {
-        return Err(format!(
-            "MixinKey length insufficient: img_key={}, sub_key={}",
-            img_key.len(),
-            sub_key.len()
-        ));
-    }
-
-    let img_prefix = &img_key[..24];
-    let sub_suffix = &sub_key[sub_key.len() - 24..];
-    let mixin_key = format!("{}{}", img_prefix, sub_suffix);
-
-    Ok(mixin_key)
+    // Concatenate and apply shuffle
+    let raw = format!("{}{}", img_key, sub_key);
+    Ok(derive_mixin_key(&raw))
 }
 
 #[cfg(test)]
@@ -207,20 +197,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_wbi_signature() {
+    fn test_generate_wbi_signature_returns_32_char_md5() {
         let mut params = BTreeMap::new();
         params.insert("bvid".to_string(), "BV1234567890".to_string());
         params.insert("cid".to_string(), "123456".to_string());
 
-        let mixin_key = "abcdefghijklmn123456789012abcdefghijklmn";
-        let result = generate_wbi_signature(&mut params, mixin_key);
+        let mixin_key = "abcdefghijklmnopqrstuvwxyz123456";
+        let signature = generate_wbi_signature(&mut params, mixin_key);
 
-        assert!(result.is_ok());
-        let signature = result.unwrap();
-        assert!(!signature.w_rid.is_empty());
-        assert!(!signature.wts.is_empty());
+        // MD5 hex digest is always 32 characters
         assert_eq!(signature.w_rid.len(), 32);
+        assert!(!signature.wts.is_empty());
         assert!(params.contains_key("wts"));
+    }
+
+    #[test]
+    fn test_generate_wbi_signature_deterministic() {
+        // Use compute_wbi_rid directly to avoid time-dependent behaviour.
+        // generate_wbi_signature overwrites wts with the current timestamp,
+        // so two sequential calls may produce different w_rid values if
+        // they straddle a second boundary. Instead, pin wts explicitly.
+        let mixin_key = "abcdefghijklmnopqrstuvwxyz123456";
+        let fixed_wts = "1700000000";
+
+        let mut params1 = BTreeMap::new();
+        params1.insert("bvid".to_string(), "BV1234567890".to_string());
+        params1.insert("wts".to_string(), fixed_wts.to_string());
+
+        let mut params2 = params1.clone();
+
+        let rid1 = compute_wbi_rid(&params1, mixin_key);
+        let rid2 = compute_wbi_rid(&params2, mixin_key);
+
+        // Same parameters + same wts → identical w_rid
+        assert_eq!(rid1, rid2);
+        // Different wts must produce a different w_rid
+        params2.insert("wts".to_string(), "1700000001".to_string());
+        let rid3 = compute_wbi_rid(&params2, mixin_key);
+        assert_ne!(rid1, rid3);
     }
 
     #[test]
@@ -229,13 +243,20 @@ mod tests {
         params.insert("z_param".to_string(), "last".to_string());
         params.insert("a_param".to_string(), "first".to_string());
 
-        let mixin_key = "abcdefghijklmn123456789012abcdefghijklmn";
-        let result = generate_wbi_signature(&mut params, mixin_key);
+        let mixin_key = "abcdefghijklmnopqrstuvwxyz123456";
+        let signature = generate_wbi_signature(&mut params, mixin_key);
 
-        assert!(result.is_ok());
-        // Verify wts was added
         assert!(params.contains_key("wts"));
         assert!(params.contains_key("a_param"));
         assert!(params.contains_key("z_param"));
+        assert_eq!(signature.w_rid.len(), 32);
+    }
+
+    #[test]
+    fn test_derive_mixin_key_length() {
+        // 64-char raw string (typical img_key + sub_key)
+        let raw = "abcdefghijklmnopqrstuvwxyz012345ABCDEFGHIJKLMNOPQRSTUVWXYZ678901";
+        let key = derive_mixin_key(raw);
+        assert_eq!(key.len(), 32);
     }
 }

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -641,7 +641,7 @@ const VideoPartCard = memo(function VideoPartCard({
                               )}
                             />
                           </div>
-                        ) : video.contentType === 'bangumi' ? (
+                        ) : !qualitiesLoading ? (
                           <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm dark:border-blue-800 dark:bg-blue-950">
                             <div className="flex items-center gap-2">
                               <Info className="h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
@@ -724,9 +724,7 @@ const VideoPartCard = memo(function VideoPartCard({
             onRedownload={handleRedownload}
             onRetry={handleRetry}
             onCancel={handleCancel}
-            hasEmbeddedAudio={
-              video.contentType === 'bangumi' && audioQualities.length === 0
-            }
+            hasEmbeddedAudio={audioQualities.length === 0}
           />
         )}
       </Form>


### PR DESCRIPTION
## Summary

This PR fixes multiple bugs that prevented regular Bilibili videos (BV format) from downloading correctly, addressing issues in the WBI signature algorithm, API response parsing, and UI progress display.

## Bug Fixes

### Backend (Rust)

- **WBI signature algorithm** (`wbi.rs`): Replaced incorrect HMAC-SHA256+base64 implementation with the correct MD5 + MIXIN_KEY_ENC_TAB shuffle algorithm as required by Bilibili's API
- **fetch_mixin_key cookie** (`bilibili.rs`): Added `cookie: Option<&str>` parameter so authenticated requests pass the cookie correctly when fetching the WBI mixin key
- **fetch_video_details double parameter send** (`bilibili.rs`): Fixed BTreeMap being sent twice; now builds parameters once and signs them together
- **head_content_length client reuse** (`bilibili.rs`): Replaced per-call `reqwest::Client::builder().build()` with shared `build_client()` helper
- **ensure_free_space boundary condition** (`bilibili.rs`): Fixed off-by-one: `free_bytes <= needed_bytes` → `free_bytes < needed_bytes`
- **Quality struct missing field** (`frontend_dto.rs`): Added `pub quality: String` field to the `Quality` struct
- **SupportFormat.description required field** (`bilibili_api.rs`): Added `#[serde(default)]` to handle missing `description` field in API responses
- **XPlayerApiResponseData structure** (`bilibili_api.rs`): Made `dash` optional; added `durl`, `support_formats`, and `quality` fields to handle non-DASH (durl) video formats
- **download_video doc comment** (`bilibili.rs`): Removed orphaned doc comment block and relocated it directly above the `download_video` function

### Frontend (TypeScript)

- **durl format audio quality display** (`VideoPartCard.tsx`): Fixed the condition showing "No audio quality" for durl-format videos (which have embedded audio) — changed to `audioQualities.length === 0`
- **durl format download progress stages** (`VideoPartCard.tsx`): Fixed `hasEmbeddedAudio` prop to correctly reflect single-file durl downloads, showing 3 progress stages instead of 6

### Tests

- **Non-deterministic WBI test** (`wbi.rs`): Extracted `compute_wbi_rid()` inner function; tests now use fixed timestamps instead of `SystemTime::now()`
- **wbi.rs doctest import** (`wbi.rs`): Added missing `use` import to the doctest example

## Test Results

- Rust unit tests: **12/12 passed**
- Rust doc tests: passed
- Frontend tests: **60/60 passed**
- Frontend build: success
- Rust build: success