### PR TITLE
fix: clear quality/subtitle info on re-download

### DIFF
--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -11,6 +11,7 @@ import {
 import { extractContentId } from '@/features/video/lib/utils'
 import {
   clearPendingDownload,
+  clearResolvedInfo,
   initPartInputs,
   setUrl,
   updatePartInputByIndex,
@@ -39,6 +40,9 @@ import type { Input, Video } from '../types'
 
 /**
  * Maps backend error codes to i18n translation keys.
+ *
+ * Backend returns error strings containing error codes like "ERR::VIDEO_NOT_FOUND".
+ * This constant maps those codes to translation keys for localized user-facing messages.
  */
 const ERROR_MAP: Record<string, string> = {
   'ERR::VIDEO_NOT_FOUND': 'video.video_not_found',
@@ -151,30 +155,25 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
    */
   const initInputsForVideo = useCallback((v: Video) => {
     const pending = processingPendingRef.current
-    const partInputs = v.parts.map((p) => {
-      const title = v.title === p.part ? v.title : `${v.title} ${p.part}`
 
-      // Pending download selects only target part; otherwise all selected
-      const selected =
-        !pending ||
-        (pending.cid !== null ? p.cid === pending.cid : p.page === pending.page)
+    const isSelected = (p: (typeof v.parts)[0]) =>
+      !pending ||
+      (pending.cid !== null ? p.cid === pending.cid : p.page === pending.page)
 
-      return {
-        cid: p.cid,
-        page: p.page,
-        title,
-        videoQuality: '',
-        audioQuality: '',
-        selected,
-        duration: p.duration,
-        thumbnailUrl: p.thumbnail.url,
-        subtitles: [],
-        subtitlesLoading: false,
-        // Don't initialize videoQualities/audioQualities - let them be undefined
-        // so we can distinguish between "not fetched yet" and "fetched but empty"
-        qualitiesLoading: false,
-      }
-    })
+    const partInputs = v.parts.map((p) => ({
+      cid: p.cid,
+      page: p.page,
+      title: v.title === p.part ? v.title : `${v.title} ${p.part}`,
+      videoQuality: '',
+      audioQuality: '',
+      selected: isSelected(p),
+      duration: p.duration,
+      thumbnailUrl: p.thumbnail.url,
+      subtitles: [],
+      subtitlesLoading: false,
+      qualitiesLoading: false,
+    }))
+
     store.dispatch(initPartInputs(partInputs))
 
     if (pending) {
@@ -287,15 +286,14 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
       videoQuality: string,
       audioQuality?: string,
     ) => {
-      const payload: Parameters<typeof updatePartInputByIndex>[0] = {
-        index,
-        title,
-        videoQuality,
-      }
-      if (audioQuality !== undefined) {
-        payload.audioQuality = audioQuality
-      }
-      store.dispatch(updatePartInputByIndex(payload))
+      store.dispatch(
+        updatePartInputByIndex({
+          index,
+          title,
+          videoQuality,
+          ...(audioQuality !== undefined && { audioQuality }),
+        }),
+      )
     },
     [],
   )
@@ -370,15 +368,15 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
     if (!processing || video.parts.length === 0) return
 
     const { cid, page } = processing
+    const matchesTarget = (pi: (typeof input.partInputs)[number]) =>
+      cid !== null ? pi.cid === cid : pi.page === page
 
-    // Select only the target part; deselect all others
-    // Prefer cid matching for accuracy, fall back to page matching
     input.partInputs.forEach((pi, idx) => {
-      const shouldSelect = cid !== null ? pi.cid === cid : pi.page === page
-      store.dispatch(updatePartSelected({ index: idx, selected: shouldSelect }))
+      store.dispatch(
+        updatePartSelected({ index: idx, selected: matchesTarget(pi) }),
+      )
     })
 
-    // Clear pending state after selection is complete
     store.dispatch(clearPendingDownload())
     processingPendingRef.current = null
   }, [video.parts, input.partInputs])
@@ -401,21 +399,23 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
         : `av${video.parts[0]?.aid ?? ''}`
 
     // Extract selected parts with their indices for download processing
-    // Type predicate filter ensures non-null items with proper type narrowing
     const selectedParts = input.partInputs
       .map((pi, idx) => (pi.selected ? { pi, idx } : null))
       .filter(
-        (item): item is { pi: (typeof input.partInputs)[0]; idx: number } =>
+        (
+          item,
+        ): item is { pi: (typeof input.partInputs)[number]; idx: number } =>
           item !== null,
       )
 
+    // Clear previous resolved quality/subtitle info before starting new download
+    store.dispatch(clearResolvedInfo())
+
     // Clear previously completed items for the selected parts to allow re-download
-    // This removes finished queue entries so they can be queued again
     for (const { idx } of selectedParts) {
       const completedItem = findCompletedItemForPart(store.getState(), idx + 1)
-      if (completedItem) {
+      if (completedItem)
         store.dispatch(clearQueueItem(completedItem.downloadId))
-      }
     }
 
     const parentId = `${videoId}-${Date.now()}`

--- a/src/features/video/model/inputSlice.ts
+++ b/src/features/video/model/inputSlice.ts
@@ -9,6 +9,12 @@ import type {
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 
+/**
+ * Default subtitle configuration for video parts.
+ *
+ * Used as initial value when part inputs are created and as fallback
+ * when subtitle data is not provided.
+ */
 export const defaultSubtitleConfig: SubtitleConfig = {
   mode: 'off',
   selectedLans: [],
@@ -125,9 +131,7 @@ export const inputSlice = createSlice({
      * @param state - Current input state
      */
     selectAll: (state) => {
-      state.partInputs.forEach((p) => {
-        p.selected = true
-      })
+      state.partInputs.forEach((p) => (p.selected = true))
     },
     /**
      * Deselects all video parts.
@@ -135,9 +139,7 @@ export const inputSlice = createSlice({
      * @param state - Current input state
      */
     deselectAll: (state) => {
-      state.partInputs.forEach((p) => {
-        p.selected = false
-      })
+      state.partInputs.forEach((p) => (p.selected = false))
     },
     /**
      * Selects all video parts on a specific page.
@@ -213,9 +215,7 @@ export const inputSlice = createSlice({
     ) => {
       const { index, config } = action.payload
       const target = state.partInputs[index]
-      if (target) {
-        target.subtitle = config
-      }
+      if (target) target.subtitle = config
     },
     /**
      * Sets subtitles loading state for a specific part.
@@ -229,9 +229,7 @@ export const inputSlice = createSlice({
     ) => {
       const { index, loading } = action.payload
       const target = state.partInputs[index]
-      if (target) {
-        target.subtitlesLoading = loading
-      }
+      if (target) target.subtitlesLoading = loading
     },
     /**
      * Sets subtitles for a specific part (lazy loading).
@@ -262,9 +260,7 @@ export const inputSlice = createSlice({
     ) => {
       const { index, loading } = action.payload
       const target = state.partInputs[index]
-      if (target) {
-        target.qualitiesLoading = loading
-      }
+      if (target) target.qualitiesLoading = loading
     },
     /**
      * Sets qualities for a specific part (lazy loading).
@@ -314,9 +310,7 @@ export const inputSlice = createSlice({
     ) => {
       const { index, open } = action.payload
       const target = state.partInputs[index]
-      if (target) {
-        target.accordionOpen = open
-      }
+      if (target) target.accordionOpen = open
     },
     /**
      * Sets the resolved quality info for a specific part.
@@ -372,8 +366,22 @@ export const inputSlice = createSlice({
      * @param state - Current input state
      */
     closeAllAccordions: (state) => {
+      state.partInputs.forEach((p) => (p.accordionOpen = false))
+    },
+    /**
+     * Clears resolved quality and subtitle info for selected parts.
+     *
+     * Called when download starts to clear previous download's
+     * resolved info before new download begins.
+     *
+     * @param state - Current input state
+     */
+    clearResolvedInfo: (state) => {
       state.partInputs.forEach((p) => {
-        p.accordionOpen = false
+        if (p.selected) {
+          p.resolvedQuality = undefined
+          p.resolvedSubtitle = undefined
+        }
       })
     },
   },
@@ -381,6 +389,7 @@ export const inputSlice = createSlice({
 
 export const {
   clearPendingDownload,
+  clearResolvedInfo,
   closeAllAccordions,
   deselectAll,
   deselectPageAll,


### PR DESCRIPTION
## Summary

Fixed an issue where previous quality, audio quality, and subtitle info remained in the expander label when re-downloading after a download completed.

## Changes

- Added `clearResolvedInfo` action to `inputSlice.ts`
  - Clears `resolvedQuality` and `resolvedSubtitle` for selected parts
- Dispatch `clearResolvedInfo()` at the start of the `download` function in `VideoInfoContext.tsx`
  - This ensures previous quality/subtitle info is cleared before a new download begins

## Test Plan

- [x] typecheck passed
- [x] lint passed
- [x] Manual test: Download a video → After completion, re-download and verify that previous info is not shown in the expander label

🤖 Generated with [Claude Code](https://claude.com/claude-code)