### PR TITLE
fix: add CSP and ATS settings for production build

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' http: https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Add Content Security Policy (CSP) to `tauri.conf.json` to allow external images and IPC connections in production builds
- Add `Info.plist` with `NSAppTransportSecurity` settings to allow HTTP connections on macOS

## Problem
In production builds, images from Bilibili's CDN were not loading due to:
1. Missing CSP `img-src` directive for external URLs
2. macOS App Transport Security (ATS) blocking HTTP connections

## Solution
- **CSP**: `default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' http: https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'`
- **ATS**: `NSAllowsArbitraryLoads = true` in Info.plist

## Test plan
- [x] Run `npm run tauri build` and verify images load correctly in the production app
- [x] Verify no CSP errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)