### PR TITLE
fix: prevent toast on blur for short URLs

### DIFF
--- a/src/features/video/ui/VideoForm1.tsx
+++ b/src/features/video/ui/VideoForm1.tsx
@@ -188,11 +188,22 @@ function VideoForm1() {
     [isShortUrl, handleExpandShortUrl],
   )
 
+  /**
+   * Handles blur event on the form.
+   * Skips submission for short URLs since they will be auto-expanded.
+   */
+  const handleFormBlur = useCallback(() => {
+    const currentUrl = form.getValues('url').trim()
+    // Skip form submission for short URLs - they will be auto-expanded
+    if (isShortUrl(currentUrl)) return
+    form.handleSubmit(onSubmit)()
+  }, [form, isShortUrl, onSubmit])
+
   return (
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        onBlur={form.handleSubmit(onSubmit)}
+        onBlur={handleFormBlur}
         className="space-y-3"
       >
         <FormField


### PR DESCRIPTION
## Summary

Fixes an issue where "Please enter a valid URL" toast was displayed when re-entering a short URL after expansion.

## Problem

When a user enters a b23.tv short URL, it gets expanded correctly. However, if the user enters the same short URL again and the input field loses focus (blur event), a validation toast appears because Zod validation runs before the `isShortUrl` check in `onSubmit`.

## Solution

Added `handleFormBlur` function that skips form submission for short URLs on blur event, since they will be auto-expanded.

## Test plan

- [x] Enter b23.tv short URL
- [x] Verify expansion and video fetch work
- [x] Re-enter the same short URL
- [x] Verify no toast appears on blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)