### PR TITLE
docs: update README images to use light theme variant

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,7 +2,7 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en.png>)
+![App Image](<public/app-image(searched)_en_light.png>)
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | Español | [Français](README.fr.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,7 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en.png>)
+![App Image](<public/app-image(searched)_en_light.png>)
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | Français
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en.png>)
+![App Image](<public/app-image(searched)_en_light.png>)
 
 [English](README.md) | 日本語 | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en.png>)
+![App Image](<public/app-image(searched)_en_light.png>)
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | 한국어 | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en.png>)
+![App Image](<public/app-image(searched)_en_light.png>)
 
 [English](README.md) | [日本語](README.ja.md) | 简体中文 | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 


### PR DESCRIPTION
## Summary
- Update all localized README files (ja, zh, ko, es, fr) to reference the light theme app image variant (`_en_light.png`) for consistency with the English README

## Test plan
- [x] Verify all README files display the correct light theme image
- [x] Verify image references match across all language variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)