### PR TITLE
fix: clear video cache when autoRenameDuplicates setting changes

### DIFF
--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -1,3 +1,5 @@
+import { store } from '@/app/store'
+import { videoApi } from '@/features/video'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { open } from '@tauri-apps/plugin-dialog'
 import { useEffect, useState } from 'react'
@@ -44,11 +46,6 @@ import { Switch } from '@/shared/ui/switch'
  * Changes are auto-saved when fields blur or when language is changed.
  * The form uses react-hook-form with Zod schema validation that supports
  * both Windows and POSIX path validation rules.
- *
- * @example
- * ```tsx
- * <SettingsForm />
- * ```
  */
 function SettingsForm() {
   const { t } = useTranslation()
@@ -70,23 +67,11 @@ function SettingsForm() {
   }, [settings.libPath, t])
 
   /**
-   * Opens a native directory picker dialog.
-   *
-   * Uses Tauri's dialog plugin to show a platform-native directory
-   * selection dialog. Returns the selected path as a string, or null if
-   * the user cancels or an error occurs.
+   * Opens a directory selection dialog using Tauri's dialog plugin.
    *
    * @param titleKey - Translation key for the dialog title
-   * @param defaultPath - Optional starting directory path
-   * @returns Selected directory path, or null if cancelled/failed
-   *
-   * @example
-   * ```typescript
-   * const path = await openDirectoryDialog('settings.output_dir_dialog_title', '/Users/you/Downloads');
-   * if (path) {
-   *   console.log('Selected:', path);
-   * }
-   * ```
+   * @param defaultPath - Optional initial directory path
+   * @returns Selected directory path or null if cancelled/error occurred
    */
   const openDirectoryDialog = async (
     titleKey: string,
@@ -97,7 +82,7 @@ function SettingsForm() {
         directory: true,
         multiple: false,
         title: t(titleKey),
-        defaultPath: defaultPath || undefined,
+        defaultPath,
       })
     } catch (error) {
       console.error('Failed to open directory dialog:', error)
@@ -106,16 +91,8 @@ function SettingsForm() {
   }
 
   /**
-   * Handles library path directory selection.
-   *
-   * Opens a directory picker dialog for selecting the FFmpeg library path.
-   * If the user selects a directory, the path is updated via the settings
-   * API and the local state is refreshed.
-   *
-   * This is useful for moving large dependencies like ffmpeg to a drive
-   * with more storage space.
-   *
-   * @throws Shows error toast if the update fails
+   * Handles library path selection via directory dialog.
+   * Updates the library path setting after user selects a directory.
    */
   const handleLibPathChange = async () => {
     setIsUpdatingLibPath(true)
@@ -133,14 +110,8 @@ function SettingsForm() {
   }
 
   /**
-   * Handles download output directory selection.
-   *
-   * Opens a directory picker dialog for selecting where downloaded videos
-   * are saved. If the user selects a directory, the form value is updated,
-   * validated, and immediately submitted to persist the change.
-   *
-   * The selected path is validated against OS-specific constraints
-   * (Windows vs POSIX) before being saved.
+   * Handles download output path selection via directory dialog.
+   * Updates the form value and submits to save the new path.
    */
   const handleDlOutputPathChange = async () => {
     setIsUpdatingDlOutputPath(true)
@@ -180,13 +151,11 @@ function SettingsForm() {
   }, [form, settings.dlOutputPath, settings.language])
 
   /**
-   * Form submission handler that saves changed settings.
+   * Handles form submission.
+   * Detects changed fields and saves only those values.
+   * Triggers language update if language setting changed.
    *
-   * Compares form data against current settings to identify which fields
-   * have changed. If the language changed, triggers a language update
-   * immediately. All changed values are then persisted via the settings API.
-   *
-   * @param data - Validated form data matching the settings schema
+   * @param data - Form data matching the schema
    */
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     const changedKeys = (['dlOutputPath', 'language'] as const).filter(
@@ -207,12 +176,9 @@ function SettingsForm() {
 
   /**
    * Handles language selection change.
+   * Updates form value and immediately submits to apply new language.
    *
-   * Updates the language field value when a user selects a different
-   * language from the radio group. Marks the form as dirty and triggers
-   * immediate validation and submission to save the change.
-   *
-   * @param val - Selected language identifier (e.g., 'en', 'ja')
+   * @param val - Selected language code
    */
   const handleLanguageChange = (val: string) => {
     form.setValue('language', val as z.infer<typeof formSchema>['language'], {
@@ -299,6 +265,8 @@ function SettingsForm() {
             checked={settings.autoRenameDuplicates ?? true}
             onCheckedChange={(checked) => {
               saveByForm({ ...settings, autoRenameDuplicates: checked })
+              // Clear video cache so new setting applies on next fetch
+              store.dispatch(videoApi.util.resetApiState())
             }}
           />
         </div>

--- a/src/features/settings/ui/TitleReplacementSettings.tsx
+++ b/src/features/settings/ui/TitleReplacementSettings.tsx
@@ -1,5 +1,5 @@
 import { store } from '@/app/store'
-import { videoApi } from '@/features/video/api/videoApi'
+import { videoApi } from '@/features/video'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -13,10 +13,7 @@ import { Switch } from '@/shared/ui/switch'
 
 const MAX_RULES = 20
 
-/**
- * Default title replacement rules.
- * Must match the defaults defined in the Rust backend.
- */
+/** Default title replacement rules. Must match the Rust backend defaults. */
 const DEFAULT_RULES: TitleReplacement[] = [
   { from: '/', to: '-', enabled: true },
   { from: ':', to: '_', enabled: true },
@@ -30,15 +27,7 @@ const DEFAULT_RULES: TitleReplacement[] = [
 
 /**
  * Title replacement settings component.
- *
- * Provides UI for managing title character replacement rules.
- * Each rule has a "from" field (character/text to replace),
- * a "to" field (replacement), and a toggle to enable/disable.
- *
- * @example
- * ```tsx
- * <TitleReplacementSettings />
- * ```
+ * Manages character replacement rules for video titles.
  */
 export function TitleReplacementSettings() {
   const { t } = useTranslation()
@@ -52,16 +41,21 @@ export function TitleReplacementSettings() {
   const rules: TitleReplacement[] = settings.titleReplacements ?? DEFAULT_RULES
 
   /**
-   * Saves the updated rules to settings and clears video cache.
+   * Saves new title replacement rules.
+   * Persists to settings and clears video cache to apply changes.
+   *
+   * @param newRules - Updated array of title replacement rules
    */
   const saveRules = async (newRules: TitleReplacement[]) => {
     await saveByForm({ ...settings, titleReplacements: newRules })
-    // Clear video cache so new rules apply on next fetch
     store.dispatch(videoApi.util.resetApiState())
   }
 
   /**
-   * Toggles a rule's enabled state.
+   * Toggles the enabled state of a title replacement rule.
+   *
+   * @param index - Index of the rule to toggle
+   * @param enabled - New enabled state
    */
   const handleToggle = async (index: number, enabled: boolean) => {
     const newRules = rules.map((rule, i) =>
@@ -71,7 +65,10 @@ export function TitleReplacementSettings() {
   }
 
   /**
-   * Starts editing a rule.
+   * Enters edit mode for a specific rule.
+   * Populates edit state with current rule values.
+   *
+   * @param index - Index of the rule to edit
    */
   const startEdit = (index: number) => {
     setEditingIndex(index)
@@ -80,7 +77,8 @@ export function TitleReplacementSettings() {
   }
 
   /**
-   * Cancels editing.
+   * Exits edit mode without saving changes.
+   * Clears edit state and resets form fields.
    */
   const cancelEdit = () => {
     setEditingIndex(null)
@@ -89,7 +87,8 @@ export function TitleReplacementSettings() {
   }
 
   /**
-   * Saves the edited rule.
+   * Saves the current edit and exits edit mode.
+   * Requires a non-empty "from" value to save.
    */
   const saveEdit = async () => {
     if (editingIndex === null || !editFrom) return
@@ -102,7 +101,9 @@ export function TitleReplacementSettings() {
   }
 
   /**
-   * Deletes a rule.
+   * Deletes a title replacement rule by index.
+   *
+   * @param index - Index of the rule to delete
    */
   const deleteRule = async (index: number) => {
     const newRules = rules.filter((_, i) => i !== index)
@@ -110,17 +111,13 @@ export function TitleReplacementSettings() {
   }
 
   /**
-   * Adds a new rule.
+   * Adds a new empty rule and immediately enters edit mode for it.
+   * Enforced by MAX_RULES limit to prevent performance issues.
    */
   const addRule = async () => {
     if (rules.length >= MAX_RULES) return
 
-    const newRule: TitleReplacement = {
-      from: '',
-      to: '',
-      enabled: true,
-    }
-    const newRules = [...rules, newRule]
+    const newRules = [...rules, { from: '', to: '', enabled: true }]
     await saveRules(newRules)
     setEditingIndex(newRules.length - 1)
   }


### PR DESCRIPTION
## Summary
- Fix video cache not being cleared when toggling `autoRenameDuplicates` setting
- Import path improvement to use Public API instead of deep path for consistency
- Apply same import fix to `TitleReplacementSettings.tsx`

## Problem
When changing the `autoRenameDuplicates` setting, the cached video information from RTK Query was not cleared. This caused the old setting to still be in effect until the cache expired (1 hour), preventing users from immediately seeing the effect of their setting change.

## Solution
- Add `store.dispatch(videoApi.util.resetApiState())` when the `autoRenameDuplicates` setting is toggled
- Fix import path from `@/features/video/api/videoApi` to `@/features/video` (Public API)
- Apply the same import path fix to `TitleReplacementSettings.tsx` for consistency

## Test Plan
- [x] Enable "Auto-rename duplicate parts" setting
- [x] Fetch a video with duplicate part names
- [x] Toggle the setting off
- [x] Verify duplicate warning appears immediately (without waiting for cache expiry)
- [x] Toggle the setting back on
- [x] Verify duplicate warning disappears immediately
- [x] Run linter: `npm run lint` ✅
- [x] Run build: `npm run build` ✅

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] No new i18n keys added

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>