### PR TITLE
fix: correct part selection and page navigation when URL changes

### DIFF
--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -16,7 +16,6 @@ import {
   initPartInputs,
   setUrl,
   updatePartInputByIndex,
-  updatePartSelected,
 } from '@/features/video/model/inputSlice'
 import { selectDuplicateIndices } from '@/features/video/model/selectors'
 import { setVideo } from '@/features/video/model/videoSlice'
@@ -402,31 +401,6 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
     processingPendingRef.current = { bvid, cid, page }
     onValid1(`https://www.bilibili.com/video/${bvid}?p=${page}`)
   }, [input.pendingDownload, onValid1])
-
-  /**
-   * Handles part selection for pending download (after video info is fetched).
-   *
-   * Once video info is loaded, this effect automatically selects the specific
-   * part that was requested from history/favorites. Selection is based on
-   * either cid (preferred) or page number as fallback.
-   */
-  useEffect(() => {
-    const processing = processingPendingRef.current
-    if (!processing || video.parts.length === 0) return
-
-    const { cid, page } = processing
-    const matchesTarget = (pi: (typeof input.partInputs)[number]) =>
-      cid !== null ? pi.cid === cid : pi.page === page
-
-    input.partInputs.forEach((pi, idx) => {
-      store.dispatch(
-        updatePartSelected({ index: idx, selected: matchesTarget(pi) }),
-      )
-    })
-
-    store.dispatch(clearPendingDownload())
-    processingPendingRef.current = null
-  }, [video.parts, input.partInputs])
 
   /**
    * Executes download for selected video/bangumi parts.

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -611,6 +611,23 @@ function HomeContentInner() {
     }
   }, [video.parts.length, currentPage, totalPages, handlePageChange])
 
+  // Clear browser 'page' param when input URL has 'p' param
+  // This ensures correct page navigation when URL input changes
+  useEffect(() => {
+    if (!input.url) return
+
+    try {
+      const pParam = new URL(input.url).searchParams.get('p')
+      if (pParam && searchParams.has('page')) {
+        const newParams = new URLSearchParams(searchParams)
+        newParams.delete('page')
+        setSearchParams(newParams, { replace: true })
+      }
+    } catch {
+      // Invalid URL
+    }
+  }, [input.url, searchParams, setSearchParams])
+
   const selectTooltip = hasActiveDownloads
     ? t('video.download_in_progress')
     : undefined


### PR DESCRIPTION
## Summary

Fixed a bug where changing the `?p` parameter in a cached video URL would result in all parts being selected instead of the specific part, and the page navigation would not update correctly.

## Root Cause

When RTK Query returned cached data, a `useEffect` hook (413-456 lines in VideoInfoContext.tsx) would execute during the `await triggerFetch()` microtask phase, consuming the `processingPendingRef` before `initInputsForVideo` could use it. This caused `initInputsForVideo` to see `pending` as `null`, resulting in all parts being selected.

Additionally, when users manually navigated to a different page (setting `?page=N` in the browser URL), subsequent URL inputs with `?p=M` would not override the browser's `?page` parameter, causing incorrect page navigation.

## Changes

- **VideoInfoContext.tsx**: Removed redundant `useEffect` that was causing race conditions with `processingPendingRef`. The part selection logic is now consolidated in `initInputsForVideo`.
- **home/index.tsx**: Added `useEffect` to clear browser `?page` param when input URL has `?p` param, ensuring correct page navigation.

## Test Plan

1. Enter `https://www.bilibili.com/video/BV1WTnozqEd3?p=159` → page 16, part 159 selected ✓
2. Manually navigate to page 1 (confirm dialog OK)
3. Enter `https://www.bilibili.com/video/BV1WTnozqEd3?p=158` → **page 16, part 158 selected** ✓

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

No existing issue. This fixes a bug discovered during testing.