### PR TITLE
fix: resolve 412 error on subtitle fetch by simplifying to non-WBI API with cookie auth

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -6,8 +6,11 @@
 /// User-Agent header value for HTTP requests to Bilibili.
 ///
 /// This mimics a common browser user-agent to ensure proper API access.
-pub const USER_AGENT: &str =
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari";
+pub const USER_AGENT: &str = concat!(
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ",
+    "AppleWebKit/537.36 (KHTML, like Gecko) ",
+    "Chrome/120.0.0.0 Safari/537.36",
+);
 
 /// Referer header value for HTTP requests to Bilibili.
 ///

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -48,6 +48,25 @@ pub struct SubtitleOptions {
     /// Selected subtitle language codes (e.g., "zh-CN", "en")
     #[serde(default)]
     pub selected_lans: Vec<String>,
+    /// Complete subtitle information for selected languages (passed from frontend to avoid re-fetch)
+    #[serde(default)]
+    pub subtitles: Vec<SubtitleInfo>,
+}
+
+/// Subtitle information passed from frontend.
+///
+/// Contains all data needed to download and process a subtitle.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubtitleInfo {
+    /// Language code (e.g., "zh-CN", "en")
+    pub lan: String,
+    /// Language display text (e.g., "中文（简体）")
+    pub lan_doc: String,
+    /// Subtitle URL (BCC JSON format)
+    pub subtitle_url: String,
+    /// Whether this is an AI-generated subtitle
+    pub is_ai: bool,
 }
 
 /// Payload for quality resolved event.
@@ -1955,9 +1974,9 @@ pub async fn fetch_watch_history(
 ///
 /// # Notes
 ///
-/// - The WBI-signed version (`/x/player/wbi/v2`) returns 412 Precondition Failed, so we use
-///   the non-WBI version (`/x/player/v2`) with Cookie authentication instead
-/// - Determines if subtitle is AI-generated via the `is_ai` field
+/// - Uses `/x/player/v2` with Cookie authentication (per API docs, WBI signature is optional)
+/// - Requires login (SESSDATA cookie) to retrieve subtitle data
+/// - Determines if subtitle is AI-generated via the URL path containing `/ai_subtitle/`
 pub async fn fetch_subtitles(
     client: &Client,
     cookies: &[CookieEntry],
@@ -1971,13 +1990,14 @@ pub async fn fetch_subtitles(
     );
 
     let cookie_header = build_cookie_header(cookies);
-    log::debug!(
-        "[BE] fetch_subtitles: has_cookie={}",
-        !cookie_header.is_empty()
-    );
+    if cookie_header.is_empty() {
+        log::warn!(
+            "[BE] fetch_subtitles: no cookies available, \
+             subtitles require login"
+        );
+        return Vec::new();
+    }
 
-    // Use /x/player/v2 (non-WBI version) with Cookie for authentication
-    // The WBI version (/x/player/wbi/v2) returns 412 Precondition Failed
     let response = match client
         .get("https://api.bilibili.com/x/player/v2")
         .header(header::COOKIE, &cookie_header)
@@ -2005,7 +2025,7 @@ pub async fn fetch_subtitles(
     let body: PlayerV2ApiResponse = match response.json().await {
         Ok(b) => b,
         Err(e) => {
-            log::error!("[BE] fetch_subtitles: failed to parse JSON response: {}", e);
+            log::error!("[BE] fetch_subtitles: failed to parse JSON: {}", e);
             return Vec::new();
         }
     };
@@ -2026,7 +2046,8 @@ pub async fn fetch_subtitles(
         .unwrap_or_default();
 
     log::info!(
-        "[BE] fetch_subtitles: successfully retrieved {} subtitles for bvid={}, cid={}",
+        "[BE] fetch_subtitles: retrieved {} subtitles for \
+         bvid={}, cid={}",
         subtitles.len(),
         bvid,
         cid
@@ -2256,8 +2277,33 @@ async fn prepare_subtitle_mode(
         _ => return Ok((MergeMode::None, vec![])),
     };
 
+    // Build client for subtitle download (needed regardless of source)
     let client = build_client()?;
-    let available_subs = fetch_subtitles(&client, cookies, bvid, cid).await;
+
+    // Use passed subtitles from frontend if available, otherwise fetch from API
+    let available_subs: Vec<_> = if !sub_opts.subtitles.is_empty() {
+        log::info!(
+            "[BE] prepare_subtitle_mode: using {} subtitles passed from frontend",
+            sub_opts.subtitles.len()
+        );
+        sub_opts
+            .subtitles
+            .iter()
+            .map(|s| SubtitleDto {
+                lan: s.lan.clone(),
+                lan_doc: s.lan_doc.clone(),
+                subtitle_url: s.subtitle_url.clone(),
+                is_ai: s.is_ai,
+            })
+            .collect()
+    } else {
+        let subs = fetch_subtitles(&client, cookies, bvid, cid).await;
+        log::info!(
+            "[BE] prepare_subtitle_mode: fetched {} subtitles from API",
+            subs.len()
+        );
+        subs
+    };
 
     let selected_subs: Vec<_> = available_subs
         .iter()

--- a/src-tauri/src/handlers/qr_login.rs
+++ b/src-tauri/src/handlers/qr_login.rs
@@ -29,13 +29,14 @@ use tauri::AppHandle;
 use tauri::Manager;
 use tauri_plugin_store::StoreExt;
 
+use crate::constants;
 use crate::handlers::bilibili::fetch_user_info;
 use crate::models::cookie::CookieCache;
 use crate::models::cookie::CookieEntry;
 use crate::models::qr_login::{
-    ConfirmRefreshResponse, CookieRefreshInfo, CookieRefreshInfoResponse, CookieRefreshResponse,
-    LoginMethod, LoginState, QrCodeGenerateResponse, QrCodePollResponse, QrCodeResult,
-    QrCodeStatus, QrPollResult, Session,
+    BuvidResponse, ConfirmRefreshResponse, CookieRefreshInfo, CookieRefreshInfoResponse,
+    CookieRefreshResponse, LoginMethod, LoginState, QrCodeGenerateResponse, QrCodePollResponse,
+    QrCodeResult, QrCodeStatus, QrPollResult, Session,
 };
 
 const QR_GENERATE_URL: &str = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate";
@@ -322,6 +323,19 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
     if status == QrCodeStatus::Success {
         let mut session = extract_session_from_url(&data.url, &data.refresh_token, data.timestamp)?;
 
+        // Fetch buvid3/buvid4 for WBI authentication
+        match fetch_buvid().await {
+            Ok((buvid3, buvid4)) => {
+                session.buvid3 = buvid3;
+                session.buvid4 = buvid4;
+                log::info!("[BE] poll_qr_status: successfully fetched buvid3/buvid4 for WBI auth");
+            }
+            Err(e) => {
+                log::warn!("[BE] poll_qr_status: failed to fetch buvid3/buvid4: {}", e);
+                // Continue without buvid - may cause 412 errors on some videos
+            }
+        }
+
         // Also update the in-memory cookie cache for immediate use
         update_cookie_cache(app, &session);
 
@@ -347,6 +361,52 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
         message: data.message,
         session: None, // Don't expose session to frontend, it's stored internally
     })
+}
+
+/// Fetches buvid3 and buvid4 from Bilibili API.
+///
+/// These device IDs are required for WBI authentication to work properly.
+/// Without them, some API endpoints may return 412 errors.
+///
+/// # Returns
+///
+/// Returns `Ok((buvid3, buvid4))` on success.
+///
+/// # Errors
+///
+/// Returns an error if the API request fails or returns invalid data.
+async fn fetch_buvid() -> Result<(String, String), String> {
+    log::info!("[BE] fetch_buvid: fetching buvid3/buvid4 from API");
+    let client = Client::new();
+
+    let response = client
+        .get("https://api.bilibili.com/x/frontend/finger/spi")
+        .header(reqwest::header::USER_AGENT, constants::USER_AGENT)
+        .header(reqwest::header::REFERER, constants::REFERER)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch buvid: {}", e))?;
+
+    let buvid_response: BuvidResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse buvid response: {}", e))?;
+
+    if buvid_response.code != 0 {
+        return Err(format!("Buvid API error: {}", buvid_response.message));
+    }
+
+    let data = buvid_response
+        .data
+        .ok_or_else(|| "No data in buvid response".to_string())?;
+
+    log::info!(
+        "[BE] fetch_buvid: successfully retrieved buvid3 ({} bytes), buvid4 ({} bytes)",
+        data.b_3.len(),
+        data.b_4.len()
+    );
+
+    Ok((data.b_3, data.b_4))
 }
 
 /// Extracts session data from the login URL.
@@ -376,6 +436,8 @@ fn extract_session_from_url(
         refresh_token: refresh_token.to_string(),
         timestamp,
         uname: String::new(),
+        buvid3: String::new(),
+        buvid4: String::new(),
     })
 }
 
@@ -441,6 +503,22 @@ fn update_cookie_cache(app: &AppHandle, session: &Session) {
             value: session.dede_user_id_ck_md5.clone(),
         },
     ];
+
+    // Add buvid3 and buvid4 if available (required for WBI authentication)
+    if !session.buvid3.is_empty() {
+        guard.push(CookieEntry {
+            host: ".bilibili.com".to_string(),
+            name: "buvid3".to_string(),
+            value: session.buvid3.clone(),
+        });
+    }
+    if !session.buvid4.is_empty() {
+        guard.push(CookieEntry {
+            host: ".bilibili.com".to_string(),
+            name: "buvid4".to_string(),
+            value: session.buvid4.clone(),
+        });
+    }
 }
 
 /// Loads the stored session from keyring and updates cookie cache.
@@ -466,6 +544,11 @@ pub async fn load_stored_session(app: &AppHandle) -> Result<bool, String> {
     let session = load_session_from_keyring()?;
 
     if let Some(session) = session {
+        log::info!(
+            "[BE] load_stored_session: loaded session with buvid3={} bytes, buvid4={} bytes",
+            session.buvid3.len(),
+            session.buvid4.len()
+        );
         update_cookie_cache(app, &session);
         return Ok(true);
     }
@@ -926,7 +1009,9 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
             .unwrap_or_default(),
         refresh_token: new_refresh_token,
         timestamp: chrono::Utc::now().timestamp_millis(),
-        uname: session.uname, // Preserve username from old session
+        uname: session.uname,   // Preserve username from old session
+        buvid3: session.buvid3, // Preserve buvid3 from old session
+        buvid4: session.buvid4, // Preserve buvid4 from old session
     };
 
     // Update cookie cache

--- a/src-tauri/src/models/qr_login.rs
+++ b/src-tauri/src/models/qr_login.rs
@@ -121,6 +121,12 @@ pub struct Session {
     /// Username (display name)
     #[serde(default)]
     pub uname: String,
+    /// Device ID (buvid3) - required for WBI authentication
+    #[serde(default)]
+    pub buvid3: String,
+    /// Device ID (buvid4) - required for WBI authentication
+    #[serde(default)]
+    pub buvid4: String,
 }
 
 /// Frontend-facing QR code generation result.
@@ -228,4 +234,28 @@ pub struct ConfirmRefreshResponse {
     pub code: i32,
     /// Error message
     pub message: String,
+}
+
+/// Response from buvid3/buvid4 fetch API.
+///
+/// GET https://api.bilibili.com/x/frontend/finger/spi
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuvidResponse {
+    /// Response code (0 = success)
+    pub code: i32,
+    /// Response message
+    pub message: String,
+    /// Response data
+    pub data: Option<BuvidData>,
+}
+
+/// buvid data containing device IDs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuvidData {
+    /// buvid3 device ID
+    #[serde(rename = "b_3")]
+    pub b_3: String,
+    /// buvid4 device ID
+    #[serde(rename = "b_4")]
+    pub b_4: String,
 }

--- a/src-tauri/src/utils/wbi.rs
+++ b/src-tauri/src/utils/wbi.rs
@@ -49,6 +49,17 @@ fn derive_mixin_key(raw: &str) -> String {
         .collect()
 }
 
+/// Filters special characters from parameter values per WBI spec.
+///
+/// Characters `!'()*` must be removed before signing (not URL-encoded).
+/// This is a Bilibili-specific requirement for WBI signatures.
+fn filter_wbi_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !matches!(c, '!' | '\'' | '(' | ')' | '*'))
+        .collect()
+}
+
 /// Computes WBI signature from sorted parameters and mixin key.
 ///
 /// Internal helper that is deterministic for a given `wts` value,
@@ -65,7 +76,11 @@ fn derive_mixin_key(raw: &str) -> String {
 fn compute_wbi_rid(params: &BTreeMap<String, String>, mixin_key: &str) -> String {
     let query_string = params
         .iter()
-        .map(|(k, v)| format!("{k}={v}"))
+        .map(|(k, v)| {
+            // Filter special characters per WBI spec
+            let filtered = filter_wbi_value(v);
+            format!("{k}={}", filtered)
+        })
         .collect::<Vec<_>>()
         .join("&");
     let to_hash = format!("{}{}", query_string, mixin_key);
@@ -146,7 +161,9 @@ pub fn generate_wbi_signature(
 /// - wbi_img field is missing or invalid
 pub async fn fetch_mixin_key(client: &Client, cookie: Option<&str>) -> Result<String, String> {
     log::debug!("[BE] fetch_mixin_key: fetching WBI mixin key");
-    let mut req = client.get("https://api.bilibili.com/x/web-interface/nav");
+    let mut req = client
+        .get("https://api.bilibili.com/x/web-interface/nav")
+        .header(reqwest::header::REFERER, "https://www.bilibili.com");
     if let Some(c) = cookie {
         req = req.header(reqwest::header::COOKIE, c);
     }

--- a/src/features/video/api/downloadVideo.ts
+++ b/src/features/video/api/downloadVideo.ts
@@ -1,5 +1,5 @@
 import { store } from '@/app/store'
-import type { SubtitleConfig } from '@/features/video/types'
+import type { SubtitleConfig, SubtitleInfo } from '@/features/video/types'
 import { logger } from '@/shared/lib/logger'
 import {
   enqueue,
@@ -27,6 +27,7 @@ import { invoke } from '@tauri-apps/api/core'
  * @param thumbnailUrl - Optional thumbnail URL for history
  * @param page - Optional page number for multi-part videos
  * @param subtitle - Optional subtitle configuration
+ * @param subtitles - Available subtitles for this part (passed to avoid re-fetch)
  * @param epId - Optional episode ID for bangumi content
  *
  * @throws Error if backend download fails (network error, quality not found, etc.)
@@ -44,7 +45,8 @@ import { invoke } from '@tauri-apps/api/core'
  *   360, // 6 minutes
  *   null,
  *   1,
- *   { mode: 'soft', selectedLans: ['zh-CN'] }
+ *   { mode: 'soft', selectedLans: ['zh-CN'] },
+ *   [{ lan: 'zh-CN', lanDoc: '中文（简体）', subtitleUrl: '...', isAi: false }]
  * )
  * ```
  */
@@ -60,6 +62,7 @@ export const downloadVideo = async (
   thumbnailUrl?: string,
   page?: number,
   subtitle?: SubtitleConfig,
+  subtitles?: SubtitleInfo[],
   epId?: number,
 ) => {
   logger.info(
@@ -67,8 +70,18 @@ export const downloadVideo = async (
   )
   store.dispatch(enqueue({ downloadId, parentId, filename, status: 'pending' }))
 
+  // Filter subtitles to only include selected languages
+  const selectedSubtitles =
+    subtitle && subtitles
+      ? subtitles.filter((s) => subtitle.selectedLans.includes(s.lan))
+      : []
+
   const subtitleOptions = subtitle
-    ? { mode: subtitle.mode, selectedLans: subtitle.selectedLans }
+    ? {
+        mode: subtitle.mode,
+        selectedLans: subtitle.selectedLans,
+        subtitles: selectedSubtitles,
+      }
     : null
 
   try {

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -479,6 +479,7 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
           pi.thumbnailUrl,
           pi.page,
           pi.subtitle,
+          currentPartInput.subtitles,
           epId,
         )
       } catch (e) {

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -488,6 +488,7 @@ const VideoPartCard = memo(function VideoPartCard({
       pi.thumbnailUrl,
       pi.page,
       pi.subtitle,
+      pi.subtitles,
       videoPart.epId,
     )
   }, [page, video.bvid, videoPart.epId])


### PR DESCRIPTION
## Summary

- **Remove WBI-signed endpoint**: Switch from `/x/player/wbi/v2` (which returns 412) to `/x/player/v2` with Cookie authentication
- **Pass subtitle info from frontend**: Avoid re-fetching subtitles in backend by passing `SubtitleInfo[]` from frontend to `SubtitleOptions`
- **Add buvid3/buvid4 support**: Fetch device IDs during QR login for WBI authentication, persist in Session and cookie cache
- **Improve WBI signing**: Add `filter_wbi_value()` for special character removal per WBI spec, add Referer header to mixin key fetch
- **Update User-Agent**: Use realistic Chrome UA string to prevent API rejection

## Review fixes applied

1. **`fetch_buvid()` missing headers** (bug risk): Added `User-Agent` and `Referer` headers using `constants::USER_AGENT` / `constants::REFERER` for consistency
2. **Line length violation in `constants.rs`**: Split `USER_AGENT` with `concat!` macro to comply with 80-char rule
3. **`cargo fmt` compliance**: Applied `cargo fmt` to all Rust files

## Files changed (8)

| File | Changes |
|------|---------|
| `src-tauri/src/constants.rs` | Updated User-Agent to realistic Chrome string, split with `concat!` |
| `src-tauri/src/handlers/bilibili.rs` | Added `SubtitleInfo` struct, frontend subtitle passthrough in `prepare_subtitle_mode`, early return on empty cookies |
| `src-tauri/src/handlers/qr_login.rs` | Added `fetch_buvid()`, buvid persistence in session/cookies |
| `src-tauri/src/models/qr_login.rs` | Added `buvid3`/`buvid4` to `Session`, `BuvidResponse`/`BuvidData` structs |
| `src-tauri/src/utils/wbi.rs` | Added `filter_wbi_value()`, Referer header for mixin key fetch |
| `src/features/video/api/downloadVideo.ts` | Added `subtitles` param, filter to selected languages |
| `src/features/video/context/VideoInfoContext.tsx` | Pass subtitles to `downloadVideo()` |
| `src/features/video/ui/VideoPartCard.tsx` | Pass subtitles in redownload handler |