### PR TITLE
🚀 Release v1.27.2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release v1.27.2 — Patch release with bug fixes for AI subtitle fetching stability.

## Related Issue

closes #317

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Changes

### Bug Fixes
- **Subtitle retry logic**: Add `fetch_subtitles_with_retry()` to handle stale CDN cache responses that return only 1 AI subtitle instead of the full set of 6 languages (#317)
- **Log level restoration**: Restore original `log::info!` levels in `fetch_subtitles()` that were inadvertently downgraded to `log::debug!` during debugging

### Version Bump
- **Previous**: v1.27.1
- **Next**: v1.27.2
- **Type**: patch

## Test Plan

- [x] Manually tested with `BV1WHfLB8Esn` — subtitles consistently return all 6 languages
- [x] `cargo build` / `cargo fmt` / `cargo clippy` all pass

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)