### PR TITLE
feat(watch-history): exclude live stream entries by bvid check

### DIFF
--- a/src/features/watch-history/model/selectors.test.ts
+++ b/src/features/watch-history/model/selectors.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { WatchHistoryEntry, WatchHistoryState } from '../types'
+import { selectFilteredEntries } from './selectors'
+
+/** Minimal RootState shape needed to test watch history selectors. */
+type MinimalState = { watchHistory: WatchHistoryState }
+
+/**
+ * Creates a minimal Redux state object for watch history selector tests.
+ *
+ * @param entries - Watch history entries to include in state
+ * @param overrides - Optional partial state overrides
+ * @returns Minimal state object
+ */
+const makeState = (
+  entries: WatchHistoryEntry[],
+  overrides: Partial<WatchHistoryState> = {},
+): MinimalState => ({
+  watchHistory: {
+    entries,
+    cursor: null,
+    loading: false,
+    loadingMore: false,
+    error: null,
+    searchQuery: '',
+    dateFilter: 'all',
+    ...overrides,
+  },
+})
+
+/**
+ * Creates a watch history entry with sensible defaults for testing.
+ *
+ * @param overrides - Optional partial entry overrides
+ * @returns A complete WatchHistoryEntry object
+ */
+const makeEntry = (
+  overrides: Partial<WatchHistoryEntry> = {},
+): WatchHistoryEntry => ({
+  title: 'Test Video',
+  cover: 'https://example.com/cover.jpg',
+  bvid: 'BV1xx411c7XD',
+  cid: 123,
+  page: 1,
+  viewAt: Math.floor(Date.now() / 1000),
+  duration: 300,
+  progress: 60,
+  url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+  ...overrides,
+})
+
+describe('selectFilteredEntries', () => {
+  describe('live stream filtering', () => {
+    it('excludes entries with empty bvid (live streams)', () => {
+      const liveEntry = makeEntry({
+        bvid: '',
+        url: 'https://www.bilibili.com/video/',
+      })
+      const state = makeState([liveEntry])
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('includes entries with a non-empty bvid (VOD)', () => {
+      const videoEntry = makeEntry({
+        bvid: 'BV1xx411c7XD',
+        url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+      })
+      const state = makeState([videoEntry])
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].bvid).toBe('BV1xx411c7XD')
+    })
+
+    it('filters out only live entries when mixed with video entries', () => {
+      const liveEntry = makeEntry({
+        title: 'Live Stream',
+        bvid: '',
+        url: 'https://www.bilibili.com/video/',
+      })
+      const videoEntry = makeEntry({
+        title: 'Normal Video',
+        bvid: 'BV1xx411c7XD',
+        url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+      })
+      const state = makeState([liveEntry, videoEntry])
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('Normal Video')
+    })
+
+    it('does not exclude entries with any non-empty bvid value', () => {
+      const entry = makeEntry({ bvid: 'BV_any_value' })
+      const state = makeState([entry])
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  describe('search query filtering', () => {
+    it('filters entries by title (case-insensitive)', () => {
+      const entries = [
+        makeEntry({ title: 'Rust Tutorial' }),
+        makeEntry({ title: 'TypeScript Guide' }),
+      ]
+      const state = makeState(entries, { searchQuery: 'rust' })
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('Rust Tutorial')
+    })
+
+    it('returns all non-live entries when search query is empty', () => {
+      const entries = [
+        makeEntry({ title: 'Video A' }),
+        makeEntry({ title: 'Video B' }),
+      ]
+      const state = makeState(entries, { searchQuery: '' })
+
+      const result = selectFilteredEntries(state as never)
+
+      expect(result).toHaveLength(2)
+    })
+  })
+})

--- a/src/features/watch-history/model/selectors.ts
+++ b/src/features/watch-history/model/selectors.ts
@@ -94,10 +94,21 @@ const isWithinDateRange = (
 }
 
 /**
+ * Checks whether the given entry is a Bilibili live stream.
+ *
+ * Live stream entries have an empty `bvid` because they are not
+ * VOD content and cannot be downloaded. They should be excluded
+ * from watch history by default.
+ */
+const isLiveEntry = (entry: WatchHistoryEntry): boolean => !entry.bvid
+
+/**
  * Memoized selector for filtered watch history entries.
  *
- * Applies search query and date filter to the entries list.
- * Search matches against video title (case-insensitive).
+ * Applies the following filters in order:
+ * 1. Excludes live stream entries (empty bvid) by default
+ * 2. Applies date range filter
+ * 3. Applies search query filter (case-insensitive title match)
  *
  * @returns Filtered array of watch history entries
  */
@@ -105,6 +116,11 @@ export const selectFilteredEntries = createSelector(
   [selectWatchHistoryEntries, selectSearchQuery, selectDateFilter],
   (entries, searchQuery, dateFilter): WatchHistoryEntry[] => {
     return entries.filter((entry) => {
+      // Exclude live stream entries (bvid is empty for live streams)
+      if (isLiveEntry(entry)) {
+        return false
+      }
+
       // Apply date filter
       if (!isWithinDateRange(entry.viewAt, dateFilter)) {
         return false


### PR DESCRIPTION
## Summary

Exclude live stream entries from the watch history view by default.
Live stream entries have an empty `bvid` (they are not VOD content and
cannot be downloaded), so `selectFilteredEntries` now uses an
`isLiveEntry` helper that returns `true` when `entry.bvid` is empty.

## Related Issue

closes #322

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] Unit tests added for `selectFilteredEntries` covering:
  - Entries with empty `bvid` are excluded
  - Entries with non-empty `bvid` are included
  - Mixed entries: only live entries are filtered out
  - Search query filtering still works correctly
- [x] `npx vitest run` — 6 tests pass

## Screenshots / Videos (Optional)

N/A (no UI changes)

## Breaking Changes

None. Existing VOD entries (non-empty `bvid`) are unaffected.

## Implementation Note

Issue #322 proposed filtering by `entry.url.includes('live.bilibili.com')`.
However, investigation of the backend code (`src-tauri/src/handlers/bilibili.rs`)
revealed that the URL is **always** generated in the form
`https://www.bilibili.com/video/{bvid}` — a `live.bilibili.com` URL is
never stored in the history entry.

The actual distinguishing trait of live stream entries is that their
`bvid` field is an empty string. The `isLiveEntry` helper therefore
checks `!entry.bvid`, which is both more accurate and simpler than a
URL prefix check.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated
- [x] i18n files synced (N/A — no user-facing text changes)