### PR TITLE
feat(subtitle): replace sequential retry with parallel requests

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -169,7 +169,7 @@ use reqwest::header;
 use reqwest::Client;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
 
 /// Builds a reqwest HTTP client with the default user agent.
@@ -2064,6 +2064,7 @@ pub async fn fetch_subtitles(
                 lan_doc: item.lan_doc,
                 subtitle_url: item.subtitle_url,
                 is_ai,
+                ai_type: item.ai_type,
             }
         })
         .collect()
@@ -2084,7 +2085,7 @@ pub async fn fetch_subtitles(
 /// Returns a list of available subtitles with language info and URLs.
 /// Returns an empty vector if no subtitles are available or on error.
 ///
-/// Retry behavior is handled by [`fetch_subtitles_with_retry`].
+/// Stale CDN mitigation is handled by [`fetch_subtitles_parallel`].
 pub async fn fetch_subtitles_for_part(
     app: &AppHandle,
     bvid: &str,
@@ -2098,7 +2099,7 @@ pub async fn fetch_subtitles_for_part(
     );
     let cookies = read_cookie(app)?.unwrap_or_default();
     let client = build_client()?;
-    let subtitles = fetch_subtitles_with_retry(&client, &cookies, bvid, cid).await;
+    let subtitles = fetch_subtitles_parallel(&client, &cookies, bvid, cid).await;
 
     log::info!(
         "[BE] fetch_subtitles_for_part: received {} subtitles",
@@ -2107,13 +2108,15 @@ pub async fn fetch_subtitles_for_part(
     Ok(subtitles)
 }
 
-/// Fetches subtitles with automatic retry for stale CDN responses.
+/// Fetches subtitles using parallel requests to mitigate stale CDN responses.
 ///
 /// Bilibili's CDN may serve stale cached responses that only include
 /// a single AI subtitle (`ai_type: 0`) instead of the full set of
-/// AI-translated subtitles (`ai_type: 1`). When a stale response is
-/// detected (exactly one AI subtitle returned), this function retries
-/// up to 2 additional times with a 1-second delay between attempts.
+/// AI-translated subtitles (`ai_type: 1`). Rather than retrying
+/// sequentially, this function fires [`PARALLEL_COUNT`] requests
+/// concurrently with a small jitter between them to increase the
+/// chance of hitting a fresh CDN node. The response with the greatest
+/// number of subtitles is returned as the best result.
 ///
 /// # Arguments
 ///
@@ -2124,56 +2127,44 @@ pub async fn fetch_subtitles_for_part(
 ///
 /// # Returns
 ///
-/// Returns a list of available subtitles. May return the stale
-/// single-AI-subtitle response if all retries are exhausted.
-async fn fetch_subtitles_with_retry(
+/// Returns the subtitle list with the most entries across all parallel
+/// attempts. Returns an empty list if all requests fail.
+async fn fetch_subtitles_parallel(
     client: &Client,
     cookies: &[CookieEntry],
     bvid: &str,
     cid: i64,
 ) -> Vec<SubtitleDto> {
-    const MAX_RETRIES: u32 = 2;
-    const RETRY_DELAY_MS: u64 = 1000;
+    const PARALLEL_COUNT: usize = 3;
+    const JITTER_STEP_MS: u64 = 200;
 
-    let mut subtitles = fetch_subtitles(client, cookies, bvid, cid).await;
+    let futures: Vec<_> = (0..PARALLEL_COUNT)
+        .map(|i| {
+            let jitter_ms = (i as u64) * JITTER_STEP_MS;
+            async move {
+                if jitter_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                }
+                fetch_subtitles(client, cookies, bvid, cid).await
+            }
+        })
+        .collect();
 
-    for attempt in 1..=MAX_RETRIES {
-        if !should_retry_subtitles(&subtitles) {
-            break;
-        }
-        log::info!(
-            "[BE] fetch_subtitles_with_retry: stale cache \
-             detected, retry {}/{}",
-            attempt,
-            MAX_RETRIES
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
-        subtitles = fetch_subtitles(client, cookies, bvid, cid).await;
-    }
+    let results = futures::future::join_all(futures).await;
 
-    subtitles
+    log::info!(
+        "[BE] fetch_subtitles_parallel: got {} results for \
+         bvid={}, cid={}",
+        results.iter().map(|r| r.len()).sum::<usize>(),
+        bvid,
+        cid,
+    );
+
+    results
+        .into_iter()
+        .max_by_key(|subtitles| subtitles.len())
+        .unwrap_or_default()
 }
-
-/// Determines whether subtitle fetching should be retried.
-///
-/// Returns `true` if the response appears to be from a stale
-/// CDN cache — specifically when exactly one AI subtitle is
-/// present, which indicates the old `ai_type: 0` response
-/// rather than the full AI-translated set.
-///
-/// # Arguments
-///
-/// * `subtitles` - Subtitle list from the most recent fetch attempt
-///
-/// # Returns
-///
-/// Returns `true` if the response looks stale and should be retried.
-fn should_retry_subtitles(subtitles: &[SubtitleDto]) -> bool {
-    // Stale cache returns exactly 1 AI subtitle;
-    // fresh cache returns 0 (no AI) or multiple.
-    subtitles.iter().filter(|s| s.is_ai).count() == 1
-}
-
 /// Fetches available video and audio qualities for a specific part.
 ///
 /// Used for lazy loading when parts are rendered in the UI
@@ -2367,10 +2358,11 @@ async fn prepare_subtitle_mode(
                 lan_doc: s.lan_doc.clone(),
                 subtitle_url: s.subtitle_url.clone(),
                 is_ai: s.is_ai,
+                ai_type: None,
             })
             .collect()
     } else {
-        let subs = fetch_subtitles_with_retry(&client, cookies, bvid, cid).await;
+        let subs = fetch_subtitles_parallel(&client, cookies, bvid, cid).await;
         log::info!(
             "[BE] prepare_subtitle_mode: fetched {} subtitles from API",
             subs.len()

--- a/src-tauri/src/models/bilibili_api.rs
+++ b/src-tauri/src/models/bilibili_api.rs
@@ -382,6 +382,10 @@ pub struct PlayerV2SubtitleItem {
     pub lan_doc: String,
     /// Subtitle URL (BCC JSON format)
     pub subtitle_url: String,
+    /// AI subtitle type: 0 = legacy AI subtitle, 1 = translated AI subtitle.
+    /// Absent for manually created subtitles.
+    #[serde(default)]
+    pub ai_type: Option<u8>,
 }
 
 /// BCC (Bilibili Closed Caption) format subtitle data.

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -223,4 +223,7 @@ pub struct SubtitleDto {
     pub subtitle_url: String,
     /// Whether this is an AI-generated subtitle
     pub is_ai: bool,
+    /// AI subtitle type: 0 = legacy AI subtitle, 1 = translated AI subtitle.
+    /// None for manually created subtitles.
+    pub ai_type: Option<u8>,
 }

--- a/src/features/video/types.ts
+++ b/src/features/video/types.ts
@@ -166,6 +166,11 @@ export type SubtitleInfo = {
   subtitleUrl: string
   /** Whether this is an AI-generated subtitle */
   isAi: boolean
+  /**
+   * AI subtitle type: 0 = legacy AI subtitle, 1 = translated AI subtitle.
+   * Undefined for manually created subtitles.
+   */
+  aiType?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Replace the sequential subtitle retry logic (`fetch_subtitles_with_retry`) with a parallel approach (`fetch_subtitles_parallel`) to more reliably mitigate stale CDN cache responses from Bilibili.

**Before:** Fire 1 request, detect stale response (exactly 1 AI subtitle), retry up to 2 more times sequentially with 1s delay each — total worst-case wait: 2s, still fails if the same CDN node is hit.

**After:** Fire 3 requests concurrently with 200ms jitter steps (0ms / 200ms / 400ms), pick the response with the most subtitles — stale detection heuristic is eliminated entirely and worst-case wait is reduced.

Also propagates `ai_type` field (`0` = legacy AI subtitle, `1` = translated AI subtitle) through `PlayerV2SubtitleItem` → `SubtitleDto` → `SubtitleInfo` TypeScript type.

## Related Issue

Closes #324

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [ ] Open a video with AI subtitles on a slow/stale CDN connection
- [ ] Verify subtitle list loads correctly (multiple AI-translated subtitles appear)
- [ ] Confirm no regression for videos with no subtitles (returns empty list)
- [ ] Confirm no regression for videos with only manually-created subtitles

## Breaking Changes

None. `SubtitleInfo.aiType` is an optional field addition; existing consumers are unaffected.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — N/A (internal CDN mitigation logic)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A (no user-facing text changes)
