### PR TITLE
feat(ui): auto-scroll card top into view on accordion expand and subtitle mode change

### DIFF
--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -300,6 +300,26 @@ const VideoPartCard = memo(function VideoPartCard({
       ? { duration: 0 }
       : undefined
 
+  /** Ref attached to the card root for scroll-into-view on expand. */
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Scrolls the [data-part-list] container so this card's top is visible.
+   * Uses a timeout to allow the expand animation (350ms) to settle.
+   */
+  const scrollCardIntoView = useCallback(() => {
+    setTimeout(() => {
+      const container = document.querySelector('[data-part-list]')
+      const item = cardRef.current
+      if (!container || !item) return
+      const containerRect = container.getBoundingClientRect()
+      const itemRect = item.getBoundingClientRect()
+      const scrollOffset =
+        itemRect.top - containerRect.top + container.scrollTop - 8
+      container.scrollTo({ top: scrollOffset, behavior: 'smooth' })
+    }, 400)
+  }, [])
+
   /**
    * Fetches quality options for the current video part.
    */
@@ -362,7 +382,7 @@ const VideoPartCard = memo(function VideoPartCard({
   /**
    * Handles accordion open/close state changes.
    * Fetches qualities and subtitles in parallel when the accordion is
-   * opened for the first time.
+   * opened for the first time. Scrolls the card top into view on open.
    */
   const handleAccordionChange = useCallback(
     async (value: string[]) => {
@@ -371,6 +391,9 @@ const VideoPartCard = memo(function VideoPartCard({
       store.dispatch(setAccordionOpen({ index: partIndex, open: isOpen }))
 
       if (!isOpen) return
+
+      // Scroll card top into view after expand animation (350ms)
+      scrollCardIntoView()
 
       const isBangumi = video.contentType === 'bangumi'
       const epId = videoPart.epId
@@ -536,12 +559,17 @@ const VideoPartCard = memo(function VideoPartCard({
   /**
    * Handles subtitle configuration changes.
    * Dispatches the updated config to Redux store.
+   * Scrolls card into view when switching from off to soft/hard mode.
    */
   const handleSubtitleConfigChange = useCallback(
     (config: Parameters<typeof updateSubtitleConfig>[0]['config']) => {
+      const prevMode = subtitle?.mode ?? 'off'
       store.dispatch(updateSubtitleConfig({ index: page - 1, config }))
+      if (prevMode === 'off' && config.mode !== 'off') {
+        scrollCardIntoView()
+      }
     },
-    [page],
+    [page, subtitle?.mode, scrollCardIntoView],
   )
 
   const schema2 = useMemo(() => buildVideoFormSchema2(t), [t])
@@ -615,7 +643,7 @@ const VideoPartCard = memo(function VideoPartCard({
   )
 
   return (
-    <div className="p-3 md:p-4">
+    <div ref={cardRef} className="p-3 md:p-4">
       <Form {...form}>
         <fieldset
           disabled={


### PR DESCRIPTION
## Summary

Auto-scroll the `[data-part-list]` container so the card's top is visible whenever the user expands the accordion or switches subtitle mode from off to soft/hard.

- Extracted a shared `scrollCardIntoView()` callback that manually calculates the scroll offset on the `[data-part-list]` container (avoids scrolling the page/AppBar)
- Uses a 400ms timeout so the accordion expand animation (350ms) finishes before scrolling
- Ref (`cardRef`) is now attached to the card root `<div>`, so the scroll target is the card top, not the accordion content
- Added subtitle mode trigger: scrolls when switching from `off` → `soft`/`hard`

## Related Issue

closes #326

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] Run `npm run dev`
- [x] Load a multi-part video
- [x] Expand an accordion on a card that is partially off-screen → card top scrolls into view
- [x] Switch subtitle mode from off to soft/hard → card top scrolls into view

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — N/A (UI scroll behavior)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A (no new strings)