### PR TITLE
feat: enable Linux builds in CI/CD release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install dependencies (Ubuntu only)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev
 
       - name: Check Rust code
         working-directory: src-tauri
@@ -140,7 +140,7 @@ jobs:
       - name: Install dependencies (Ubuntu only)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev
 
       - name: Run Clippy
         working-directory: src-tauri
@@ -159,7 +159,7 @@ jobs:
       - name: Install dependencies (Ubuntu only)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev
 
       - name: Check Rust formatting
         working-directory: src-tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,8 @@ jobs:
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest' # Intel
             args: '--target x86_64-apple-darwin'
-          # Uncomment to enable Linux builds
-          # - platform: 'ubuntu-22.04'
-          #   args: ''
+          - platform: 'ubuntu-22.04'
+            args: ''
           - platform: 'windows-latest'
             args: ''
 
@@ -121,12 +120,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Uncomment to enable Linux builds
-      # - name: Install dependencies (Ubuntu only)
-      #   if: matrix.platform == 'ubuntu-22.04'
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Install dependencies (Ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev
 
       - name: Install frontend dependencies
         run: test -f package-lock.json && npm ci || npm install
@@ -180,6 +178,8 @@ jobs:
               { match: `_${version}_aarch64.dmg`, fixedName: 'bilibili-downloader-gui_macOS_arm64.dmg' },
               { match: `_${version}_x64.dmg`, fixedName: 'bilibili-downloader-gui_macOS_x64.dmg' },
               { match: `_${version}_x64-setup.exe`, fixedName: 'bilibili-downloader-gui_Windows_x64-setup.exe' },
+              { match: `_${version}_amd64.deb`, fixedName: 'bilibili-downloader-gui_Linux_x64.deb' },
+              { match: `_${version}_amd64.AppImage.tar.gz`, fixedName: 'bilibili-downloader-gui_Linux_x64.AppImage.tar.gz' },
             ];
 
             // Remove old fixed-name assets if they exist from a previous run

--- a/README.es.md
+++ b/README.es.md
@@ -58,7 +58,7 @@ Sin anuncios, sin seguimiento. 100% gratis.
 
 ## Instalación
 
-|        Plataforma         |                                                                                       Descarga                                                                                       |
+| Plataforma                | Descarga                                                                                                                                                                             |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |

--- a/README.es.md
+++ b/README.es.md
@@ -8,13 +8,14 @@
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Descargador de videos de Bilibili para Windows y macOS
+## Descargador de videos de Bilibili para Windows, macOS y Linux
 
 Sin anuncios, sin seguimiento. 100% gratis.
 
@@ -57,11 +58,13 @@ Sin anuncios, sin seguimiento. 100% gratis.
 
 ## Instalación
 
-| Plataforma                | Descarga                                                                                                                                                                     |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+|        Plataforma         |                                                                                       Descarga                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > Las compilaciones de macOS no están firmadas. En el primer inicio, ejecuta:

--- a/README.fr.md
+++ b/README.fr.md
@@ -8,13 +8,14 @@
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Téléchargeur de vidéos Bilibili pour Windows et macOS
+## Téléchargeur de vidéos Bilibili pour Windows, macOS et Linux
 
 Pas de publicités, pas de suivi. 100 % gratuit.
 
@@ -57,11 +58,13 @@ Pas de publicités, pas de suivi. 100 % gratuit.
 
 ## Installation
 
-| Plateforme                | Téléchargement                                                                                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+|        Plateforme         |                                                                                    Téléchargement                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > Les builds macOS ne sont pas signés. Au premier lancement, exécutez :

--- a/README.fr.md
+++ b/README.fr.md
@@ -58,7 +58,7 @@ Pas de publicités, pas de suivi. 100 % gratuit.
 
 ## Installation
 
-|        Plateforme         |                                                                                    Téléchargement                                                                                    |
+| Plateforme                | Téléchargement                                                                                                                                                                       |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |

--- a/README.ja.md
+++ b/README.ja.md
@@ -58,7 +58,7 @@
 
 ## インストール
 
-|     プラットフォーム      |                                                                                     ダウンロード                                                                                     |
+| プラットフォーム          | ダウンロード                                                                                                                                                                         |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,13 +8,14 @@
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Windows/macOS対応のBilibili動画ダウンローダー
+## Windows/macOS/Linux対応のBilibili動画ダウンローダー
 
 広告なし、追跡なし。100%無料。
 
@@ -57,11 +58,13 @@
 
 ## インストール
 
-| プラットフォーム          | ダウンロード                                                                                                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+|     プラットフォーム      |                                                                                     ダウンロード                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > macOSビルドは署名されていません。初回起動時に以下を実行してください：

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,13 +8,14 @@
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Windows 및 macOS Bilibili 동영상 다운로더
+## Windows, macOS 및 Linux Bilibili 동영상 다운로더
 
 광고 없음, 추적 없음. 100% 무료.
 
@@ -57,11 +58,13 @@
 
 ## 설치
 
-| 플랫폼                    | 다운로드                                                                                                                                                                     |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+|          플랫폼           |                                                                                       다운로드                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > macOS 빌드는 서명되지 않았습니다. 첫 실행 시 다음을 실행하세요:

--- a/README.ko.md
+++ b/README.ko.md
@@ -58,7 +58,7 @@
 
 ## 설치
 
-|          플랫폼           |                                                                                       다운로드                                                                                       |
+| 플랫폼                    | 다운로드                                                                                                                                                                             |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ No ads, no tracking. 100% free.
 
 ## Installation
 
-| Platform                  | Download                                                                                                                                                                     |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
-| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                     |
+| Platform                  | Download                                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ English | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어]
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Windows and macOS Bilibili Video Downloader
+## Windows, macOS, and Linux Bilibili Video Downloader
 
 No ads, no tracking. 100% free.
 
@@ -62,6 +63,8 @@ No ads, no tracking. 100% free.
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
 | **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                     |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > macOS builds are not signed. On first launch, run:

--- a/README.zh.md
+++ b/README.zh.md
@@ -58,7 +58,7 @@
 
 ## 安装
 
-|           平台            |                                                                                         下载                                                                                         |
+| 平台                      | 下载                                                                                                                                                                                 |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
 | **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,13 +8,14 @@
 
 [![Windows](https://img.shields.io/badge/Windows-Supported-0078D6?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+V2luZG93cyAxMTwvdGl0bGU+PHBhdGggZmlsbD0iIzAwQTRFRiIgZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4=)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)
 [![macOS](https://img.shields.io/badge/macOS-Supported-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)
+[![Linux](https://img.shields.io/badge/Linux-Supported-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)
 [![Downloads](https://img.shields.io/github/downloads/j4rviscmd/bilibili-downloader-gui/total?style=for-the-badge&color=blue&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases)<br/>
 [![Latest Release](https://img.shields.io/github/v/release/j4rviscmd/bilibili-downloader-gui?style=for-the-badge&color=green&label=Latest&logo=github&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest)
 [![Last Commit](https://img.shields.io/github/last-commit/j4rviscmd/bilibili-downloader-gui/main?style=for-the-badge&color=1F6FEB&label=Last%20Update&logo=git&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/commits/main)
 [![CI](https://img.shields.io/github/actions/workflow/status/j4rviscmd/bilibili-downloader-gui/ci.yml?style=for-the-badge&label=CI&color=brightgreen&logo=githubactions&logoColor=white)](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-MIT-018FF5?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 
-## Windows 和 macOS Bilibili 视频下载器
+## Windows、macOS 和 Linux Bilibili 视频下载器
 
 无广告，无追踪。100% 免费。
 
@@ -57,11 +58,13 @@
 
 ## 安装
 
-| 平台                      | 下载                                                                                                                                                                         |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)             |
-| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                 |
-| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe) |
+|           平台            |                                                                                         下载                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS (Apple Silicon)** | [bilibili-downloader-gui_macOS_arm64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_arm64.dmg)                     |
+| **macOS (Intel)**         | [bilibili-downloader-gui_macOS_x64.dmg](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_macOS_x64.dmg)                         |
+| **Windows**               | [bilibili-downloader-gui_Windows_x64-setup.exe](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Windows_x64-setup.exe)         |
+| **Linux (deb)**           | [bilibili-downloader-gui_Linux_x64.deb](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.deb)                         |
+| **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
 > macOS 构建未签名。首次启动时运行：

--- a/docs/src/components/sections/Download.astro
+++ b/docs/src/components/sections/Download.astro
@@ -40,8 +40,8 @@ const platforms = [
   },
   {
     key: "linux",
-    href: "#",
-    disabled: true,
+    href: `${baseUrl}/bilibili-downloader-gui_Linux_x64.deb`,
+    disabled: false,
     svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="h-10 w-10"><rect width="20" height="14" x="2" y="3" rx="2" ry="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>`,
   },
 ];

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -18,25 +18,37 @@ use tauri::AppHandle;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
 
-/// 字幕オプション
+/// Options for embedding subtitles during video merging.
+///
+/// Used by [`merge_avs`] to specify subtitle file path, language code,
+/// and display title for each subtitle track.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubtitleMergeOptions {
-    /// 字幕ファイルのパス
+    /// Absolute path to the subtitle file (e.g., `.srt` or `.ass`).
     pub path: PathBuf,
-    /// 言語コード (ISO 639-2)
+    /// ISO 639-2 language code (e.g., `"eng"`, `"jpn"`, `"chi"`).
     pub language: String,
-    /// トラックタイトル（表示名）
+    /// Human-readable track title displayed in media players (e.g., `"English"`).
     pub title: String,
 }
 
-/// マージモード
+/// Specifies how subtitles should be merged into the output video.
+///
+/// This enum controls the subtitle handling strategy during the ffmpeg merge
+/// process performed by [`merge_avs`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum MergeMode {
-    /// 字幕なし（従来の動画+音声のみ）
+    /// No subtitles; merges video and audio streams only (equivalent to [`merge_av`]).
     None,
-    /// ソフトサブ（字幕をトラックとして埋め込み）
+    /// Soft subtitles: embeds subtitle tracks into the container without re-encoding.
+    ///
+    /// Viewers can toggle subtitle visibility during playback.
+    /// Multiple subtitle tracks are supported.
     SoftSub(Vec<SubtitleMergeOptions>),
-    /// ハードサブ（字幕を動画に焼き付け）
+    /// Hard subtitles: burns subtitles into the video frame via re-encoding.
+    ///
+    /// Subtitles are always visible and cannot be toggled off.
+    /// Uses `libx264` with `fast` preset for encoding.
     HardSub(SubtitleMergeOptions),
 }
 
@@ -81,7 +93,7 @@ pub fn validate_ffmpeg(app: &AppHandle) -> bool {
 }
 
 /// Removes the ffmpeg root directory or file if it exists.
-fn cleanup_ffmpeg_dir(ffmpeg_root: &PathBuf) {
+fn cleanup_ffmpeg_dir(ffmpeg_root: &Path) {
     if ffmpeg_root.is_dir() {
         let _ = fs::remove_dir_all(ffmpeg_root);
     } else if ffmpeg_root.is_file() {
@@ -133,6 +145,11 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         )
     } else if cfg!(target_os = "macos") {
         ("https://evermeet.cx/ffmpeg/getrelease/zip", "ffmpeg.zip")
+    } else if cfg!(target_os = "linux") {
+        (
+            "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-lgpl.tar.xz",
+            "ffmpeg-master-latest-linux64-lgpl.tar.xz",
+        )
     } else {
         return Ok(false);
     };
@@ -165,10 +182,10 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
     // Remove archive file after successful extraction
     let _ = fs::remove_file(&archive_path);
 
-    // Grant execute permission on macOS
-    #[cfg(target_os = "macos")]
+    // Grant execute permission on Unix (macOS and Linux)
+    #[cfg(unix)]
     {
-        let ffmpeg_bin = ffmpeg_root.join("ffmpeg");
+        let ffmpeg_bin = get_ffmpeg_path(app);
         let Some(ffmpeg_path_str) = ffmpeg_bin.to_str() else {
             return Err(anyhow::anyhow!("Invalid ffmpeg path"));
         };
@@ -203,7 +220,7 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
 /// # Errors
 ///
 /// Returns an error if extraction or file I/O fails.
-async fn unpack_archive(archive_path: &PathBuf, dest: &PathBuf) -> Result<bool> {
+async fn unpack_archive(archive_path: &Path, dest: &Path) -> Result<bool> {
     let ext = archive_path
         .extension()
         .and_then(|s| s.to_str())
@@ -271,6 +288,11 @@ fn build_ffmpeg_bin_path(base_path: &Path) -> PathBuf {
             .join("ffmpeg-master-latest-win64-lgpl-shared")
             .join("bin")
             .join("ffmpeg")
+    } else if cfg!(target_os = "linux") {
+        base_path
+            .join("ffmpeg-master-latest-linux64-lgpl")
+            .join("bin")
+            .join("ffmpeg")
     } else {
         base_path.join("ffmpeg")
     };
@@ -291,7 +313,7 @@ fn build_ffmpeg_bin_path(base_path: &Path) -> PathBuf {
 /// # Returns
 ///
 /// Returns `true` if the binary exists and can be executed successfully.
-fn validate_command(path: &PathBuf) -> bool {
+fn validate_command(path: &Path) -> bool {
     if !path.exists() {
         return false;
     }
@@ -423,9 +445,39 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
 
 /// Merges separate video and audio files into a single MP4 file.
 ///
-/// This function uses ffmpeg to combine video and audio streams:
-/// - Video stream is copied without re-encoding (fast)
-/// - Audio stream is re-encoded to AAC
+/// Delegates to [`merge_avs`] with [`MergeMode::None`].
+/// See [`merge_avs`] for detailed documentation on arguments, return values, and errors.
+pub async fn merge_av(
+    app: &AppHandle,
+    video_path: &std::path::Path,
+    audio_path: &std::path::Path,
+    output_path: &std::path::Path,
+    download_id: Option<String>,
+    duration_ms: Option<u64>,
+) -> Result<(), String> {
+    merge_avs(
+        app,
+        video_path,
+        audio_path,
+        output_path,
+        download_id,
+        duration_ms,
+        MergeMode::None,
+    )
+    .await
+}
+
+/// Merges video, audio, and optional subtitles into a single MP4 file.
+///
+/// This is an extended version of [`merge_av`] that supports subtitle handling
+/// based on the specified [`MergeMode`]:
+///
+/// - **None**: Merges video and audio only (identical to [`merge_av`]).
+///   Video stream is copied without re-encoding; audio is re-encoded to AAC.
+/// - **SoftSub**: Embeds subtitle tracks into the container (`mov_text` codec).
+///   Viewers can toggle subtitles on/off during playback. Supports multiple tracks.
+/// - **HardSub**: Burns subtitles into the video frame using the `subtitles` filter.
+///   Requires re-encoding via `libx264` with `fast` preset.
 ///
 /// Progress events are emitted to the frontend during the merge process.
 ///
@@ -437,6 +489,7 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
 /// * `output_path` - Path for the merged output file (.mp4)
 /// * `download_id` - Optional download ID for progress tracking
 /// * `duration_ms` - Optional video duration in milliseconds for accurate progress
+/// * `subtitle_mode` - Controls how subtitles are handled during the merge
 ///
 /// # Returns
 ///
@@ -446,164 +499,9 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
 ///
 /// Returns an error if:
 /// - File paths contain invalid UTF-8
+/// - Subtitle file paths are invalid (when using SoftSub or HardSub mode)
 /// - ffmpeg execution fails
 /// - ffmpeg returns a non-zero exit code
-pub async fn merge_av(
-    app: &AppHandle,
-    video_path: &std::path::Path,
-    audio_path: &std::path::Path,
-    output_path: &std::path::Path,
-    download_id: Option<String>,
-    duration_ms: Option<u64>,
-) -> Result<(), String> {
-    log::info!(
-        "[BE] merge_av: starting merge download_id={:?}, output={:?}",
-        download_id,
-        output_path
-    );
-    let filename = output_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("output");
-
-    // Set dummy filesize of 100MB for merge progress calculation
-    // This allows percentage calculation: downloaded_bytes / (100 * 1024 * 1024) * 100
-    // We'll send percentage * 1048576 as downloaded_bytes to get correct percentage
-    let emits = Emits::new(
-        app.clone(),
-        download_id.unwrap_or(filename.to_string()),
-        Some(100 * 1024 * 1024), // 100MB dummy size
-    );
-    let _ = emits.set_stage("merge").await;
-
-    let ffmpeg_path = get_ffmpeg_path(app);
-
-    // Convert paths to strings for ffmpeg command
-    let to_str_err = || "Invalid path".to_string();
-    let video_str = video_path.to_str().ok_or_else(to_str_err)?;
-    let audio_str = audio_path.to_str().ok_or_else(to_str_err)?;
-    let output_str = output_path.to_str().ok_or_else(to_str_err)?;
-
-    let mut cmd = AsyncCommand::new(&ffmpeg_path);
-    cmd.args([
-        "-i",
-        video_str,
-        "-i",
-        audio_str,
-        "-c:v",
-        "copy",
-        "-c:a",
-        "aac",
-        "-progress",
-        "pipe:1",
-        "-y",
-        output_str,
-    ]);
-
-    // Windowsでコンソールウィンドウが開かないようにする
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
-
-    // Spawn ffmpeg with stdout and stderr piped for progress parsing and error handling
-    let mut child = cmd
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
-
-    let stdout = child.stdout.as_mut().ok_or("Failed to capture stdout")?;
-
-    let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
-
-    let reader = BufReader::new(stdout);
-    let mut lines = reader.lines();
-
-    // Read stderr in background for error details
-    let mut stderr_reader = BufReader::new(stderr);
-    let mut stderr_lines = String::new();
-    let stderr_task = tokio::spawn(async move {
-        let mut line = String::new();
-        while stderr_reader.read_line(&mut line).await.unwrap_or(0) > 0 {
-            stderr_lines.push_str(&line);
-            line.clear();
-        }
-        stderr_lines
-    });
-
-    // Parse progress from ffmpeg output
-    // Note: out_time_ms is in microseconds (us), not milliseconds (ms)
-    while let Ok(Some(line)) = lines.next_line().await {
-        if let Some(time_str) = line.strip_prefix("out_time_ms=") {
-            let out_time_us: u64 = time_str.trim().parse().unwrap_or(0);
-
-            // Convert microseconds to milliseconds for percentage calculation
-            let out_time_ms = out_time_us / 1000;
-
-            // Calculate percentage using actual video duration or fallback to estimate
-            let total_duration_ms = duration_ms.unwrap_or(300_000); // 5 minutes fallback
-            let percentage = if total_duration_ms > 0 {
-                (out_time_ms as f64 / total_duration_ms as f64) * 100.0
-            } else {
-                0.0
-            };
-
-            // Clamp to 95% max until completion
-            let clamped_percentage = percentage.min(95.0);
-
-            // Convert percentage to "downloaded bytes" for progress calculation
-            // With 100MB dummy filesize: percentage * 1MB = downloaded_bytes
-            emits.update_progress((clamped_percentage as u64) * 1024 * 1024);
-        }
-
-        if line == "progress=end" {
-            break;
-        }
-    }
-
-    let status = child
-        .wait()
-        .await
-        .map_err(|e| format!("Failed to wait for ffmpeg: {e}"))?;
-
-    // Get stderr output for error details
-    let stderr_output = stderr_task
-        .await
-        .unwrap_or_else(|e| format!("Failed to read stderr: {e}"));
-
-    if !status.success() {
-        return Err(format!(
-            "ffmpeg failed to merge video and audio.\nExit code: {:?}\nstderr: {}",
-            status.code(),
-            stderr_output
-        ));
-    }
-    // 完了ステージを送信後 complete 呼び出し (単一 Emits ライフサイクル)
-    let _ = emits.set_stage("complete").await;
-    emits.complete().await;
-
-    Ok(())
-}
-
-/// 動画・音声・字幕をマージしてMP4ファイルを生成する
-///
-/// 字幕オプションに応じて以下のモードをサポート:
-/// - None: 従来の動画+音声のみ（merge_avと同等）
-/// - SoftSub: 字幕をトラックとして埋め込み（再生時にON/OFF可能）
-/// - HardSub: 字幕を動画に焼き付け（再エンコード必要）
-///
-/// # Arguments
-///
-/// * `app` - Tauriアプリケーションハンドル
-/// * `video_path` - 動画ファイルのパス
-/// * `audio_path` - 音声ファイルのパス
-/// * `output_path` - 出力ファイルのパス
-/// * `download_id` - ダウンロードID（進捗通知用）
-/// * `duration_ms` - 動画の長さ（ミリ秒、進捗計算用）
-/// * `subtitle_mode` - 字幕マージモード
 pub async fn merge_avs(
     app: &AppHandle,
     video_path: &std::path::Path,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,28 +49,73 @@ pub use utils::wbi;
 /// Initializes and runs the Tauri application.
 ///
 /// This function configures the Tauri application with necessary plugins,
-/// registers Tauri commands, and performs initial setup including developer
-/// tools configuration in debug mode.
+/// registers all Tauri commands, and performs initial setup including:
+/// - Logging plugin initialization with rotation and TTL cleanup
+/// - Cookie cache initialization
+/// - Developer tools activation in debug mode
+/// - Window state restoration in release mode
 ///
 /// # Registered Tauri Commands
 ///
+/// **FFmpeg Management:**
 /// - `validate_ffmpeg`: Validates ffmpeg installation
 /// - `install_ffmpeg`: Downloads and installs ffmpeg binary
+///
+/// **Cookie & Authentication:**
 /// - `get_cookie`: Retrieves cookies from Firefox
+/// - `generate_qr_code`: Generates QR code for login
+/// - `poll_qr_status`: Polls QR code login status
+/// - `qr_logout`: Logs out by clearing stored session and cookies
+/// - `set_login_method`: Sets the preferred login method
+/// - `get_login_method`: Gets the current login method preference
+/// - `get_login_state`: Gets the current login state
+/// - `load_qr_session`: Loads stored QR session on startup
+/// - `check_cookie_refresh`: Checks if cookie refresh is needed
+/// - `refresh_cookie`: Refreshes the cookie using stored refresh token
+///
+/// **User & Video Information:**
 /// - `fetch_user`: Fetches user information from Bilibili
 /// - `fetch_video_info`: Retrieves video metadata
+/// - `fetch_bangumi_info`: Retrieves bangumi episode metadata
+/// - `fetch_subtitles_for_part`: Fetches subtitles for a video part
+/// - `fetch_part_qualities`: Fetches video/audio qualities for a part
+/// - `fetch_bangumi_part_qualities`: Fetches qualities for a bangumi part
+/// - `expand_short_url`: Expands b23.tv short URLs to full URLs
+///
+/// **Downloads:**
 /// - `download_video`: Downloads a video with specified quality
-/// - `get_settings`: Retrieves application settings
-/// - `set_settings`: Updates application settings
-/// - `get_os`: Returns the current operating system identifier
+/// - `cancel_download`: Cancels a specific download by ID
+/// - `cancel_all_downloads`: Cancels all active downloads
+/// - `cleanup_temp_files`: Cleans up orphaned temporary files
+///
+/// **Favorites & History:**
+/// - `fetch_favorite_folders`: Fetches all favorite folders
+/// - `fetch_favorite_videos`: Fetches videos from a favorite folder
+/// - `fetch_watch_history`: Fetches user watch history with pagination
 /// - `get_history`: Retrieves all download history entries
 /// - `add_history_entry`: Adds a new history entry
 /// - `remove_history_entry`: Removes a history entry by ID
 /// - `clear_history`: Clears all history entries
 /// - `search_history`: Searches history with filters
 /// - `export_history`: Exports history in JSON or CSV format
+///
+/// **Settings & Paths:**
+/// - `get_settings`: Retrieves application settings
+/// - `set_settings`: Updates application settings
+/// - `update_lib_path`: Updates library storage path and moves ffmpeg
+/// - `get_current_lib_path`: Returns the current library path
+/// - `get_os`: Returns the current operating system identifier
+///
+/// **File Operations:**
+/// - `reveal_in_folder`: Reveals a file in the system file manager
+/// - `open_file`: Opens a file with the default application
+///
+/// **GitHub Integration:**
 /// - `get_release_notes`: Fetches release notes from GitHub API
 /// - `get_repo_stars`: Fetches star count for a GitHub repository
+///
+/// **Development Only (debug builds):**
+/// - `set_simulate_logout`: Toggles simulate logout flag for testing
 ///
 /// # Panics
 ///
@@ -601,26 +646,17 @@ async fn set_settings(app: AppHandle, settings: Settings) -> Result<(), String> 
 async fn update_lib_path(app: AppHandle, new_path: String) -> Result<(), String> {
     use crate::utils::paths;
 
-    // Get current lib_path (or default)
+    // Get current settings for later update
     let current_settings = settings::get_settings(&app).await?;
-    let _old_lib_path = current_settings
-        .lib_path
-        .as_ref()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| paths::get_default_lib_path(&app));
 
     // Use the user-selected path as-is (no /lib suffix for user-specified paths)
     let new_lib_path = PathBuf::from(&new_path);
 
-    // Get old and new ffmpeg root paths
+    // Get old ffmpeg root path
     let old_ffmpeg_path = paths::get_ffmpeg_root_path(&app);
 
-    // Determine new ffmpeg root path based on new lib path
-    let new_ffmpeg_path = if cfg!(target_os = "windows") {
-        new_lib_path.join("ffmpeg-master-latest-win64-lgpl-shared")
-    } else {
-        new_lib_path.join("ffmpeg")
-    };
+    // Determine new ffmpeg root path using the shared platform resolver
+    let new_ffmpeg_path = new_lib_path.join(paths::ffmpeg_subdir());
 
     // Move ffmpeg (if it exists)
     if old_ffmpeg_path.exists() {

--- a/src-tauri/src/utils/paths.rs
+++ b/src-tauri/src/utils/paths.rs
@@ -18,20 +18,25 @@
 //! ```
 
 use crate::models::settings::Settings;
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tauri::{AppHandle, Manager};
 
 /// Returns the platform-specific ffmpeg subdirectory name.
-const fn ffmpeg_subdir() -> &'static str {
+pub const fn ffmpeg_subdir() -> &'static str {
     if cfg!(target_os = "windows") {
         "ffmpeg-master-latest-win64-lgpl-shared"
+    } else if cfg!(target_os = "linux") {
+        "ffmpeg-master-latest-linux64-lgpl"
     } else {
         "ffmpeg"
     }
 }
 
 /// Ensures a directory exists, creating it if necessary.
-fn ensure_dir_exists(path: &PathBuf) {
+fn ensure_dir_exists(path: &Path) {
     if !path.exists() {
         let _ = fs::create_dir_all(path);
     }
@@ -93,7 +98,8 @@ pub fn get_lib_path(app: &AppHandle) -> PathBuf {
 /// Returns the platform-specific path to the ffmpeg binary.
 ///
 /// On Windows: `{libPath}/ffmpeg-master-latest-win64-lgpl-shared/.../bin/ffmpeg.exe`
-/// On macOS/Linux: `{libPath}/ffmpeg/ffmpeg`
+/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-lgpl/ffmpeg-master-latest-linux64-lgpl/bin/ffmpeg`
+/// On macOS: `{libPath}/ffmpeg/ffmpeg`
 ///
 /// # Arguments
 ///
@@ -112,6 +118,8 @@ pub fn get_ffmpeg_path(app: &AppHandle) -> PathBuf {
             .join("bin")
             .join("ffmpeg")
             .with_extension("exe")
+    } else if cfg!(target_os = "linux") {
+        lib.join(subdir).join(subdir).join("bin").join("ffmpeg")
     } else {
         lib.join(subdir).join("ffmpeg")
     }
@@ -122,7 +130,8 @@ pub fn get_ffmpeg_path(app: &AppHandle) -> PathBuf {
 /// This is the directory where ffmpeg files are extracted.
 ///
 /// On Windows: `{libPath}/ffmpeg-master-latest-win64-lgpl-shared`
-/// On macOS/Linux: `{libPath}/ffmpeg`
+/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-lgpl`
+/// On macOS: `{libPath}/ffmpeg`
 ///
 /// # Arguments
 ///
@@ -137,10 +146,8 @@ pub fn get_ffmpeg_root_path(app: &AppHandle) -> PathBuf {
 
 /// Returns the path to the application settings file.
 ///
-/// **CHANGED:** Now stores settings at `app_data_dir()/settings.json`
-/// (previously was at `resource_dir()/lib/settings.json`).
-///
-/// This ensures settings persist across application updates.
+/// Settings are stored at `app_data_dir()/settings.json` to ensure
+/// they persist across application updates.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
## Summary
- Enable Ubuntu 22.04 in the release workflow build matrix with required system dependencies (`libdbus-1-dev` for keyring crate)
- Add Linux fixed-name release asset mappings (`.deb` and `.AppImage.tar.gz`)
- Implement FFmpeg auto-install support for Linux using BtbN `lgpl-static` builds with `tar.xz` extraction
- Fix FFmpeg path double-nesting bug for Linux archive extraction
- Add Linux supported badge and download links to all 6 README language variants and docs site
- Refactor `merge_av` to delegate to `merge_avs` (eliminate ~100 lines of duplication)

Closes #110

## Test plan
- [ ] Verify release workflow builds successfully on Ubuntu 22.04
- [ ] Verify `.deb` and `.AppImage.tar.gz` assets are uploaded with correct fixed names
- [ ] Verify FFmpeg auto-install works on Linux (download, extract `tar.xz`, chmod +x, validate)
- [ ] Verify FFmpeg path resolution correctly handles double-nested archive structure
- [ ] Verify Linux download links work on docs site
- [ ] Verify CI workflow passes with `libdbus-1-dev` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)