### PR TITLE
docs: switch README app image based on user theme

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | Español | [Français](README.fr.md)

--- a/README.es.md
+++ b/README.es.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | Español | [Français](README.fr.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | Français
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | Français

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 [English](README.md) | 日本語 | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 [English](README.md) | 日本語 | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | 한국어 | [Español](README.es.md) | [Français](README.fr.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh.md) | 한국어 | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 English | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 English | [日本語](README.ja.md) | [简体中文](README.zh.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,10 @@
 
 # Bilibili Downloader GUI
 
-![App Image](<public/app-image(searched)_en_light.png>)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
+  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+</picture>
 
 [English](README.md) | [日本語](README.ja.md) | 简体中文 | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,8 +3,8 @@
 # Bilibili Downloader GUI
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="<public/app-image(searched)_en.png>">
-  <img src="<public/app-image(searched)_en_light.png>" alt="App Image">
+  <source media="(prefers-color-scheme: dark)" srcset="./public/app-image(searched)_en.png">
+  <img src="./public/app-image(searched)_en_light.png" alt="App Image">
 </picture>
 
 [English](README.md) | [日本語](README.ja.md) | 简体中文 | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md)


### PR DESCRIPTION
## Summary

- Replace static markdown image with `<picture>` tag using `prefers-color-scheme` media query
- Automatically display dark/light themed screenshot based on the user's system theme
- Apply to all 6 language READMEs (en, ja, zh, ko, es, fr)

## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [ ] View the PR preview on GitHub with system dark theme enabled
- [ ] View the PR preview on GitHub with system light theme enabled
- [ ] Verify the correct image is displayed for each theme

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)