### PR TITLE
docs: add macOS ad-hoc signing config and update README

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -70,7 +70,7 @@ Sin anuncios, sin seguimiento. 100% gratis.
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> Las compilaciones de macOS no están firmadas. En el primer inicio, ejecuta:
+> Las compilaciones de macOS usan firma de código ad-hoc (sin notarización de Apple). En el primer inicio, ve a **Configuración del Sistema > Privacidad y Seguridad** y haz clic en **Abrir de todos modos**. Alternativamente, ejecuta:
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/README.fr.md
+++ b/README.fr.md
@@ -70,7 +70,7 @@ Pas de publicités, pas de suivi. 100 % gratuit.
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> Les builds macOS ne sont pas signés. Au premier lancement, exécutez :
+> Les builds macOS utilisent la signature de code ad hoc (sans notarisation Apple). Au premier lancement, allez dans **Réglages Système > Confidentialité et sécurité** et cliquez sur **Ouvrir quand même**. Alternativement, exécutez :
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/README.ja.md
+++ b/README.ja.md
@@ -70,7 +70,7 @@
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> macOSビルドは署名されていません。初回起動時に以下を実行してください：
+> macOSビルドはアドホックコード署名を使用しています（Appleの公証は受けていません）。初回起動時に **システム設定 > プライバシーとセキュリティ** で **このまま開く** をクリックしてください。または、以下を実行してください：
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/README.ko.md
+++ b/README.ko.md
@@ -70,7 +70,7 @@
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> macOS 빌드는 서명되지 않았습니다. 첫 실행 시 다음을 실행하세요:
+> macOS 빌드는 임시 코드 서명을 사용합니다(Apple 공증 없음). 첫 실행 시 **시스템 설정 > 개인정보 보호 및 보안**에서 **그래도 열기**를 클릭하세요. 또는 다음을 실행하세요:
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ No ads, no tracking. 100% free.
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> macOS builds are not signed. On first launch, run:
+> macOS builds use ad-hoc code signing (not Apple-notarized). On first launch, go to **System Settings > Privacy & Security** and click **Open Anyway**. Alternatively, run:
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/README.zh.md
+++ b/README.zh.md
@@ -70,7 +70,7 @@
 | **Linux (AppImage)**      | [bilibili-downloader-gui_Linux_x64.AppImage.tar.gz](https://github.com/j4rviscmd/bilibili-downloader-gui/releases/latest/download/bilibili-downloader-gui_Linux_x64.AppImage.tar.gz) |
 
 > [!NOTE]
-> macOS 构建未签名。首次启动时运行：
+> macOS 构建使用临时代码签名（未经 Apple 公证）。首次启动时，请前往 **系统设置 > 隐私与安全性** 并点击 **仍要打开**。或者运行：
 >
 > ```bash
 > xattr -dr com.apple.quarantine "/Applications/bilibili-downloader-gui.app"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
     "createUpdaterArtifacts": true,
     "active": true,
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

- Add `signingIdentity: "-"` to `bundle.macOS` in tauri.conf.json for ad-hoc code signing, preventing build errors on macOS without an Apple Developer certificate
- Update macOS installation NOTE in all 6 language READMEs to explain ad-hoc signing and add System Settings > Privacy & Security guidance

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [ ] Verify tauri.conf.json is valid JSON with correct macOS config
- [ ] Verify all 6 README files have consistent ad-hoc signing note
- [ ] Verify build succeeds with the new config

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)