### PR TITLE
🚀 Release v1.29.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version from v1.29.0 to v1.29.1
- Fix download progress regression during CDN switches
- Correct image paths in picture tag for GitHub rendering
- Add macOS ad-hoc signing config and update README
- Switch README app image based on user theme

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [ ] Verify app builds successfully with new version
- [ ] Verify CDN switch progress no longer regresses
- [ ] Verify README renders correctly on GitHub (light/dark theme)

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)