### PR TITLE
feat(settings): add toggle for GitHub Stars display

### DIFF
--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -81,6 +81,12 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub auto_rename_duplicates: Option<bool>,
+    #[serde(
+        rename = "showGithubStars",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub show_github_stars: Option<bool>,
 }
 
 /// Supported UI languages.

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -57,6 +57,18 @@ import { Separator } from '@/shared/ui/separator'
 import { Switch } from '@/shared/ui/switch'
 
 /**
+ * Returns the login status display text key based on session and method.
+ */
+function getLoginStatusText(
+  session: Session | null,
+  loginMethod: LoginMethod,
+): string {
+  if (session === null) return 'login.notLoggedIn'
+  if (loginMethod === 'qrCode') return 'login.qrCodeLoggedIn'
+  return 'login.firefoxCookieLoggedIn'
+}
+
+/**
  * Converts Session to User type for userSlice.
  *
  * @param session - Session data from login state
@@ -287,6 +299,20 @@ function SettingsForm() {
             </FormItem>
           )}
         />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>{t('settings.show_github_stars_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.show_github_stars_description')}
+            </p>
+          </div>
+          <Switch
+            checked={settings.showGithubStars ?? true}
+            onCheckedChange={(checked) => {
+              saveByForm({ ...settings, showGithubStars: checked })
+            }}
+          />
+        </div>
         <Separator />
         <FormField
           control={form.control}
@@ -380,11 +406,7 @@ function SettingsForm() {
           <Label>{t('login.loginStatus')}</Label>
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground text-sm">
-              {session === null
-                ? t('login.notLoggedIn')
-                : loginMethod === 'qrCode'
-                  ? t('login.qrCodeLoggedIn')
-                  : t('login.firefoxCookieLoggedIn')}
+              {t(getLoginStatusText(session, loginMethod))}
             </span>
             {loginMethod === 'qrCode' && session && (
               <Button

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -15,6 +15,7 @@ const initialState: SettingsState = {
   language: 'en',
   dialogOpen: false,
   autoRenameDuplicates: true,
+  showGithubStars: true,
 }
 
 /**

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -46,6 +46,12 @@ export interface Settings {
    * Defaults to true if not specified.
    */
   autoRenameDuplicates?: boolean
+  /**
+   * Whether to show GitHub stars in the app bar.
+   *
+   * Defaults to true if not specified.
+   */
+  showGithubStars?: boolean
   // Frontendのみの管理につき、localStorageでのみ保存している
   // TODO: themeをjson管理
   // theme: 'light' | 'dark'

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -228,6 +228,8 @@
     "lib_path_change_success": "Library storage location updated successfully",
     "lib_path_change_error": "Failed to change library storage location",
     "app_section_label": "Application",
+    "show_github_stars_label": "Show GitHub Stars",
+    "show_github_stars_description": "Display the star count in the app bar",
     "current_version": "Current version: {{version}}",
     "update_check": {
       "aria_label": "Update check",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -225,6 +225,8 @@
     "lib_path_change_success": "Ubicación de almacenamiento de biblioteca actualizada correctamente",
     "lib_path_change_error": "Error al cambiar la ubicación de almacenamiento de biblioteca",
     "app_section_label": "Aplicación",
+    "show_github_stars_label": "Mostrar GitHub Stars",
+    "show_github_stars_description": "Mostrar el recuento de estrellas en la barra de la aplicación",
     "current_version": "Versión actual: {{version}}",
     "update_check": {
       "aria_label": "Verificación de actualizaciones",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -225,6 +225,8 @@
     "lib_path_change_success": "Emplacement de stockage de la bibliothèque mis à jour avec succès",
     "lib_path_change_error": "Échec de la modification de l'emplacement de stockage de la bibliothèque",
     "app_section_label": "Application",
+    "show_github_stars_label": "Afficher les GitHub Stars",
+    "show_github_stars_description": "Afficher le nombre d'étoiles dans la barre d'application",
     "current_version": "Version actuelle : {{version}}",
     "update_check": {
       "aria_label": "Vérification des mises à jour",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -228,6 +228,8 @@
     "lib_path_change_success": "ライブラリ保存先を変更しました",
     "lib_path_change_error": "ライブラリ保存先の変更に失敗しました",
     "app_section_label": "アプリケーション",
+    "show_github_stars_label": "GitHub Stars を表示",
+    "show_github_stars_description": "アプリバーにスター数を表示します",
     "current_version": "現在のバージョン: {{version}}",
     "update_check": {
       "aria_label": "アップデート確認",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -225,6 +225,8 @@
     "lib_path_change_success": "라이브러리 저장 위치가 성공적으로 업데이트되었습니다",
     "lib_path_change_error": "라이브러리 저장 위치 변경 실패",
     "app_section_label": "애플리케이션",
+    "show_github_stars_label": "GitHub Stars 표시",
+    "show_github_stars_description": "앱 바에 스타 수를 표시합니다",
     "current_version": "현재 버전: {{version}}",
     "update_check": {
       "aria_label": "업데이트 확인",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -225,6 +225,8 @@
     "lib_path_change_success": "库存储位置已成功更新",
     "lib_path_change_error": "更改库存储位置失败",
     "app_section_label": "应用程序",
+    "show_github_stars_label": "显示 GitHub Stars",
+    "show_github_stars_description": "在应用栏中显示星标数",
     "current_version": "当前版本: {{version}}",
     "update_check": {
       "aria_label": "更新检查",
@@ -442,7 +444,6 @@
     "cancel": "取消",
     "qrSessionDeleted": "QR会话已删除",
     "usingFirefoxCookie": "正在使用Firefox Cookie进行认证",
-    "notLoggedIn": "未登录",
     "session_expired": "会话已过期，请重新登录。"
   }
 }

--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -1,3 +1,4 @@
+import { useSelector } from '@/app/store'
 import { QRCodeLoginDialog } from '@/features/login'
 import ToggleThemeButton from '@/features/preference/ui/ToggleThemeButton'
 import type { User } from '@/features/user'
@@ -45,6 +46,9 @@ type Props = {
 function AppBar({ user, theme, setTheme }: Props) {
   const { t } = useTranslation()
   const [isQrLoginDialogOpen, setIsQrLoginDialogOpen] = useState(false)
+  const showGithubStars = useSelector(
+    (state) => state.settings.showGithubStars ?? true,
+  )
 
   const maskedUserName = user.data.isLogin ? maskUserName(user.data.uname) : ''
   const hasUsername = user.data.isLogin && user.data.uname
@@ -89,7 +93,9 @@ function AppBar({ user, theme, setTheme }: Props) {
           )}
         </div>
         <div className="flex items-center gap-3">
-          <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />
+          {showGithubStars && (
+            <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />
+          )}
           <ToggleThemeButton theme={theme} setTheme={setTheme} />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add `showGithubStars` boolean setting to allow users to opt out of displaying GitHub Stars count in the app bar
- Default value is `true` (shown) to preserve existing behavior
- Setting is persisted to `settings.json` via the existing settings infrastructure

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] Run `npm run dev` / `npm run tauri dev`
- [x] Verify GitHub Stars is displayed in app bar by default
- [x] Open Settings dialog, find "Show GitHub Stars" switch below the language section
- [x] Toggle switch OFF — Stars display disappears from app bar
- [x] Toggle switch ON — Stars display reappears
- [x] Restart app — setting persists

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)