### PR TITLE
refactor: translate Japanese comments to English for consistency

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,6 +1,6 @@
 fn main() {
-    // 開発ビルド時はルート .env を優先読み込みし GA 関連値を埋め込む
-    // .env フォーマット: KEY=VALUE (空行/ # コメント行は無視)
+    // In dev builds, prefer root .env for GA-related values
+    // .env format: KEY=VALUE (blank lines / # comment lines are ignored)
     #[cfg(debug_assertions)]
     {
         let mut loaded: Option<&str> = None;
@@ -34,7 +34,7 @@ fn main() {
         }
     }
 
-    // CI / 本番など環境変数で直接渡された値があれば (開発でも .env が与えないキーを補完)
+    // Override with environment variables if set (CI/production, or keys missing from .env)
     if let Ok(secret) = std::env::var("GA_API_SECRET") {
         println!("cargo:rustc-env=GA_API_SECRET={secret}");
     }

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -506,19 +506,19 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         .register(&options.download_id)
         .await;
 
-    // 1. 出力ファイルパス決定 + 自動リネーム
+    // 1. Determine output file path + auto-rename
     let output_path = auto_rename(&build_output_path(app, &options.filename).await?);
 
-    // 2. Cookie取得（WBI署名により非ログインユーザでも動作）
+    // 2. Get cookies (WBI signing enables non-logged-in usage)
     let cookies = read_cookie(app)?.unwrap_or_default();
     let cookie_header = build_cookie_header(&cookies);
 
-    // 3. バンガミの場合、プレイヤー結果を取得してis_previewとdurl形式をチェック
+    // 3. For bangumi, fetch player result to check is_preview and durl format
     let bangumi_preview_info: Option<bool> = if let Some(ep_id) = options.ep_id {
         let player_result = fetch_bangumi_player_result(&cookies, ep_id, options.cid).await?;
         let is_preview = player_result.is_preview.map(|v| v == 1);
 
-        // durl形式（MP4直接URL）の場合
+        // durl format (direct MP4 URL)
         if player_result.dash.is_none() {
             return download_bangumi_durl(
                 app,
@@ -534,7 +534,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         None
     };
 
-    // 4. 動画詳細取得 (選択品質のURL抽出) - DASH形式
+    // 4. Fetch video details (extract URL for selected quality) - DASH format
     let details = if let Some(ep_id) = options.ep_id {
         fetch_bangumi_details_for_download(&cookies, ep_id, options.cid).await?
     } else {
@@ -548,7 +548,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         )
     })?;
 
-    // 通常動画 durl 形式（音声が映像に埋め込まれているMP4）
+    // Regular video durl format (audio embedded in MP4)
     if data.dash.is_none() {
         if let Some(durl_segments) = &data.durl {
             let durl_segment = durl_segments.first().ok_or("ERR::QUALITY_NOT_FOUND")?;
@@ -633,7 +633,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
     let dash_data = data.dash.unwrap();
 
-    // 選択品質が存在しなければフォールバック (先頭 = 最も高品質)
+    // Fallback if selected quality is unavailable (first = highest quality)
     // None means best available → -1 won't match any real quality ID.
     let requested_quality = options.quality.unwrap_or(-1);
     let (video_url, video_backup_urls, raw_video_fallback) =
@@ -680,23 +680,23 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     )
     .ok();
 
-    // 5. 容量事前チェック (取得できなければスキップ)
+    // 5. Pre-check disk space (skip if size cannot be determined)
     let video_size = head_content_length(&video_url, Some(&cookie_header)).await;
     let audio_size = head_content_length(&audio_url, Some(&cookie_header)).await;
     if let (Some(vs), Some(asz)) = (video_size, audio_size) {
-        let total_needed = vs + asz + (5 * 1024 * 1024); // 余裕 5MB
+        let total_needed = vs + asz + (5 * 1024 * 1024); // 5MB buffer
         ensure_free_space(&output_path, total_needed)?;
     }
 
-    // 6. temp ファイルパス生成
+    // 6. Generate temp file paths
     let lib_path = get_lib_path(app);
     let temp_video_path = lib_path.join(format!("temp_video_{}.m4s", options.download_id));
     let temp_audio_path = lib_path.join(format!("temp_audio_{}.m4s", options.download_id));
 
     // Result to track success/failure for cleanup
     let result = async {
-        // 7. セマフォ取得 + 並列ダウンロード + マージ
-        // セマフォは「マージ完了まで保持」され、並列実行数はマージ処理の負荷に基づく
+        // 7. Acquire semaphore + parallel download + merge
+        // Semaphore is held until merge completes; concurrency is based on merge load
         let permit = crate::handlers::concurrency::VIDEO_SEMAPHORE
             .clone()
             .acquire_owned()
@@ -705,7 +705,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
         let cookie = Some(cookie_header);
 
-        // 音声と動画を並列ダウンロード (片方失敗で即時キャンセル)
+        // Download audio and video in parallel (cancel immediately if either fails)
         tokio::try_join!(
             retry_download(|| {
                 download_url(
@@ -735,7 +735,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             }),
         )?;
 
-        // 字幕処理
+        // Subtitle processing
         let (subtitle_mode, subtitle_language_labels) = prepare_subtitle_mode(
             &options.subtitle,
             &cookies,
@@ -763,7 +763,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         )
         .ok();
 
-        // 字幕ファイルのパスを保持（クリーンアップ用）
+        // Keep subtitle file paths for cleanup
         let subtitle_paths: Vec<PathBuf> = match &subtitle_mode {
             crate::handlers::ffmpeg::MergeMode::SoftSub(subs) => {
                 subs.iter().map(|s| s.path.clone()).collect()
@@ -774,7 +774,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             _ => vec![],
         };
 
-        // マージ実行
+        // Execute merge
         log::info!(
             "[BE] download_video: starting ffmpeg merge id={}",
             options.download_id
@@ -791,20 +791,20 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         .await
         .map_err(|_| String::from("ERR::MERGE_FAILED"))?;
 
-        // マージ完了後にセマフォを解放
+        // Release semaphore after merge completes
         drop(permit);
 
-        // temp 削除
+        // Delete temp files
         let _ = tokio::fs::remove_file(&temp_video_path).await;
         let _ = tokio::fs::remove_file(&temp_audio_path).await;
         for sub_path in subtitle_paths {
             let _ = tokio::fs::remove_file(&sub_path).await;
         }
 
-        // 出力パスを保持 (クローンで履歴保存に渡す)
+        // Keep output path (clone for history saving)
         let output_path_str = output_path.to_string_lossy().to_string();
 
-        // 実際のファイルサイズを取得
+        // Get actual file size
         let actual_file_size = tokio::fs::metadata(&output_path)
             .await
             .ok()
@@ -816,7 +816,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             actual_file_size
         );
 
-        // 履歴に保存 (非同期で失敗してもダウンロードには影響しない)
+        // Save to history (async failure does not affect download)
         let app = app.clone();
         let bvid = options.bvid.clone();
         let filename = options.filename.clone();
@@ -1684,7 +1684,7 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
             }
         }
     }
-    // Windows 等未実装 -> スキップ
+    // Not implemented on Windows, etc. -> skip
     Ok(())
 }
 
@@ -1857,7 +1857,7 @@ pub async fn fetch_watch_history(
         view_at
     );
 
-    // 1. Cookie取得（必須）
+    // 1. Get cookies (required)
     let cookies = read_cookie(app)?.unwrap_or_default();
 
     if cookies.is_empty() {
@@ -1866,8 +1866,8 @@ pub async fn fetch_watch_history(
 
     let cookie_header = build_cookie_header(&cookies);
 
-    // 2. API呼び出し
-    // 初回リクエストではパラメータを省略、2回目以降はmax/view_atを使用
+    // 2. API call
+    // Omit parameters on first request; use max/view_at for subsequent pages
     let client = build_client()?;
     let url = if max == 0 && view_at == 0 {
         "https://api.bilibili.com/x/web-interface/history/cursor?business=archive".to_string()
@@ -1898,7 +1898,7 @@ pub async fn fetch_watch_history(
         )
     })?;
 
-    // 3. エラーハンドリング（-101: 未ログイン）
+    // 3. Error handling (-101: not logged in)
     if body.code == -101 {
         return Err("ERR::UNAUTHORIZED".into());
     }
@@ -1914,7 +1914,7 @@ pub async fn fetch_watch_history(
         .data
         .ok_or_else(|| "Watch history API returned no data".to_string())?;
 
-    // 4. DTO変換（サムネイルを並列でBase64エンコード）
+    // 4. DTO conversion (encode thumbnails to Base64 in parallel)
     let entry_futures: Vec<_> = data
         .list
         .into_iter()

--- a/src-tauri/src/handlers/cookie.rs
+++ b/src-tauri/src/handlers/cookie.rs
@@ -44,7 +44,7 @@ pub fn read_cookie(app: &AppHandle) -> Result<Option<Vec<CookieEntry>>, String> 
         }
     }
 
-    // キャッシュを参照する場合は、app.state::<CookieCache>().cookies.lock() から取出
+    // Retrieve from cache via app.state::<CookieCache>().cookies.lock()
     if let Some(cache) = app.try_state::<CookieCache>() {
         if let Ok(guard) = cache.cookies.lock() {
             let cookies = guard.clone();
@@ -85,7 +85,7 @@ fn find_firefox_cookie_file(app: &AppHandle) -> Option<PathBuf> {
     if !filepath.exists() {
         return None;
     }
-    // プロファイル配下を走査して最初に見つかった cookies.sqlite を返す
+    // Scan profiles directory and return the first cookies.sqlite found
     if let Ok(entries) = fs::read_dir(&filepath) {
         for entry in entries.flatten() {
             let p = entry.path().join("cookies.sqlite");
@@ -121,18 +121,18 @@ fn find_firefox_cookie_file(app: &AppHandle) -> Option<PathBuf> {
 /// - SQLite database cannot be opened or queried
 pub async fn get_cookie(app: &AppHandle) -> Result<bool, String> {
     log::info!("[BE] get_cookie: reading cookies from Firefox");
-    // 1) ローカルの Firefox cookie DB を探索
+    // 1) Search for local Firefox cookie DB
     let Some(cookiefile) = find_firefox_cookie_file(app) else {
         log::warn!("[BE] get_cookie: Firefox cookie file not found");
         return Ok(false);
     };
 
-    // 2) 一時ディレクトリにコピー（Firefox 実行中ロック対策）
+    // 2) Copy to temp directory (to avoid lock while Firefox is running)
     let tmp_dir = std::env::temp_dir();
     let tmp_cookie = tmp_dir.join("temp_cookiefile.sqlite");
     fs::copy(&cookiefile, &tmp_cookie).map_err(|e| format!("failed to copy cookie db: {e}"))?;
 
-    // 3) SQLite を開いて moz_cookies から host, name, value を読む（デバッグ表示）
+    // 3) Open SQLite and read host, name, value from moz_cookies (for debug display)
     let mut cookies = HashMap::<String, String>::new();
     let read_res: SqlResult<bool> = (|| {
         let conn = Connection::open(&tmp_cookie)?;
@@ -160,8 +160,8 @@ pub async fn get_cookie(app: &AppHandle) -> Result<bool, String> {
                 "[BE] get_cookie: successfully loaded {} cookies",
                 cookies.len()
             );
-            // メモリキャッシュへ保存
-            // NOTE: 次回の処理でキャッシュを参照する場合は、app.state::<CookieCache>().cookies.lock() から取出
+            // Save to memory cache
+            // NOTE: To read the cache later, access via app.state::<CookieCache>().cookies.lock()
             if let Some(cache) = app.try_state::<CookieCache>() {
                 if let Ok(mut guard) = cache.cookies.lock() {
                     let mut vec = Vec::with_capacity(cookies.len());

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -127,11 +127,11 @@ fn cleanup_ffmpeg_dir(ffmpeg_root: &Path) {
 /// - Permission setting fails (macOS)
 pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
     log::info!("[BE] install_ffmpeg: starting ffmpeg installation");
-    // ffmpegバイナリのダウンロード処理
+    // Download ffmpeg binary
     // let ffmpeg_path = get_ffmpeg_path(app);
     let ffmpeg_root = get_ffmpeg_root_path(app);
 
-    // ffmpeg_rootが存在しない場合は作成
+    // Create ffmpeg_root if it doesn't exist
     if !ffmpeg_root.exists() {
         fs::create_dir_all(&ffmpeg_root)
             .map_err(|e| anyhow::anyhow!("Failed to create ffmpeg directory: {}", e))?;
@@ -239,22 +239,22 @@ async fn unpack_archive(archive_path: &Path, dest: &Path) -> Result<bool> {
         let file = File::open(archive_path)?;
         let mut archive = zip::ZipArchive::new(file)?;
 
-        // 出力先ディレクトリが存在しない場合は作成
+        // Create output directory if it doesn't exist
         if !dest.exists() {
             std::fs::create_dir_all(dest)?;
         }
 
-        // アーカイブ内の各ファイルを展開
+        // Extract each file from the archive
         for i in 0..archive.len() {
             let mut file = archive.by_index(i)?;
             let outpath = dest.join(file.name());
 
-            // ディレクトリの場合はスキップ
+            // Skip directories
             if file.name().ends_with('/') {
                 continue;
             }
 
-            // ファイルを展開
+            // Extract file
             if let Some(p) = outpath.parent() {
                 if !p.exists() {
                     std::fs::create_dir_all(p)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -187,11 +187,11 @@ pub fn run() {
             load_qr_session,
             check_cookie_refresh,
             refresh_cookie,
-            // record_download_click  // NOTE: GA4 Analytics は無効化されています
+            // record_download_click  // NOTE: GA4 Analytics is currently disabled
             #[cfg(debug_assertions)]
             set_simulate_logout,
         ])
-        // 開発環境以外で`app`宣言ではBuildに失敗するため、`_app`を使用
+        // Use `_app` because `app` causes build failure outside dev environment
         .setup(|app| {
             // Register debug-only plugins
             #[cfg(debug_assertions)]
@@ -254,7 +254,7 @@ pub fn run() {
                 });
             }
 
-            // Cookieキャッシュを初期化
+            // Initialize cookie cache
             app.manage(CookieCache::default());
 
             // Development mode: Initialize simulate logout flag
@@ -263,14 +263,14 @@ pub fn run() {
                 app.manage(SimulateLogoutFlag::default());
             }
 
-            // Analytics 初期化 (非同期で失敗握りつぶし)
-            // NOTE: GA4 Analytics は無効化されています
+            // Analytics initialization (async errors are swallowed)
+            // NOTE: GA4 Analytics is currently disabled
             // let handle: AppHandle = app.handle().clone();
             // tauri::async_runtime::spawn(async move {
             //     crate::utils::analytics::init_analytics(&handle).await;
             // });
-            // 開発環境の場合は、開発者コンソールを有効化
-            // E2Eテスト時はコンソールを開かない
+            // Enable dev console in development environment
+            // Don't open console during E2E tests
             #[cfg(debug_assertions)]
             {
                 if !crate::handlers::qr_login::is_e2e_testing() {
@@ -962,7 +962,7 @@ async fn open_file(path: String) -> Result<(), String> {
     Ok(())
 }
 
-// NOTE: GA4 Analytics は無効化されています
+// NOTE: GA4 Analytics is currently disabled
 // #[tauri::command]
 // async fn record_download_click(app: AppHandle, download_id: String) -> Result<(), String> {
 //     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/utils/analytics.rs
+++ b/src-tauri/src/utils/analytics.rs
@@ -322,7 +322,7 @@ async fn send_event_internal(
         "events": [Value::Object(event_obj)],
     });
 
-    // Debug モード判定: release build では GA_DEBUG=1 を指定しても無効 (cfg 判定)
+    // Debug mode: GA_DEBUG=1 has no effect in release builds (cfg guard)
     #[cfg(debug_assertions)]
     let debug_mode = true;
     #[cfg(not(debug_assertions))]
@@ -345,7 +345,7 @@ async fn send_event_internal(
         Ok(r) => {
             let status = r.status().as_u16();
             if debug_mode {
-                // Debug エンドポイントは常に 200 で JSON を返す想定
+                // Debug endpoint is expected to return 200 with JSON
                 let parsed = r.json::<serde_json::Value>().await.ok();
                 let mut msgs: Vec<String> = Vec::new();
                 if let Some(p) = parsed.as_ref() {
@@ -365,7 +365,7 @@ async fn send_event_internal(
                     msgs
                 );
             } else if !r.status().is_success() {
-                // 非 debug で失敗時は swallow
+                // Swallow errors in non-debug mode
                 return Ok(());
             }
             Ok(())

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -46,8 +46,8 @@ export interface Settings {
    * Defaults to true if not specified.
    */
   autoRenameDuplicates?: boolean
-  // Frontendのみの管理につき、localStorageでのみ保存している
-  // TODO: themeをjson管理
+  // Managed on frontend only, stored in localStorage
+  // TODO: manage theme in json
   // theme: 'light' | 'dark'
 }
 

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -54,10 +54,10 @@ export const useSettings = () => {
       }
     } catch (e) {
       const raw = String(e)
-      // settings.rs で返されるコード (シングルコロン形式) を優先判定
+      // Prefer single-colon format returned by settings.rs
       //   ERR:SETTINGS_PATH_NOT_DIRECTORY
       //   ERR:SETTINGS_PATH_NOT_EXIST
-      // 既存のダブルコロン形式 (将来互換) も一応残す
+      // Keep double-colon format for backward compatibility
       let messageKey: string | null = null
       if (raw.includes('ERR:SETTINGS_PATH_NOT_DIRECTORY'))
         messageKey = 'settings.path_not_directory'

--- a/src/features/sidebar/model/sidebarSlice.ts
+++ b/src/features/sidebar/model/sidebarSlice.ts
@@ -2,13 +2,13 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 
 /**
- * サイドバーの状態管理
+ * Sidebar state management
  *
- * サイドバーの開閉状態を管理するRedux状態。
- * この状態は settings.json に永続化され、ページ遷移後も維持される。
+ * Redux state that manages the sidebar open/close state.
+ * This state is persisted in settings.json and maintained across page transitions.
  */
 export type SidebarState = {
-  /** サイドバーが開いているかどうか */
+  /** Whether the sidebar is open */
   sidebarOpen: boolean
 }
 
@@ -17,20 +17,20 @@ const initialState: SidebarState = {
 }
 
 /**
- * サイドバー用Redux Slice
+ * Redux Slice for sidebar
  *
- * サイドバーの開閉状態を管理する。状態はRedux Toolkitの
- * createSliceを使用して定義され、setSidebarOpenアクションを通じて更新される。
+ * Manages the sidebar open/close state. State is defined using
+ * Redux Toolkit's createSlice and updated via the setSidebarOpen action.
  */
 export const sidebarSlice = createSlice({
   name: 'sidebar',
   initialState,
   reducers: {
     /**
-     * サイドバーの開閉状態を設定
+     * Sets the sidebar open/close state
      *
-     * @param state - 現在のRedux状態
-     * @param action - boolean値を含むアクション（true: 開く, false: 閉じる）
+     * @param state - Current Redux state
+     * @param action - Action containing a boolean value (true: open, false: close)
      */
     setSidebarOpen: (state, action: PayloadAction<boolean>) => {
       state.sidebarOpen = action.payload

--- a/src/features/video/lib/concurrency.ts
+++ b/src/features/video/lib/concurrency.ts
@@ -1,13 +1,13 @@
 /**
- * シンプルな並行実行数リミッター。
+ * Simple concurrency limiter.
  *
- * 同時に実行できる非同期タスク数を制限し、
- * 超過分はキューに積んで順次実行する。
+ * Limits the number of asynchronous tasks that can run simultaneously,
+ * queuing excess tasks for sequential execution.
  *
  * @example
  * ```typescript
  * const limiter = createConcurrencyLimiter(3)
- * // 最大3並列で実行される
+ * // Runs with max 3 concurrent tasks
  * await limiter.run(() => fetch('/api/1'))
  * ```
  */
@@ -23,10 +23,10 @@ export function createConcurrencyLimiter(maxConcurrency: number) {
   }
 
   /**
-   * タスクをキューに追加し、並行制限内で実行する。
+   * Queues a task and runs it within the concurrency limit.
    *
-   * @param fn - 実行する非同期関数
-   * @returns タスクの戻り値の Promise
+   * @param fn - Async function to execute
+   * @returns Promise resolving to the task's return value
    */
   async function run<T>(fn: () => Promise<T>): Promise<T> {
     await new Promise<void>((resolve) => {

--- a/src/features/video/lib/formSchema.ts
+++ b/src/features/video/lib/formSchema.ts
@@ -121,7 +121,7 @@ export const buildVideoFormSchema1 = (t: TFunction) =>
             return
           }
 
-          // bilibili.com 直下のみ許可（必要に応じてサブドメインも許可可能）
+          // Only allow bilibili.com directly (subdomains can be allowed if needed)
           const ok = /^www\.bilibili\.com$/i.test(hostname)
           if (!ok) {
             ctx.addIssue({
@@ -130,7 +130,7 @@ export const buildVideoFormSchema1 = (t: TFunction) =>
             })
             return
           }
-          // 動画URL または バンガミURL のパス形式をチェック
+          // Check path format for video URL or bangumi URL
           const isVideoPath = /^\/video\/[a-zA-Z0-9]+/.test(pathname)
           const isBangumiPath = /^\/bangumi\/play\/ep\d+/.test(pathname)
           if (!isVideoPath && !isBangumiPath) {
@@ -140,7 +140,7 @@ export const buildVideoFormSchema1 = (t: TFunction) =>
             })
           }
         } catch {
-          // .url() が既にURL形式の検証とメッセージを担当
+          // .url() already handles URL format validation and messages
         }
       }),
   })

--- a/src/features/video/ui/VideoForm1.tsx
+++ b/src/features/video/ui/VideoForm1.tsx
@@ -54,7 +54,7 @@ function VideoForm1() {
 
   useEffect(() => {
     const trimmedUrl = input.url.trim()
-    // 空文字の場合はバリデーションをスキップ（初期表示時のエラー防止）
+    // Skip validation for empty strings (prevent errors on initial render)
     form.setValue('url', trimmedUrl, { shouldValidate: trimmedUrl.length > 0 })
   }, [form, input.url])
 

--- a/src/pages/favorite/index.tsx
+++ b/src/pages/favorite/index.tsx
@@ -65,9 +65,9 @@ export function FavoriteContent() {
   }
 
   /**
-   * お気に入りリストの手動更新を処理します。
+   * Handles manual refresh of the favorite list.
    *
-   * データを再取得し、成功トーストを表示します。
+   * Re-fetches data and shows a success toast.
    */
   const handleRefresh = () => {
     refresh()

--- a/src/shared/animate-ui/radix/sidebar.tsx
+++ b/src/shared/animate-ui/radix/sidebar.tsx
@@ -39,30 +39,30 @@ type Settings = {
 }
 
 /**
- * サイドバーコンテキストのプロパティ型
+ * Sidebar context property types
  *
- * SidebarProvider から提供されるコンテキスト値の型定義。
+ * Type definition for context values provided by SidebarProvider.
  */
 type SidebarContextProps = {
-  /** サイドバーの現在の状態 */
+  /** Current state of the sidebar */
   state: 'expanded' | 'collapsed'
-  /** デスクトップ表示でサイドバーが開いているか */
+  /** Whether the sidebar is open in desktop view */
   open: boolean
-  /** サイドバーの開閉を設定する関数 */
+  /** Function to set the sidebar open/close state */
   setOpen: (open: boolean) => void
-  /** サイドバーの開閉を切り替える関数 */
+  /** Function to toggle the sidebar open/close state */
   toggleSidebar: () => void
 }
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
 /**
- * サイドバーコンテキストを使用するフック
+ * Hook for using the sidebar context
  *
- * SidebarProvider の配下で使用し、サイドバーの状態と操作関数を取得する。
+ * Used within SidebarProvider to get sidebar state and action functions.
  *
- * @throws SidebarProvider の配下以外で使用した場合エラー
- * @returns サイドバーコンテキスト値
+ * @throws Error if used outside of SidebarProvider
+ * @returns Sidebar context value
  *
  * @example
  * ```tsx
@@ -78,28 +78,28 @@ function useSidebar() {
 }
 
 /**
- * SidebarProvider のプロパティ型
+ * SidebarProvider property types
  */
 type SidebarProviderProps = React.ComponentProps<'div'> & {
-  /** デフォルトの開閉状態 */
+  /** Default open/close state */
   defaultOpen?: boolean
-  /** 制御モードでの開閉状態（省略時はRedux状態を使用） */
+  /** Open/close state in controlled mode (uses Redux state when omitted) */
   open?: boolean
-  /** 開閉状態変更時のコールバック */
+  /** Callback on open/close state change */
   onOpenChange?: (open: boolean) => void
 }
 
 /**
- * サイドバーコンテキストプロバイダ
+ * Sidebar context provider
  *
- * サイドバーの状態を管理し、子コンポーネントにコンテキストを提供する。
- * Reduxとsettings.jsonの両方と同期し、ページ遷移後も状態を維持する。
+ * Manages sidebar state and provides context to child components.
+ * Syncs with both Redux and settings.json to maintain state across page navigations.
  *
- * 機能:
- * - settings.json からの初期状態読み込み
- * - Reduxへの状態同期
- * - settings.json への状態永続化
- * - キーボードショートカット対応 (Cmd/Ctrl + B)
+ * Features:
+ * - Load initial state from settings.json
+ * - Sync state to Redux
+ * - Persist state to settings.json
+ * - Keyboard shortcut support (Cmd/Ctrl + B)
  *
  * @example
  * ```tsx
@@ -233,31 +233,31 @@ function SidebarProvider({
 }
 
 /**
- * Sidebar コンポーネントのプロパティ型
+ * Sidebar component property types
  */
 type SidebarProps = React.ComponentProps<'div'> & {
-  /** サイドバーの配置位置 */
+  /** Sidebar placement position */
   side?: 'left' | 'right'
-  /** サイドバーの表示スタイル */
+  /** Sidebar display style */
   variant?: 'sidebar' | 'floating' | 'inset'
-  /** 折りたたみの動作モード */
+  /** Collapse behavior mode */
   collapsible?: 'offcanvas' | 'icon' | 'none'
-  /** コンテナ用の追加クラス名 */
+  /** Additional class names for the container */
   containerClassName?: string
-  /** ホバー時のアニメーションを有効にするか */
+  /** Whether to enable hover animation */
   animateOnHover?: boolean
-  /** アニメーションのトランジション設定 */
+  /** Animation transition settings */
   transition?: Transition
 }
 
 /**
- * サイドバーメインコンポーネント
+ * Main sidebar component
  *
- * デスクトップとモバイルで異なる表示モードをサポートするサイドバー。
+ * A sidebar that supports different display modes for desktop and mobile.
  *
- * 表示モード:
- * - デスクトップ: collapsible='offcanvas' で画面外にスライド、'icon' でアイコンのみ表示
- * - モバイル: Sheet コンポーネントとしてオーバーレイ表示
+ * Display modes:
+ * - Desktop: collapsible='offcanvas' slides off-screen, 'icon' shows icons only
+ * - Mobile: Overlay display using Sheet component
  *
  * @example
  * ```tsx
@@ -362,15 +362,15 @@ function Sidebar({
 }
 
 /**
- * SidebarTrigger のプロパティ型
+ * SidebarTrigger property types
  */
 type SidebarTriggerProps = React.ComponentProps<typeof Button>
 
 /**
- * サイドバー開閉トリガーボタン
+ * Sidebar toggle trigger button
  *
- * クリック時にサイドバーの開閉を切り替えるボタンコンポーネント。
- * AppBar 等に配置して使用する。
+ * A button component that toggles the sidebar open/close on click.
+ * Typically placed in the AppBar.
  *
  * @example
  * ```tsx
@@ -400,15 +400,15 @@ function SidebarTrigger({ className, onClick, ...props }: SidebarTriggerProps) {
 }
 
 /**
- * SidebarRail のプロパティ型
+ * SidebarRail property types
  */
 type SidebarRailProps = React.ComponentProps<'button'>
 
 /**
- * サイドバーレール（ホバー領域）
+ * Sidebar rail (hover area)
  *
- * サイドバーの端に配置される見えないホバー領域。
- * ホバー時にクリックまたはドラッグ操作でサイドバーを切り替えることができる。
+ * An invisible hover area placed at the edge of the sidebar.
+ * Allows toggling the sidebar via click or drag when hovered.
  */
 function SidebarRail({ className, ...props }: SidebarRailProps) {
   const { toggleSidebar } = useSidebar()
@@ -437,15 +437,15 @@ function SidebarRail({ className, ...props }: SidebarRailProps) {
 }
 
 /**
- * SidebarInset のプロパティ型
+ * SidebarInset property types
  */
 type SidebarInsetProps = React.ComponentProps<'main'>
 
 /**
- * サイドバーのメインコンテンツ領域
+ * Main content area of the sidebar
  *
- * サイドバーに隣接するメインコンテンツを表示する領域。
- * variant='inset' の場合、特殊なスタイルが適用される。
+ * Displays the main content adjacent to the sidebar.
+ * Special styles are applied when variant='inset'.
  */
 function SidebarInset({ className, ...props }: SidebarInsetProps) {
   return (
@@ -462,14 +462,14 @@ function SidebarInset({ className, ...props }: SidebarInsetProps) {
 }
 
 /**
- * SidebarInput のプロパティ型
+ * SidebarInput property types
  */
 type SidebarInputProps = React.ComponentProps<typeof Input>
 
 /**
- * サイドバー用入力コンポーネント
+ * Sidebar input component
  *
- * サイドバー内での使用に最適化された入力フィールド。
+ * An input field optimized for use within the sidebar.
  */
 function SidebarInput({ className, ...props }: SidebarInputProps) {
   return (
@@ -483,14 +483,14 @@ function SidebarInput({ className, ...props }: SidebarInputProps) {
 }
 
 /**
- * SidebarHeader のプロパティ型
+ * SidebarHeader property types
  */
 type SidebarHeaderProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーヘッダー領域
+ * Sidebar header area
  *
- * サイドバーの上部に配置されるヘッダーコンテンツ用コンテナ。
+ * A container for header content placed at the top of the sidebar.
  */
 function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
   return (
@@ -504,14 +504,14 @@ function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
 }
 
 /**
- * SidebarFooter のプロパティ型
+ * SidebarFooter property types
  */
 type SidebarFooterProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーフッター領域
+ * Sidebar footer area
  *
- * サイドバーの下部に配置されるフッターコンテンツ用コンテナ。
+ * A container for footer content placed at the bottom of the sidebar.
  */
 function SidebarFooter({ className, ...props }: SidebarFooterProps) {
   return (
@@ -525,12 +525,12 @@ function SidebarFooter({ className, ...props }: SidebarFooterProps) {
 }
 
 /**
- * SidebarSeparator のプロパティ型
+ * SidebarSeparator property types
  */
 type SidebarSeparatorProps = React.ComponentProps<typeof Separator>
 
 /**
- * サイドバー内の区切り線
+ * Divider within the sidebar
  */
 function SidebarSeparator({ className, ...props }: SidebarSeparatorProps) {
   return (
@@ -544,14 +544,14 @@ function SidebarSeparator({ className, ...props }: SidebarSeparatorProps) {
 }
 
 /**
- * SidebarContent のプロパティ型
+ * SidebarContent property types
  */
 type SidebarContentProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーコンテンツ領域
+ * Sidebar content area
  *
- * スクロール可能なメインコンテンツを表示する領域。
+ * Displays the scrollable main content.
  */
 function SidebarContent({ className, ...props }: SidebarContentProps) {
   return (
@@ -568,14 +568,14 @@ function SidebarContent({ className, ...props }: SidebarContentProps) {
 }
 
 /**
- * SidebarGroup のプロパティ型
+ * SidebarGroup property types
  */
 type SidebarGroupProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーグループ
+ * Sidebar group
  *
- * 関連するメニューアイテムをグループ化するコンテナ。
+ * A container for grouping related menu items.
  */
 function SidebarGroup({ className, ...props }: SidebarGroupProps) {
   return (
@@ -589,16 +589,16 @@ function SidebarGroup({ className, ...props }: SidebarGroupProps) {
 }
 
 /**
- * SidebarGroupLabel のプロパティ型
+ * SidebarGroupLabel property types
  */
 type SidebarGroupLabelProps = React.ComponentProps<'div'> & {
   asChild?: boolean
 }
 
 /**
- * サイドバーグループのラベル
+ * Sidebar group label
  *
- * グループのタイトルを表示する。iconモード時は非表示になる。
+ * Displays the group title. Hidden when in icon mode.
  */
 function SidebarGroupLabel({
   className,
@@ -621,16 +621,16 @@ function SidebarGroupLabel({
 }
 
 /**
- * SidebarGroupAction のプロパティ型
+ * SidebarGroupAction property types
  */
 type SidebarGroupActionProps = React.ComponentProps<'button'> & {
   asChild?: boolean
 }
 
 /**
- * サイドバーグループのアクションボタン
+ * Sidebar group action button
  *
- * グループの右上に配置されるアクションボタン。
+ * An action button placed at the top-right of the group.
  */
 function SidebarGroupAction({
   className,
@@ -653,14 +653,14 @@ function SidebarGroupAction({
 }
 
 /**
- * SidebarGroupContent のプロパティ型
+ * SidebarGroupContent property types
  */
 type SidebarGroupContentProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーグループのコンテンツ
+ * Sidebar group content
  *
- * グループ内のメニューアイテムを配置するコンテナ。
+ * A container for placing menu items within a group.
  */
 function SidebarGroupContent({
   className,
@@ -677,14 +677,14 @@ function SidebarGroupContent({
 }
 
 /**
- * SidebarMenu のプロパティ型
+ * SidebarMenu property types
  */
 type SidebarMenuProps = React.ComponentProps<'ul'>
 
 /**
- * サイドバーメニューリスト
+ * Sidebar menu list
  *
- * メニューアイテムのリストを表示するコンテナ。
+ * A container for displaying a list of menu items.
  */
 function SidebarMenu({ className, ...props }: SidebarMenuProps) {
   return (
@@ -698,14 +698,14 @@ function SidebarMenu({ className, ...props }: SidebarMenuProps) {
 }
 
 /**
- * SidebarMenuItem のプロパティ型
+ * SidebarMenuItem property types
  */
 type SidebarMenuItemProps = React.ComponentProps<'li'>
 
 /**
- * サイドバーメニューアイテム
+ * Sidebar menu item
  *
- * 個々のメニューアイテムを表すリスト要素。
+ * A list element representing an individual menu item.
  */
 function SidebarMenuItem({ className, ...props }: SidebarMenuItemProps) {
   return (
@@ -758,7 +758,7 @@ const sidebarMenuButtonVariants = cva(
 )
 
 /**
- * SidebarMenuButton のプロパティ型
+ * SidebarMenuButton property types
  */
 type SidebarMenuButtonProps = React.ComponentProps<'button'> & {
   asChild?: boolean
@@ -767,9 +767,9 @@ type SidebarMenuButtonProps = React.ComponentProps<'button'> & {
 } & VariantProps<typeof sidebarMenuButtonVariants>
 
 /**
- * サイドバーメニューボタン
+ * Sidebar menu button
  *
- * メニューアイテムのボタン。ツールチップ表示とアクティブ状態の管理に対応。
+ * A button for menu items. Supports tooltip display and active state management.
  *
  * @example
  * ```tsx
@@ -831,10 +831,10 @@ type SidebarMenuActionProps = React.ComponentProps<'button'> & {
 }
 
 /**
- * サイドバーメニューアクションボタン
+ * Sidebar menu action button
  *
- * メニューアイテム内に配置されるアクションボタン。
- * showOnHover を有効にすると、ホバー時のみ表示される。
+ * An action button placed within a menu item.
+ * When showOnHover is enabled, it is only visible on hover.
  */
 function SidebarMenuAction({
   className,
@@ -860,14 +860,14 @@ function SidebarMenuAction({
 }
 
 /**
- * SidebarMenuBadge のプロパティ型
+ * SidebarMenuBadge property types
  */
 type SidebarMenuBadgeProps = React.ComponentProps<'div'>
 
 /**
- * サイドバーメニューバッジ
+ * Sidebar menu badge
  *
- * メニューアイテムの右側に表示されるバッジ（通知数など）。
+ * A badge displayed on the right side of a menu item (e.g., notification count).
  */
 function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps) {
   return (
@@ -884,16 +884,16 @@ function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps) {
 }
 
 /**
- * SidebarMenuSkeleton のプロパティ型
+ * SidebarMenuSkeleton property types
  */
 type SidebarMenuSkeletonProps = React.ComponentProps<'div'> & {
   showIcon?: boolean
 }
 
 /**
- * サイドバーメニュースケルトン
+ * Sidebar menu skeleton
  *
- * 読み込み中に表示されるプレースホルダー。
+ * A placeholder displayed during loading.
  */
 function SidebarMenuSkeleton({
   className,
@@ -929,14 +929,14 @@ function SidebarMenuSkeleton({
 }
 
 /**
- * SidebarMenuSub のプロパティ型
+ * SidebarMenuSub property types
  */
 type SidebarMenuSubProps = React.ComponentProps<'ul'>
 
 /**
- * サイドバーサブメニューリスト
+ * Sidebar sub-menu list
  *
- * 入れ子になったサブメニューアイテムのリスト。
+ * A list of nested sub-menu items.
  */
 function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
   return (
@@ -954,14 +954,14 @@ function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
 }
 
 /**
- * SidebarMenuSubItem のプロパティ型
+ * SidebarMenuSubItem property types
  */
 type SidebarMenuSubItemProps = React.ComponentProps<'li'>
 
 /**
- * サイドバーサブメニューアイテム
+ * Sidebar sub-menu item
  *
- * サブメニュー内の個々のアイテム。
+ * An individual item within a sub-menu.
  */
 function SidebarMenuSubItem({ className, ...props }: SidebarMenuSubItemProps) {
   return (
@@ -975,7 +975,7 @@ function SidebarMenuSubItem({ className, ...props }: SidebarMenuSubItemProps) {
 }
 
 /**
- * SidebarMenuSubButton のプロパティ型
+ * SidebarMenuSubButton property types
  */
 type SidebarMenuSubButtonProps = React.ComponentProps<'a'> & {
   asChild?: boolean
@@ -984,9 +984,9 @@ type SidebarMenuSubButtonProps = React.ComponentProps<'a'> & {
 }
 
 /**
- * サイドバーサブメニューボタン
+ * Sidebar sub-menu button
  *
- * サブメニューアイテムのボタン。
+ * A button for sub-menu items.
  */
 function SidebarMenuSubButton({
   asChild = false,


### PR DESCRIPTION
## Summary

Translate all Japanese comments (code comments, JSDoc, rustdoc) across 14 files to English, unifying the comment language for better international maintainability.

**Scope:**
- 6 Rust files in `src-tauri/` (72 comment lines)
- 8 TypeScript files in `src/` (145 comment lines)

**Excluded (by design):**
- Test data containing Chinese characters (actual API response values)
- UI language labels (`日本語`, `中文`, etc.)
- JSDoc/rustdoc example values showing actual API return values

## Related Issue

Closes #250

## Type of Change

- [x] ♻️ Refactoring

## Test Plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `cargo build` passes (pre-existing warnings only)
- [x] Verified no untranslated Japanese comments remain (grep verified)
- [x] Verified no code logic was changed (comment-only modifications)

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)