### PR TITLE
feat: add developer option to toggle devtools on startup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -271,11 +271,25 @@ pub fn run() {
             // });
             // Enable dev console in development environment
             // Don't open console during E2E tests
+            // Respects the openDevtoolsOnStartup setting (defaults to true)
             #[cfg(debug_assertions)]
             {
                 if !crate::handlers::qr_login::is_e2e_testing() {
-                    let window = app.get_webview_window("main").unwrap();
-                    window.open_devtools();
+                    let settings_path = crate::utils::paths::get_settings_path(app.handle());
+                    let should_open = if settings_path.exists() {
+                        std::fs::read_to_string(&settings_path)
+                            .ok()
+                            .and_then(|content| serde_json::from_str::<Settings>(&content).ok())
+                            .and_then(|s| s.open_devtools_on_startup)
+                            .unwrap_or(true)
+                    } else {
+                        true
+                    };
+
+                    if should_open {
+                        let window = app.get_webview_window("main").unwrap();
+                        window.open_devtools();
+                    }
                 }
             }
             Ok(())

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -87,6 +87,14 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub show_github_stars: Option<bool>,
+    /// Whether to open devtools on app startup (development mode only).
+    /// Defaults to true if not specified.
+    #[serde(
+        rename = "openDevtoolsOnStartup",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub open_devtools_on_startup: Option<bool>,
 }
 
 /// Supported UI languages.

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -52,6 +52,12 @@ export interface Settings {
    * Defaults to true if not specified.
    */
   showGithubStars?: boolean
+  /**
+   * Whether to open devtools on app startup (development mode only).
+   *
+   * Defaults to true if not specified.
+   */
+  openDevtoolsOnStartup?: boolean
   // Managed on frontend only, stored in localStorage
   // TODO: manage theme in json
   // theme: 'light' | 'dark'

--- a/src/features/settings/ui/DevOptions.tsx
+++ b/src/features/settings/ui/DevOptions.tsx
@@ -10,6 +10,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import { useSettings } from '@/features/settings/useSettings'
 import { useUser } from '@/features/user'
 import { logger } from '@/shared/lib/logger'
 
@@ -20,6 +21,7 @@ export function DevOptions() {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const { onChangeUser, getUserInfo } = useUser()
+  const { settings, saveByForm } = useSettings()
   const simulateLogout = useSelector(
     (state: RootState) => state.dev?.simulateLogout ?? false,
   )
@@ -61,6 +63,10 @@ export function DevOptions() {
     }
   }
 
+  const handleToggleDevtools = (checked: boolean) => {
+    saveByForm({ ...settings, openDevtoolsOnStartup: checked })
+  }
+
   // Only show in development mode
   if (!import.meta.env.DEV) {
     return null
@@ -77,6 +83,24 @@ export function DevOptions() {
         />
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 space-y-4 rounded-lg border border-amber-500/20 bg-amber-50/30 p-4 dark:border-amber-500/10 dark:bg-amber-950/10">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label
+              htmlFor="open-devtools-on-startup"
+              className="text-sm font-medium text-amber-800 dark:text-amber-300"
+            >
+              {t('settings.dev_options.open_devtools_on_startup')}
+            </Label>
+            <p className="text-xs text-amber-600 dark:text-amber-400/80">
+              {t('settings.dev_options.open_devtools_on_startup_description')}
+            </p>
+          </div>
+          <Switch
+            id="open-devtools-on-startup"
+            checked={settings.openDevtoolsOnStartup ?? true}
+            onCheckedChange={handleToggleDevtools}
+          />
+        </div>
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">
             <Label

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -244,6 +244,8 @@
     },
     "dev_options": {
       "title": "Developer Options",
+      "open_devtools_on_startup": "Open DevTools on startup",
+      "open_devtools_on_startup_description": "When enabled, the browser DevTools console opens automatically when the app starts. Takes effect on next restart.",
       "simulate_logout": "Simulate non-logged-in state",
       "simulate_logout_description": "When enabled, the app behaves as if you are not logged in (for testing purposes)."
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -241,6 +241,8 @@
     },
     "dev_options": {
       "title": "Opciones de desarrollo",
+      "open_devtools_on_startup": "Abrir DevTools al iniciar",
+      "open_devtools_on_startup_description": "Cuando está habilitado, la consola DevTools del navegador se abre automáticamente al iniciar la aplicación. Se aplica en el próximo reinicio.",
       "simulate_logout": "Simular estado sin sesión iniciada",
       "simulate_logout_description": "Cuando está habilitado, la aplicación funciona como si no hubieras iniciado sesión (para pruebas)."
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -241,6 +241,8 @@
     },
     "dev_options": {
       "title": "Options de développement",
+      "open_devtools_on_startup": "Ouvrir DevTools au démarrage",
+      "open_devtools_on_startup_description": "Lorsqu'activé, la console DevTools du navigateur s'ouvre automatiquement au démarrage de l'application. Prend effet au prochain redémarrage.",
       "simulate_logout": "Simuler l'état non connecté",
       "simulate_logout_description": "Lorsqu'activé, l'application se comporte comme si vous n'étiez pas connecté (à des fins de test)."
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -244,6 +244,8 @@
     },
     "dev_options": {
       "title": "開発者オプション",
+      "open_devtools_on_startup": "起動時にDevToolsを開く",
+      "open_devtools_on_startup_description": "有効にすると、アプリ起動時にブラウザのDevToolsコンソールが自動的に開きます。次回起動時に反映されます。",
       "simulate_logout": "非ログイン状態をシミュレート",
       "simulate_logout_description": "有効にすると、アプリはログインしていない状態として動作します（テスト用）。"
     },

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -241,6 +241,8 @@
     },
     "dev_options": {
       "title": "개발자 옵션",
+      "open_devtools_on_startup": "시작 시 DevTools 열기",
+      "open_devtools_on_startup_description": "활성화하면 앱 시작 시 브라우저 DevTools 콘솔이 자동으로 열립니다. 다음 재시작 시 적용됩니다.",
       "simulate_logout": "비로그인 상태 시뮬레이션",
       "simulate_logout_description": "활성화하면 앱이 로그인하지 않은 상태로 실행됩니다(테스트용)."
     },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -241,6 +241,8 @@
     },
     "dev_options": {
       "title": "开发者选项",
+      "open_devtools_on_startup": "启动时打开开发者工具",
+      "open_devtools_on_startup_description": "启用后，应用启动时会自动打开浏览器开发者工具控制台。下次启动时生效。",
       "simulate_logout": "模拟未登录状态",
       "simulate_logout_description": "启用后，应用将以未登录状态运行（用于测试）。"
     },


### PR DESCRIPTION
## Summary

Add a developer option to control whether the debug console (DevTools) opens automatically when the app starts in development mode.

## Changes

- **Backend (Rust)**: Added `openDevtoolsOnStartup` field to `Settings` struct, modified startup logic to read the setting and conditionally open devtools
- **Frontend (TypeScript)**: Added toggle switch in Developer Options section of Settings dialog
- **i18n**: Added translation keys for all 6 languages (en, ja, zh, ko, fr, es)

## Behavior

- Default: **ON** (existing behavior preserved)
- Setting takes effect on next app restart
- Only visible in development mode (`#[cfg(debug_assertions)]` / `import.meta.env.DEV`)
- Persisted in `settings.json` via existing `get_settings`/`set_settings` commands