### PR TITLE
chore: add .forest.toml with copy exclusion patterns

### DIFF
--- a/.forest.toml
+++ b/.forest.toml
@@ -1,0 +1,9 @@
+[start]
+exclude = [
+    "target",       # Rust/Cargo build artifacts (17GB+) - cargo build for regeneration
+    "node_modules", # npm dependencies (275MB) - npm install for regeneration
+    "dist",         # Vite build output - npm run build for regeneration
+    "gen",          # Tauri auto-generated code (src-tauri/gen)
+    "plans",        # Working plan files (git untracked)
+    "references",   # Local API docs reference (git untracked)
+]


### PR DESCRIPTION
## Summary
- Add `.forest.toml` configuration to exclude large/regeneratable directories from worktree copies
- Expected savings: **17GB+** per worktree creation

## Excluded directories
| Pattern | Target | Reason |
|---|---|---|
| `target` | `src-tauri/target` | Rust/Cargo build artifacts (17GB+) |
| `node_modules` | `node_modules` | npm dependencies (275MB) |
| `dist` | `dist` | Vite build output |
| `gen` | `src-tauri/gen` | Tauri auto-generated code |
| `plans` | `plans` | Local working plan files |
| `references` | `references` | Local API docs reference |

## Note
Forest only supports basename-level patterns (no path separators). `target` matches `src-tauri/target` since it's the only `target` directory in this project.

## Test plan
- [ ] Run `forest start test-exclude` and verify `src-tauri/target/`, `node_modules/` are not copied
- [ ] Run `forest finish test-exclude` to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)