### PR TITLE
chore: update .forest.toml exclude paths for accuracy

### DIFF
--- a/.forest.toml
+++ b/.forest.toml
@@ -1,9 +1,9 @@
 [start]
 exclude = [
-    "target",       # Rust/Cargo build artifacts (17GB+) - cargo build for regeneration
-    "node_modules", # npm dependencies (275MB) - npm install for regeneration
-    "dist",         # Vite build output - npm run build for regeneration
-    "gen",          # Tauri auto-generated code (src-tauri/gen)
-    "plans",        # Working plan files (git untracked)
-    "references",   # Local API docs reference (git untracked)
+    "src-tauri/target", # Rust/Cargo build artifacts (17GB+) - cargo build for regeneration
+    "src-tauri/gen",    # Tauri auto-generated code (src-tauri/gen)
+    # "node_modules",     # npm dependencies (275MB) - npm install for regeneration
+    "dist",             # Vite build output - npm run build for regeneration
+    "plans",            # Working plan files (git untracked)
+    # "references",       # Local API docs reference (git untracked)
 ]

--- a/.forest.toml
+++ b/.forest.toml
@@ -4,6 +4,5 @@ exclude = [
     "src-tauri/gen",    # Tauri auto-generated code (src-tauri/gen)
     # "node_modules",     # npm dependencies (275MB) - npm install for regeneration
     "dist",             # Vite build output - npm run build for regeneration
-    "plans",            # Working plan files (git untracked)
     # "references",       # Local API docs reference (git untracked)
 ]

--- a/worktree-copy-manual
+++ b/worktree-copy-manual
@@ -1,1 +1,0 @@
-references/


### PR DESCRIPTION
## Summary
- Changed `target`/`gen` to `src-tauri/target`/`src-tauri/gen` for more accurate path specification
- Commented out `node_modules` from the exclusion list (needed in worktree copies)
- Removed `plans` from the exclusion list
- Removed `worktree-copy-manual`

## Test plan
- [x] Verify exclude paths in `.forest.toml` are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)