### PR TITLE
fix: switch ffmpeg to GPL static build for subtitle merge support

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -789,7 +789,14 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             subtitle_mode,
         )
         .await
-        .map_err(|_| String::from("ERR::MERGE_FAILED"))?;
+        .map_err(|e| {
+            log::error!(
+                "[BE] download_video: ffmpeg merge failed id={}: {}",
+                options.download_id,
+                e
+            );
+            String::from("ERR::MERGE_FAILED")
+        })?;
 
         // Release semaphore after merge completes
         drop(permit);

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -138,17 +138,18 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
     }
 
     // Download URL and filename based on platform
+    // Windows GPL is available only as .zip; Linux GPL as .tar.xz
     let (url, filename) = if cfg!(target_os = "windows") {
         (
-            "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip",
-            "ffmpeg-master-latest-win64-lgpl-shared.zip",
+            "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
+            "ffmpeg-master-latest-win64-gpl.zip",
         )
     } else if cfg!(target_os = "macos") {
         ("https://evermeet.cx/ffmpeg/getrelease/zip", "ffmpeg.zip")
     } else if cfg!(target_os = "linux") {
         (
-            "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-lgpl.tar.xz",
-            "ffmpeg-master-latest-linux64-lgpl.tar.xz",
+            "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz",
+            "ffmpeg-master-latest-linux64-gpl.tar.xz",
         )
     } else {
         return Ok(false);
@@ -284,13 +285,12 @@ async fn unpack_archive(archive_path: &Path, dest: &Path) -> Result<bool> {
 fn build_ffmpeg_bin_path(base_path: &Path) -> PathBuf {
     let mut path = if cfg!(target_os = "windows") {
         base_path
-            .join("ffmpeg-master-latest-win64-lgpl-shared")
-            .join("ffmpeg-master-latest-win64-lgpl-shared")
+            .join("ffmpeg-master-latest-win64-gpl")
             .join("bin")
             .join("ffmpeg")
     } else if cfg!(target_os = "linux") {
         base_path
-            .join("ffmpeg-master-latest-linux64-lgpl")
+            .join("ffmpeg-master-latest-linux64-gpl")
             .join("bin")
             .join("ffmpeg")
     } else {

--- a/src-tauri/src/utils/paths.rs
+++ b/src-tauri/src/utils/paths.rs
@@ -27,9 +27,9 @@ use tauri::{AppHandle, Manager};
 /// Returns the platform-specific ffmpeg subdirectory name.
 pub const fn ffmpeg_subdir() -> &'static str {
     if cfg!(target_os = "windows") {
-        "ffmpeg-master-latest-win64-lgpl-shared"
+        "ffmpeg-master-latest-win64-gpl"
     } else if cfg!(target_os = "linux") {
-        "ffmpeg-master-latest-linux64-lgpl"
+        "ffmpeg-master-latest-linux64-gpl"
     } else {
         "ffmpeg"
     }
@@ -97,8 +97,8 @@ pub fn get_lib_path(app: &AppHandle) -> PathBuf {
 
 /// Returns the platform-specific path to the ffmpeg binary.
 ///
-/// On Windows: `{libPath}/ffmpeg-master-latest-win64-lgpl-shared/.../bin/ffmpeg.exe`
-/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-lgpl/ffmpeg-master-latest-linux64-lgpl/bin/ffmpeg`
+/// On Windows: `{libPath}/ffmpeg-master-latest-win64-gpl/.../bin/ffmpeg.exe`
+/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-gpl/.../bin/ffmpeg`
 /// On macOS: `{libPath}/ffmpeg/ffmpeg`
 ///
 /// # Arguments
@@ -129,8 +129,8 @@ pub fn get_ffmpeg_path(app: &AppHandle) -> PathBuf {
 ///
 /// This is the directory where ffmpeg files are extracted.
 ///
-/// On Windows: `{libPath}/ffmpeg-master-latest-win64-lgpl-shared`
-/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-lgpl`
+/// On Windows: `{libPath}/ffmpeg-master-latest-win64-gpl`
+/// On Linux: `{libPath}/ffmpeg-master-latest-linux64-gpl`
 /// On macOS: `{libPath}/ffmpeg`
 ///
 /// # Arguments

--- a/src-tauri/src/utils/subtitle.rs
+++ b/src-tauri/src/utils/subtitle.rs
@@ -9,8 +9,12 @@ use crate::models::bilibili_api::BccSubtitle;
 ///
 /// BCC format uses `from`/`to` fields in seconds, while SRT uses
 /// `HH:MM:SS,mmm --> HH:MM:SS,mmm` timestamp format.
+///
+/// The output includes a UTF-8 BOM prefix to ensure correct encoding
+/// detection by ffmpeg on Windows.
 pub fn bcc_to_srt(bcc: &BccSubtitle) -> String {
-    bcc.body
+    let srt_content = bcc
+        .body
         .iter()
         .enumerate()
         .map(|(i, entry)| {
@@ -19,7 +23,10 @@ pub fn bcc_to_srt(bcc: &BccSubtitle) -> String {
             format!("{}\n{} --> {}\n{}\n", i + 1, start, end, entry.content)
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n");
+
+    // UTF-8 BOM ensures ffmpeg correctly detects encoding on Windows
+    format!("\u{FEFF}{}", srt_content)
 }
 
 /// Formats a time in seconds to SRT timestamp format (HH:MM:SS,mmm).
@@ -146,7 +153,7 @@ mod tests {
         };
 
         let srt = bcc_to_srt(&bcc);
-        let expected = "1\n00:00:00,000 --> 00:00:02,500\nHello world\n";
+        let expected = "\u{FEFF}1\n00:00:00,000 --> 00:00:02,500\nHello world\n";
         assert_eq!(srt, expected);
     }
 
@@ -191,6 +198,6 @@ mod tests {
         };
 
         let srt = bcc_to_srt(&bcc);
-        assert_eq!(srt, "");
+        assert_eq!(srt, "\u{FEFF}");
     }
 }


### PR DESCRIPTION
## Summary

Switch the ffmpeg download from LGPL shared build to GPL static build to resolve subtitle merge failures on Windows. The LGPL build lacks `libx264` (GPL-licensed), causing HardSub merge to fail with "encoder not found".

## Changes

- **Windows**: Download URL changed to GPL static `.zip` (from LGPL shared `.zip`)
- **Linux**: Download URL changed to GPL static `.tar.xz` (from LGPL static `.tar.xz`)
- **macOS**: Unchanged (already uses GPL from evermeet.cx)
- **SRT Output**: Added UTF-8 BOM prefix for Windows ffmpeg SRT parsing compatibility
- **Error Handling**: ffmpeg stderr is now logged before returning `ERR::MERGE_FAILED`

## Impact

- Users updating to this version will re-download ffmpeg (~211MB for Windows GPL build) on first launch
- Old LGPL ffmpeg files remain on disk (not auto-cleaned) but are no longer referenced
- HardSub and SoftSub subtitle merge should now work correctly on all platforms