### PR TITLE
chore: release v1.31.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release v1.31.0

### Changes since v1.30.0
- feat: add developer option to toggle devtools on startup
- fix: switch ffmpeg to GPL static build for subtitle merge support
- chore: remove worktree-copy-manual
- chore: remove plans from forest exclude list
- chore: update .forest.toml exclude paths for accuracy
- chore: add .forest.toml with copy exclusion patterns
- chore: remove unused count feature and unused barrel exports

## Related Issue

N/A (Release PR)

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] Verify version number is updated to 1.31.0 in tauri.conf.json
- [x] Build succeeds with `cargo build`

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A for release chore)
- [x] i18n files synced (N/A for release chore)