### PR TITLE
feat: add font size setting with slider UI

### DIFF
--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -97,11 +97,7 @@ pub struct Settings {
     pub open_devtools_on_startup: Option<bool>,
     /// Base font size in pixels (12-20). Applied as root font-size for rem-based scaling.
     /// Defaults to 16 (browser default) if not specified.
-    #[serde(
-        rename = "fontSize",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "fontSize", default, skip_serializing_if = "Option::is_none")]
     pub font_size: Option<u8>,
 }
 

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -95,6 +95,14 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub open_devtools_on_startup: Option<bool>,
+    /// Base font size in pixels (12-20). Applied as root font-size for rem-based scaling.
+    /// Defaults to 16 (browser default) if not specified.
+    #[serde(
+        rename = "fontSize",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub font_size: Option<u8>,
 }
 
 /// Supported UI languages.

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,61 @@
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Slider as SliderPrimitive } from "radix-ui"
+import { Slider as SliderPrimitive } from 'radix-ui'
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 function Slider({
   className,
@@ -18,7 +18,7 @@ function Slider({
         : Array.isArray(defaultValue)
           ? defaultValue
           : [min, max],
-    [value, defaultValue, min, max]
+    [value, defaultValue, min, max],
   )
 
   return (
@@ -29,21 +29,21 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
-        className
+        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        className,
       )}
       {...props}
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          'bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5',
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            'bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
           )}
         />
       </SliderPrimitive.Track>
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -8,6 +8,7 @@ import {
   loadQrSession,
   refreshCookie,
 } from '@/features/login'
+import { applyFontSize, parseFontSize } from '@/features/settings'
 import { useSettings } from '@/features/settings/useSettings'
 import { useUser } from '@/features/user'
 import { changeLanguage, type SupportedLang } from '@/shared/i18n'
@@ -125,6 +126,7 @@ export const useInit = () => {
     // Version checking is handled by UpdaterProvider (non-blocking dialog)
     const settings = await getAppSettings()
     await applyLanguageSetting(settings?.language)
+    applyFontSize(parseFontSize(settings?.fontSize))
 
     // Early exit on ffmpeg check failure
     if (!(await checkFfmpeg())) {

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -11,7 +11,7 @@ import { videoApi } from '@/features/video'
 import { logger } from '@/shared/lib/logger'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { open } from '@tauri-apps/plugin-dialog'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -27,12 +27,20 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Slider } from '@/components/ui/slider'
 import { callGetCurrentLibPath } from '@/features/settings/api/settingApi'
 import {
   buildSettingsFormSchema,
   formSchema,
 } from '@/features/settings/dialog/formSchema'
 import { languages } from '@/features/settings/language/languages'
+import {
+  applyFontSize,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  parseFontSize,
+} from '@/features/settings/lib/fontSize'
+import type { FontSizePreset } from '@/features/settings/type'
 import { DevOptions } from '@/features/settings/ui/DevOptions'
 import { TitleReplacementSettings } from '@/features/settings/ui/TitleReplacementSettings'
 import { UpdateCheckButton } from '@/features/settings/ui/UpdateCheckButton'
@@ -270,6 +278,17 @@ function SettingsForm() {
     form.handleSubmit(onSubmit)()
   }
 
+  const currentFontSize = parseFontSize(settings.fontSize)
+
+  const handleFontSizeChange = useCallback(
+    (value: number[]) => {
+      const size = parseFontSize(value[0]) as FontSizePreset
+      applyFontSize(size)
+      saveByForm({ ...settings, fontSize: size })
+    },
+    [settings, saveByForm],
+  )
+
   return (
     <Form {...form}>
       <FormDescription className="mb-4">
@@ -299,6 +318,28 @@ function SettingsForm() {
             </FormItem>
           )}
         />
+        <div className="space-y-3">
+          <div className="space-y-0.5">
+            <Label>{t('settings.font_size_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.font_size_description')}
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <Slider
+              min={FONT_SIZE_MIN}
+              max={FONT_SIZE_MAX}
+              step={1}
+              value={[currentFontSize]}
+              onValueChange={handleFontSizeChange}
+              className="flex-1"
+            />
+            <span className="w-10 text-right text-sm tabular-nums">
+              {currentFontSize}px
+            </span>
+          </div>
+        </div>
+        <Separator />
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">
             <Label>{t('settings.show_github_stars_label')}</Label>

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -6,5 +6,12 @@
  * @module features/settings
  */
 
+export {
+  FONT_SIZE_DEFAULT,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  applyFontSize,
+  parseFontSize,
+} from '@/features/settings/lib/fontSize'
 export * from '@/features/settings/settingsSlice'
 export * from '@/features/settings/type'

--- a/src/features/settings/lib/fontSize.ts
+++ b/src/features/settings/lib/fontSize.ts
@@ -1,0 +1,47 @@
+import type { FontSizePreset } from '@/features/settings/type'
+
+/**
+ * Default font size in pixels (browser standard).
+ */
+export const FONT_SIZE_DEFAULT: FontSizePreset = 16
+
+/**
+ * Minimum allowed font size in pixels.
+ */
+export const FONT_SIZE_MIN = 12
+
+/**
+ * Maximum allowed font size in pixels.
+ */
+export const FONT_SIZE_MAX = 20
+
+/**
+ * Apply the given font size to the document root element.
+ *
+ * Sets `font-size` on `<html>` so that all rem-based utilities
+ * (e.g. Tailwind) scale proportionally.
+ *
+ * @param fontSize - The font size preset to apply, in pixels.
+ */
+export function applyFontSize(fontSize: FontSizePreset): void {
+  document.documentElement.style.fontSize = `${fontSize}px`
+}
+
+/**
+ * Parse and sanitize an unknown value into a valid font size preset.
+ *
+ * Returns the default font size when the value is not a number.
+ * Otherwise rounds the value to the nearest integer and clamps it
+ * within the allowed range (`FONT_SIZE_MIN` to `FONT_SIZE_MAX`).
+ *
+ * @param value - Raw value to parse (e.g. from persisted settings).
+ * @returns A valid `FontSizePreset` within the allowed range.
+ */
+export function parseFontSize(value: unknown): FontSizePreset {
+  if (typeof value !== 'number') return FONT_SIZE_DEFAULT
+  const clamped = Math.min(
+    FONT_SIZE_MAX,
+    Math.max(FONT_SIZE_MIN, Math.round(value)),
+  )
+  return clamped as FontSizePreset
+}

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -16,6 +16,7 @@ const initialState: SettingsState = {
   dialogOpen: false,
   autoRenameDuplicates: true,
   showGithubStars: true,
+  fontSize: 16,
 }
 
 /**

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -58,10 +58,23 @@ export interface Settings {
    * Defaults to true if not specified.
    */
   openDevtoolsOnStartup?: boolean
+  /**
+   * Base font size in pixels (12-20).
+   *
+   * Applied as root font-size for rem-based scaling.
+   * Defaults to 16 (browser default) if not specified.
+   */
+  fontSize?: FontSizePreset
   // Managed on frontend only, stored in localStorage
   // TODO: manage theme in json
   // theme: 'light' | 'dark'
 }
+
+/**
+ * Font size preset in pixels, applied as root font-size.
+ * All rem-based Tailwind utilities scale proportionally.
+ */
+export type FontSizePreset = 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20
 
 /**
  * Supported language codes for the application.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -230,6 +230,8 @@
     "app_section_label": "Application",
     "show_github_stars_label": "Show GitHub Stars",
     "show_github_stars_description": "Display the star count in the app bar",
+    "font_size_label": "Font Size",
+    "font_size_description": "Adjust the base font size. Changes apply immediately.",
     "current_version": "Current version: {{version}}",
     "update_check": {
       "aria_label": "Update check",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -227,6 +227,8 @@
     "app_section_label": "Aplicación",
     "show_github_stars_label": "Mostrar GitHub Stars",
     "show_github_stars_description": "Mostrar el recuento de estrellas en la barra de la aplicación",
+    "font_size_label": "Tamaño de fuente",
+    "font_size_description": "Ajusta el tamaño de fuente base. Los cambios se aplican inmediatamente.",
     "current_version": "Versión actual: {{version}}",
     "update_check": {
       "aria_label": "Verificación de actualizaciones",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -227,6 +227,8 @@
     "app_section_label": "Application",
     "show_github_stars_label": "Afficher les GitHub Stars",
     "show_github_stars_description": "Afficher le nombre d'étoiles dans la barre d'application",
+    "font_size_label": "Taille de police",
+    "font_size_description": "Ajustez la taille de police de base. Les modifications sont appliquées immédiatement.",
     "current_version": "Version actuelle : {{version}}",
     "update_check": {
       "aria_label": "Vérification des mises à jour",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -230,6 +230,8 @@
     "app_section_label": "アプリケーション",
     "show_github_stars_label": "GitHub Stars を表示",
     "show_github_stars_description": "アプリバーにスター数を表示します",
+    "font_size_label": "フォントサイズ",
+    "font_size_description": "基本のフォントサイズを調整します。変更は即座に適用されます。",
     "current_version": "現在のバージョン: {{version}}",
     "update_check": {
       "aria_label": "アップデート確認",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -227,6 +227,8 @@
     "app_section_label": "애플리케이션",
     "show_github_stars_label": "GitHub Stars 표시",
     "show_github_stars_description": "앱 바에 스타 수를 표시합니다",
+    "font_size_label": "글꼴 크기",
+    "font_size_description": "기본 글꼴 크기를 조정합니다. 변경 사항이 즉시 적용됩니다.",
     "current_version": "현재 버전: {{version}}",
     "update_check": {
       "aria_label": "업데이트 확인",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -227,6 +227,8 @@
     "app_section_label": "应用程序",
     "show_github_stars_label": "显示 GitHub Stars",
     "show_github_stars_description": "在应用栏中显示星标数",
+    "font_size_label": "字体大小",
+    "font_size_description": "调整基础字体大小。更改会立即生效。",
     "current_version": "当前版本: {{version}}",
     "update_check": {
       "aria_label": "更新检查",

--- a/src/shared/animate-ui/radix/switch.tsx
+++ b/src/shared/animate-ui/radix/switch.tsx
@@ -47,7 +47,7 @@ function Switch({
       <motion.button
         data-slot="switch"
         className={cn(
-          'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input relative flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-[3px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:justify-end data-[state=unchecked]:justify-start',
+          'focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input relative flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-[0.1875rem] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:justify-end data-[state=unchecked]:justify-start',
           className,
         )}
         whileTap="tap"
@@ -93,13 +93,13 @@ function Switch({
             layout
             transition={{ type: 'spring', stiffness: 300, damping: 25 }}
             style={{
-              width: 18,
-              height: 18,
+              width: '1.125rem',
+              height: '1.125rem',
             }}
             animate={
               isTapped
-                ? { width: 21, transition: { duration: 0.1 } }
-                : { width: 18, transition: { duration: 0.1 } }
+                ? { width: '1.3125rem', transition: { duration: 0.1 } }
+                : { width: '1.125rem', transition: { duration: 0.1 } }
             }
           >
             {thumbIcon && typeof thumbIcon !== 'string' ? thumbIcon : null}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,6 +5,7 @@
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary
- Add configurable font size (12-20px) via slider in the settings dialog
- Font size is applied as root `font-size` so all rem-based Tailwind utilities scale proportionally
- Persisted to `settings.json` via the existing Tauri backend settings flow
- Updated Switch component to use rem-based dimensions for proper scaling at all font sizes
- Added i18n keys for all 6 languages (en, ja, zh, ko, es, fr)

## Test plan
- [ ] Open settings dialog and verify font size slider appears after language section
- [ ] Drag slider to 12px (minimum) and verify all UI elements scale down properly, no overflow
- [ ] Drag slider to 20px (maximum) and verify all UI elements scale up properly
- [ ] Verify font size persists after app restart
- [ ] Verify default is 16px when no `fontSize` in settings.json (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)