### PR TITLE
fix: statically link liblzma to resolve macOS launch crash

### DIFF
--- a/src-tauri/.language
+++ b/src-tauri/.language
@@ -1,0 +1,1 @@
+japanese

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.47.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 octocrab = "0.42"
 semver = "0.11"
-xz2 = "0.1.7"
+xz2 = { version = "0.1.7", features = ["static"] }
 tar = "0.4.44"
 zip = "2.2.3"
 rusqlite = { version = "0.31", features = ["bundled"] }


### PR DESCRIPTION
## Summary

- Enable `static` feature on the `xz2` crate to statically link liblzma instead of dynamically linking to the system library
- Fixes a macOS launch crash where the app failed to load `/opt/homebrew/*/liblzma.5.dylib` due to code signing Team ID mismatch between the ad-hoc signed app binary and the Homebrew-installed shared library

## Background

The crash report showed:
```
Library not loaded: /opt/homebrew/*/liblzma.5.dylib
Reason: code signature not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs
```

The `xz2` crate was dynamically linking to the system's `liblzma`, which caused the app to crash on machines where the Homebrew library had a different signing identity.

## Test plan

- [x] `cargo build` succeeds with static linking
- [x] `otool -L` confirms no dynamic dependency on `liblzma.5.dylib`
- [ ] Release build (.dmg) launches successfully on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)