### PR TITLE
chore: release v1.32.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version from v1.32.0 to v1.32.1

## Changes since v1.32.0

### Fixed
- Statically link liblzma to fix macOS launch crash (code signing Team ID mismatch with Homebrew's dynamic library)

🤖 Generated with [Claude Code](https://claude.com/claude-code)