### PR TITLE
feat: replace keyring with argon2 + AES-256-GCM encrypted file storage

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -158,6 +182,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -513,13 +549,15 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 name = "bilibili-downloader-gui"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "argon2",
  "base16ct",
  "base64 0.22.1",
  "chrono",
  "futures",
+ "hostname",
  "image",
- "keyring",
  "libc",
  "log",
  "md5",
@@ -596,6 +634,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -913,7 +960,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1149,6 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1187,6 +1235,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1229,27 +1286,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "dbus"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "zeroize",
-]
 
 [[package]]
 name = "deflate64"
@@ -2006,6 +2042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2383,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2908,21 +2965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "dbus-secret-service",
- "log",
- "security-framework 2.11.1",
- "security-framework 3.5.1",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,15 +3020,6 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3904,6 +3937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4096,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4377,6 +4427,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -7055,6 +7117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7521,7 +7593,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -7542,7 +7614,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -7554,7 +7626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -7587,13 +7659,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7602,7 +7680,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -7613,7 +7691,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7622,7 +7700,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7698,7 +7776,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7715,7 +7793,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7724,7 +7802,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,7 +49,9 @@ rsa = "0.9"
 sha2 = "0.10"
 base16ct = { version = "0.2", features = ["alloc"] }
 num-bigint = "0.4.6"
-keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+argon2 = "0.5"
+aes-gcm = "0.10"
+hostname = "0.4"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/handlers/qr_login.rs
+++ b/src-tauri/src/handlers/qr_login.rs
@@ -3,16 +3,14 @@
 //! This module handles Bilibili QR code authentication flow:
 //! 1. Generate QR code image
 //! 2. Poll for login status
-//! 3. Store session securely in OS keyring on success
-//! 4. Logout (clear session from keyring)
+//! 3. Store session in encrypted file on success
+//! 4. Logout (clear session file)
 //!
 //! # Security
 //!
-//! Session tokens (SESSDATA, refresh_token, etc.) are stored in the OS's
-//! secure credential storage:
-//! - macOS: Keychain
-//! - Windows: Credential Manager
-//! - Linux: Secret Service (gnome-keyring, KWallet, etc.)
+//! Session tokens (SESSDATA, refresh_token, etc.) are encrypted with
+//! argon2 + AES-256-GCM and stored in the app data directory.
+//! The encryption key is derived from hostname + username.
 //!
 //! The tauri-plugin-store is only used for non-sensitive settings
 //! like the preferred login method.
@@ -38,37 +36,25 @@ use crate::models::qr_login::{
     CookieRefreshResponse, LoginMethod, LoginState, QrCodeGenerateResponse, QrCodePollResponse,
     QrCodeResult, QrCodeStatus, QrPollResult, Session,
 };
+use crate::utils::secure_storage::{EncryptedFileStorage, SecureStorage};
 
 const QR_GENERATE_URL: &str = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate";
 const QR_POLL_URL: &str = "https://passport.bilibili.com/x/passport-login/web/qrcode/poll";
 const STORE_FILE_NAME: &str = "login_state.json";
 const LOGIN_STATE_KEY: &str = "loginState";
 
-// Keyring configuration
-const KEYRING_SERVICE: &str = "com.j4rviscmd.bilibili-downloader-gui";
-const KEYRING_SESSION_KEY: &str = "session";
+// Encrypted file storage instance
+static STORAGE: EncryptedFileStorage = EncryptedFileStorage::new();
 
-// Session cache to avoid multiple keyring access dialogs
+// Session cache to avoid repeated file reads and key derivation
 // None = not initialized yet, Some(None) = no session, Some(Some(session)) = session exists
 static SESSION_CACHE: RwLock<Option<Option<Session>>> = RwLock::new(None);
 
-/// Returns true if running in E2E test mode (bypasses OS keyring).
+/// Returns true if running in E2E test mode (bypasses secure storage).
 pub fn is_e2e_testing() -> bool {
     std::env::var("E2E_TESTING")
         .map(|v| v == "true")
         .unwrap_or(false)
-}
-
-// Keyring Helper Functions
-
-/// Creates a keyring entry for the session credential.
-///
-/// # Errors
-///
-/// Returns an error if the keyring entry cannot be created.
-fn create_keyring_entry() -> Result<keyring::Entry, String> {
-    keyring::Entry::new(KEYRING_SERVICE, KEYRING_SESSION_KEY)
-        .map_err(|e| format!("Failed to create keyring entry: {}", e))
 }
 
 /// Creates a bilibili cookie entry with the standard host.
@@ -80,27 +66,18 @@ fn bilibili_cookie(name: &str, value: String) -> CookieEntry {
     }
 }
 
-/// Saves session to OS keyring.
+/// Saves session to encrypted file storage.
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - Keyring is not available (e.g., no Secret Service on Linux)
-/// - Failed to store the credential
-fn save_session_to_keyring(session: &Session) -> Result<(), String> {
+/// Returns an error if encryption or file write fails.
+fn save_session_to_store(app: &AppHandle, session: &Session) -> Result<(), String> {
     if is_e2e_testing() {
-        log::info!("[BE] save_session_to_keyring: skipped (E2E_TESTING)");
+        log::info!("[BE] save_session_to_store: skipped (E2E_TESTING)");
         return Ok(());
     }
-    log::info!("[BE] save_session_to_keyring: saving session to keyring");
-    let entry = create_keyring_entry()?;
-
-    let session_json = serde_json::to_string(session)
-        .map_err(|e| format!("Failed to serialize session: {}", e))?;
-
-    entry
-        .set_password(&session_json)
-        .map_err(|e| format!("Failed to store session in keyring: {}", e))?;
+    log::info!("[BE] save_session_to_store: saving session");
+    STORAGE.save(app, session)?;
 
     // Update cache
     {
@@ -110,17 +87,14 @@ fn save_session_to_keyring(session: &Session) -> Result<(), String> {
         *cache = Some(Some(session.clone()));
     }
 
-    log::info!(
-        "[BE] save_session_to_keyring: session saved successfully ({} bytes)",
-        session_json.len()
-    );
+    log::info!("[BE] save_session_to_store: session saved successfully");
     Ok(())
 }
 
-/// Loads session from OS keyring with caching.
+/// Loads session from encrypted file storage with caching.
 ///
-/// Uses an in-memory cache to avoid multiple keyring access dialogs.
-/// On first call, reads from keyring and caches the result.
+/// Uses an in-memory cache to avoid repeated file reads.
+/// On first call, reads from encrypted file and caches the result.
 /// Subsequent calls return the cached value.
 ///
 /// # Returns
@@ -129,74 +103,59 @@ fn save_session_to_keyring(session: &Session) -> Result<(), String> {
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - Keyring is not available
-/// - Failed to retrieve the credential
-fn load_session_from_keyring() -> Result<Option<Session>, String> {
+/// Returns an error if file read or decryption fails.
+fn load_session_from_store(app: &AppHandle) -> Result<Option<Session>, String> {
     if is_e2e_testing() {
-        log::info!("[BE] load_session_from_keyring: skipped (E2E_TESTING)");
+        log::info!("[BE] load_session_from_store: skipped (E2E_TESTING)");
         return Ok(None);
     }
-    log::info!("[BE] load_session_from_keyring: loading session from keyring");
+    log::info!("[BE] load_session_from_store: loading session");
     // Check cache first
     {
         let cache = SESSION_CACHE
             .read()
             .map_err(|e| format!("Failed to read cache: {}", e))?;
         if let Some(cached) = cache.as_ref() {
-            log::info!("[BE] load_session_from_keyring: returning cached session");
+            log::info!("[BE] load_session_from_store: returning cached session");
             return Ok(cached.clone());
         }
     }
 
-    // Not cached, read from keyring
-    let entry = create_keyring_entry().map_err(|e| {
-        log::error!("[BE] load_session_from_keyring: {}", e);
-        e
-    })?;
+    // Not cached, read from storage
+    let result = STORAGE.load(app);
 
-    let result = match entry.get_password() {
-        Ok(json) => {
-            let session: Session = serde_json::from_str(&json)
-                .map_err(|e| format!("Failed to deserialize session: {}", e))?;
-            log::info!("[BE] load_session_from_keyring: session loaded successfully");
-            Ok(Some(session))
+    match &result {
+        Ok(Some(session)) => {
+            log::info!("[BE] load_session_from_store: session loaded successfully");
+            let mut cache = SESSION_CACHE
+                .write()
+                .map_err(|e| format!("Failed to write cache: {}", e))?;
+            *cache = Some(Some(session.clone()));
         }
-        Err(keyring::Error::NoEntry) => {
-            log::info!("[BE] load_session_from_keyring: no session found");
-            Ok(None)
+        Ok(None) => {
+            log::info!("[BE] load_session_from_store: no session found");
+            let mut cache = SESSION_CACHE
+                .write()
+                .map_err(|e| format!("Failed to write cache: {}", e))?;
+            *cache = Some(None);
         }
-        Err(e) => {
-            log::error!(
-                "[BE] load_session_from_keyring: failed to get password: {}",
-                e
-            );
-            Err(format!("Failed to retrieve session from keyring: {}", e))
-        }
-    };
-
-    // Cache the result
-    if let Ok(ref session) = result {
-        let mut cache = SESSION_CACHE
-            .write()
-            .map_err(|e| format!("Failed to write cache: {}", e))?;
-        *cache = Some(session.clone());
+        Err(e) => log::error!("[BE] load_session_from_store: {}", e),
     }
 
     result
 }
 
-/// Deletes session from OS keyring and clears cache.
+/// Deletes session from encrypted file storage and clears cache.
 ///
 /// # Errors
 ///
-/// Returns an error if deletion fails (ignores "no entry" error).
-fn delete_session_from_keyring() -> Result<(), String> {
+/// Returns an error if file deletion fails.
+fn delete_session_from_store(app: &AppHandle) -> Result<(), String> {
     if is_e2e_testing() {
-        log::info!("[BE] delete_session_from_keyring: skipped (E2E_TESTING)");
+        log::info!("[BE] delete_session_from_store: skipped (E2E_TESTING)");
         return Ok(());
     }
-    log::info!("[BE] delete_session_from_keyring: deleting session from keyring");
+    log::info!("[BE] delete_session_from_store: deleting session");
     // Clear cache first
     {
         let mut cache = SESSION_CACHE
@@ -205,25 +164,10 @@ fn delete_session_from_keyring() -> Result<(), String> {
         *cache = None;
     }
 
-    let entry = create_keyring_entry().map_err(|e| {
-        log::error!("[BE] delete_session_from_keyring: {}", e);
-        e
-    })?;
+    STORAGE.delete(app)?;
 
-    match entry.delete_credential() {
-        Ok(()) => {
-            log::info!("[BE] delete_session_from_keyring: session deleted successfully");
-            Ok(())
-        }
-        Err(keyring::Error::NoEntry) => {
-            log::info!("[BE] delete_session_from_keyring: no session to delete");
-            Ok(())
-        }
-        Err(e) => {
-            log::error!("[BE] delete_session_from_keyring: failed to delete: {}", e);
-            Err(format!("Failed to delete session from keyring: {}", e))
-        }
-    }
+    log::info!("[BE] delete_session_from_store: session deleted successfully");
+    Ok(())
 }
 
 /// Generates a QR code for Bilibili login.
@@ -466,13 +410,13 @@ fn extract_session_from_url(
     })
 }
 
-/// Saves the session to OS keyring and login method to store.
+/// Saves the session to encrypted file storage and login method to store.
 ///
-/// The session tokens are stored securely in the OS's credential storage,
+/// The session tokens are encrypted and stored in the app data directory,
 /// while only the login method preference is stored in the regular store.
 async fn save_session(app: &AppHandle, session: &Session) -> Result<(), String> {
-    // Save session to keyring (secure storage)
-    save_session_to_keyring(session)?;
+    // Save session to encrypted file storage
+    save_session_to_store(app, session)?;
 
     // Save only the login method to store (non-sensitive)
     let store = app
@@ -524,7 +468,7 @@ fn update_cookie_cache(app: &AppHandle, session: &Session) {
     *guard = cookies;
 }
 
-/// Loads the stored session from keyring and updates cookie cache.
+/// Loads the stored session from encrypted file and updates cookie cache.
 ///
 /// This should be called on app startup to restore login state.
 ///
@@ -534,7 +478,7 @@ fn update_cookie_cache(app: &AppHandle, session: &Session) {
 ///
 /// # Errors
 ///
-/// Returns an error if keyring is not available (e.g., no Secret Service on Linux).
+/// Returns an error if file read or decryption fails.
 pub async fn load_stored_session(app: &AppHandle) -> Result<bool, String> {
     // Check login method preference
     let login_state = get_login_state_from_store(app).await?;
@@ -543,8 +487,8 @@ pub async fn load_stored_session(app: &AppHandle) -> Result<bool, String> {
         return Ok(false);
     }
 
-    // Load session from keyring
-    let session = load_session_from_keyring()?;
+    // Load session from encrypted file storage
+    let session = load_session_from_store(app)?;
 
     if let Some(session) = session {
         log::info!(
@@ -559,7 +503,7 @@ pub async fn load_stored_session(app: &AppHandle) -> Result<bool, String> {
     Ok(false)
 }
 
-/// Logs out by clearing the stored session from keyring and cookie cache.
+/// Logs out by clearing the stored session and cookie cache.
 ///
 /// # Arguments
 ///
@@ -576,8 +520,8 @@ pub async fn logout(app: &AppHandle) -> Result<(), String> {
         }
     }
 
-    // Delete session from keyring
-    delete_session_from_keyring()?;
+    // Delete session from encrypted file storage
+    delete_session_from_store(app)?;
 
     // Clear login method from store
     let store = app
@@ -612,7 +556,7 @@ pub async fn set_login_method(app: &AppHandle, method: LoginMethod) -> Result<()
         .store(STORE_FILE_NAME)
         .map_err(|e| format!("Failed to open store: {}", e))?;
 
-    // Only store the method, not the session (session is in keyring)
+    // Only store the method, not the session (session is in encrypted file)
     let login_state = LoginState {
         method,
         session: None,
@@ -646,7 +590,7 @@ pub async fn get_login_method(app: &AppHandle) -> Result<LoginMethod, String> {
 
 /// Gets the current login state from store (method only, no session).
 ///
-/// Session data is loaded from keyring separately.
+/// Session data is loaded from encrypted file separately.
 async fn get_login_state_from_store(app: &AppHandle) -> Result<LoginState, String> {
     let store = match app.store(STORE_FILE_NAME) {
         Ok(s) => s,
@@ -667,7 +611,7 @@ async fn get_login_state_from_store(app: &AppHandle) -> Result<LoginState, Strin
     Ok(state)
 }
 
-/// Gets the current login state including session from keyring.
+/// Gets the current login state including session from encrypted file.
 ///
 /// # Arguments
 ///
@@ -675,17 +619,17 @@ async fn get_login_state_from_store(app: &AppHandle) -> Result<LoginState, Strin
 ///
 /// # Returns
 ///
-/// Returns the current login state with session (if available from keyring).
+/// Returns the current login state with session (if available from encrypted file).
 ///
 /// # Errors
 ///
-/// Returns an error if keyring is not available.
+/// Returns an error if file read or decryption fails.
 pub async fn get_login_state(app: &AppHandle) -> Result<LoginState, String> {
     let store_state = get_login_state_from_store(app).await?;
 
-    // Load session from keyring if using QR code method
+    // Load session from encrypted file if using QR code method
     let session = if store_state.method == LoginMethod::QrCode {
-        load_session_from_keyring()?
+        load_session_from_store(app)?
     } else {
         None
     };
@@ -791,16 +735,11 @@ fn generate_correspond_path(timestamp: i64) -> Result<String, String> {
 ///
 /// The HTML response contains a div with id '1-name' containing the refresh_csrf token.
 async fn fetch_refresh_csrf(app: &AppHandle, correspond_path: &str) -> Result<String, String> {
-    log::debug!("[BE] fetch_refresh_csrf: Starting...");
     let cookies = get_cookie_header(app);
     let url = format!("{}{}", CORRESPOND_URL_PREFIX, correspond_path);
     log::debug!("[BE] fetch_refresh_csrf: URL: {}", url);
 
-    let client = Client::builder()
-        .build()
-        .map_err(|e| format!("Failed to build client: {}", e))?;
-
-    log::debug!("[BE] fetch_refresh_csrf: Sending request...");
+    let client = Client::new();
     let response = client
         .get(&url)
         .header("Cookie", &cookies)
@@ -810,23 +749,19 @@ async fn fetch_refresh_csrf(app: &AppHandle, correspond_path: &str) -> Result<St
         .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
         .send()
         .await
-        .map_err(|e| {
-            log::debug!("[BE] fetch_refresh_csrf: Request failed: {}", e);
-            format!("Failed to fetch refresh_csrf: {}", e)
-        })?;
+        .map_err(|e| format!("Failed to fetch refresh_csrf: {}", e))?;
 
     log::debug!(
         "[BE] fetch_refresh_csrf: Response status: {}",
         response.status()
     );
 
-    let html = response.text().await.map_err(|e| {
-        log::debug!("[BE] fetch_refresh_csrf: Failed to read body: {}", e);
-        format!("Failed to read response: {}", e)
-    })?;
+    let html = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response: {}", e))?;
 
     log::debug!("[BE] fetch_refresh_csrf: HTML length: {} bytes", html.len());
-    log::debug!("[BE] fetch_refresh_csrf: HTML content: {}", html);
 
     // Parse refresh_csrf from HTML: <div id="1-name">{refresh_csrf}</div>
     let start_tag = r#"<div id="1-name">"#;
@@ -875,14 +810,10 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
     log::debug!("[BE] Refresh needed, timestamp: {}", refresh_info.timestamp);
 
     // Get current session for refresh_token and csrf
-    let login_state = get_login_state(app).await.map_err(|e| {
-        log::debug!("[BE] ERROR getting login state: {}", e);
-        e
-    })?;
-    let session = login_state.session.ok_or_else(|| {
-        log::debug!("[BE] ERROR: No QR session found in login state");
-        "No QR session found".to_string()
-    })?;
+    let login_state = get_login_state(app).await?;
+    let session = login_state
+        .session
+        .ok_or_else(|| "No QR session found".to_string())?;
 
     log::debug!(
         "[BE] Found session: sessdata={} bytes, refresh_token={} bytes",
@@ -891,10 +822,7 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
     );
 
     // Step 2: Generate CorrespondPath
-    let correspond_path = generate_correspond_path(refresh_info.timestamp).map_err(|e| {
-        log::debug!("[BE] ERROR generating correspond path: {}", e);
-        e
-    })?;
+    let correspond_path = generate_correspond_path(refresh_info.timestamp)?;
     log::debug!(
         "[BE] Generated CorrespondPath: {} bytes",
         correspond_path.len()
@@ -902,12 +830,7 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
 
     // Step 3: Fetch refresh_csrf
     log::debug!("[BE] Fetching refresh_csrf...");
-    let refresh_csrf = fetch_refresh_csrf(app, &correspond_path)
-        .await
-        .map_err(|e| {
-            log::debug!("[BE] ERROR fetching refresh_csrf: {}", e);
-            e
-        })?;
+    let refresh_csrf = fetch_refresh_csrf(app, &correspond_path).await?;
     log::debug!("[BE] Got refresh_csrf: {}", refresh_csrf);
 
     // Step 4: Call cookie refresh API
@@ -936,19 +859,13 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
     let new_cookies = extract_cookies_from_response(&response);
     log::debug!("[BE] Extracted {} cookies from response", new_cookies.len());
 
-    // Get response body as text first for debugging
-    let response_text = response.text().await.map_err(|e| {
-        log::debug!("[BE] ERROR reading response body: {}", e);
-        format!("Failed to read response body: {}", e)
-    })?;
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response body: {}", e))?;
 
-    log::debug!("[BE] Response body: {}", response_text);
-
-    let refresh_response: CookieRefreshResponse =
-        serde_json::from_str(&response_text).map_err(|e| {
-            log::debug!("[BE] ERROR parsing JSON: {}", e);
-            format!("Failed to parse refresh response: {}", e)
-        })?;
+    let refresh_response: CookieRefreshResponse = serde_json::from_str(&response_text)
+        .map_err(|e| format!("Failed to parse refresh response: {}", e))?;
 
     log::debug!(
         "[BE] Refresh API code: {}, message: {}",

--- a/src-tauri/src/models/qr_login.rs
+++ b/src-tauri/src/models/qr_login.rs
@@ -93,7 +93,7 @@ impl From<i32> for QrCodeStatus {
 
 /// Session data stored after successful login.
 ///
-/// This is persisted using OS keyring for secure storage,
+/// This is persisted in an encrypted file for secure storage,
 /// enabling automatic login on subsequent app launches.
 ///
 /// This structure is shared across different login methods (QR code, Firefox cookies, etc.)
@@ -164,13 +164,14 @@ pub enum LoginMethod {
 
 /// Stored login state for persistence.
 ///
-/// Note: Session data is stored in OS keyring,/// while only the login method preference is stored in tauri-plugin-store.
+/// Note: Session data is stored in an encrypted file,
+/// while only the login method preference is stored in tauri-plugin-store.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginState {
     /// Preferred login method
     pub method: LoginMethod,
-    /// Session data (stored in OS keyring, not in store)
+    /// Session data (stored in encrypted file, not in store)
     #[serde(rename = "session")]
     pub session: Option<Session>,
 }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -10,5 +10,6 @@ pub mod error_handler;
 pub mod log_cleanup;
 pub mod paths;
 pub mod sanitize;
+pub mod secure_storage;
 pub mod subtitle;
 pub mod wbi;

--- a/src-tauri/src/utils/secure_storage.rs
+++ b/src-tauri/src/utils/secure_storage.rs
@@ -1,0 +1,201 @@
+//! Encrypted File Storage for Session Data
+//!
+//! Replaces OS keyring with argon2 + AES-256-GCM encrypted file storage.
+//! The encrypted session file is stored in the Tauri app data directory.
+//!
+//! # Encryption
+//!
+//! - Key derivation: argon2id from hostname + username
+//! - Encryption: AES-256-GCM with random nonce per write
+//! - File format: [nonce: 12 bytes][ciphertext + GCM tag]
+//! - File permissions: 0o600 on Unix
+
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
+use aes_gcm::Aes256Gcm;
+use aes_gcm::Nonce;
+use argon2::{Algorithm, Argon2, Params, Version};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+use crate::models::qr_login::Session;
+
+const SESSION_FILE: &str = ".session.enc";
+const NONCE_SIZE: usize = 12;
+
+/// Alias for results returned by secure storage operations.
+pub type Result<T> = std::result::Result<T, String>;
+
+/// Trait for secure session storage operations.
+pub trait SecureStorage: Send + Sync {
+    fn save(&self, app: &AppHandle, session: &Session) -> Result<()>;
+    fn load(&self, app: &AppHandle) -> Result<Option<Session>>;
+    fn delete(&self, app: &AppHandle) -> Result<()>;
+}
+
+/// AES-256-GCM encrypted file storage.
+///
+/// Uses argon2id for key derivation and AES-256-GCM for authenticated
+/// encryption. Each write generates a fresh random nonce to ensure
+/// semantic security across successive saves.
+pub struct EncryptedFileStorage;
+
+impl EncryptedFileStorage {
+    /// Creates a new `EncryptedFileStorage` instance.
+    ///
+    /// This is a zero-sized type, so construction is effectively free.
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for EncryptedFileStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecureStorage for EncryptedFileStorage {
+    fn save(&self, app: &AppHandle, session: &Session) -> Result<()> {
+        let json = serde_json::to_vec(session)
+            .map_err(|e| format!("Failed to serialize session: {}", e))?;
+
+        let key = derive_key()?;
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let cipher = Aes256Gcm::new_from_slice(&key)
+            .map_err(|e| format!("Failed to create cipher: {}", e))?;
+
+        let ciphertext = cipher
+            .encrypt(&nonce, json.as_ref())
+            .map_err(|e| format!("Encryption failed: {}", e))?;
+
+        let mut blob = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+        blob.extend_from_slice(&nonce);
+        blob.extend_from_slice(&ciphertext);
+
+        let path = session_file_path(app);
+        fs::write(&path, &blob).map_err(|e| format!("Failed to write session file: {}", e))?;
+
+        set_file_permissions(&path);
+
+        log::info!("[BE] secure_storage::save: wrote {} bytes", blob.len());
+        Ok(())
+    }
+
+    fn load(&self, app: &AppHandle) -> Result<Option<Session>> {
+        let path = session_file_path(app);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let blob = fs::read(&path).map_err(|e| format!("Failed to read session file: {}", e))?;
+
+        if blob.len() <= NONCE_SIZE {
+            log::warn!("[BE] secure_storage::load: file too short, treating as empty");
+            return Ok(None);
+        }
+
+        let (nonce_bytes, ciphertext) = blob.split_at(NONCE_SIZE);
+        let nonce = Nonce::from_slice(nonce_bytes);
+
+        let key = derive_key()?;
+        let cipher = Aes256Gcm::new_from_slice(&key)
+            .map_err(|e| format!("Failed to create cipher: {}", e))?;
+
+        let plaintext = match cipher.decrypt(nonce, ciphertext) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!(
+                    "[BE] secure_storage::load: decryption failed ({}), \
+                     treating as no session",
+                    e
+                );
+                return Ok(None);
+            }
+        };
+
+        let session: Session = serde_json::from_slice(&plaintext)
+            .map_err(|e| format!("Failed to deserialize session: {}", e))?;
+
+        log::info!("[BE] secure_storage::load: session loaded successfully");
+        Ok(Some(session))
+    }
+
+    fn delete(&self, app: &AppHandle) -> Result<()> {
+        let path = session_file_path(app);
+        if path.exists() {
+            fs::remove_file(&path).map_err(|e| format!("Failed to delete session file: {}", e))?;
+            log::info!("[BE] secure_storage::delete: session file deleted");
+        } else {
+            log::info!("[BE] secure_storage::delete: no session file to delete");
+        }
+        Ok(())
+    }
+}
+
+/// Derives a 256-bit encryption key using argon2id.
+///
+/// The key material is derived from:
+/// - **Password**: `"bilibili-dl-session:{USER}"` (or `USERNAME` on Windows)
+/// - **Salt**: `"bilibili-dl:{hostname}:{user}"`
+///
+/// Argon2 parameters: 64 MiB memory, 3 iterations, 4 parallelism.
+///
+/// # Errors
+///
+/// Returns an error if the hostname cannot be resolved or argon2
+/// parameter construction / hashing fails.
+fn derive_key() -> Result<[u8; 32]> {
+    let host = hostname::get()
+        .map_err(|e| format!("Failed to get hostname: {}", e))?
+        .to_string_lossy()
+        .to_string();
+
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let password = format!("bilibili-dl-session:{}", user);
+    let salt_input = format!("bilibili-dl:{}:{}", host, user);
+
+    let params = Params::new(64 * 1024, 3, 4, Some(32))
+        .map_err(|e| format!("Failed to create argon2 params: {}", e))?;
+
+    let hasher = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+
+    let mut key = [0u8; 32];
+    hasher
+        .hash_password_into(password.as_bytes(), salt_input.as_bytes(), &mut key)
+        .map_err(|e| format!("Key derivation failed: {}", e))?;
+
+    Ok(key)
+}
+
+/// Returns the path to the encrypted session file in the app data directory.
+///
+/// Falls back to the current directory if the app data directory is
+/// unavailable.
+fn session_file_path(app: &AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(SESSION_FILE)
+}
+
+/// Restricts the session file to owner-read/write only (0o600) on Unix.
+///
+/// Failures are logged as warnings but do not propagate, since overly
+/// permissive file modes are a security concern but not a functional error.
+#[cfg(unix)]
+fn set_file_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(e) = fs::set_permissions(path, fs::Permissions::from_mode(0o600)) {
+        log::warn!("[BE] secure_storage: failed to set file permissions: {}", e);
+    }
+}
+
+/// No-op on non-Unix platforms.
+///
+/// Windows uses ACLs; the file inherits the user's permissions by default.
+#[cfg(not(unix))]
+fn set_file_permissions(_path: &Path) {}

--- a/src/features/login/model/useLogin.ts
+++ b/src/features/login/model/useLogin.ts
@@ -35,9 +35,32 @@ import {
   setSession,
 } from './loginSlice'
 
+/** Interval between successive QR status polls, in milliseconds. */
 const POLL_INTERVAL_MS = 2000
+
+/** Time after which an unscanned QR code is considered expired, in milliseconds. */
 const QR_EXPIRY_MS = 180000
 
+/**
+ * Hook that encapsulates the complete QR-code login lifecycle.
+ *
+ * Manages QR code generation, recursive status polling, session
+ * persistence, logout, and login-method switching.  Polling timers
+ * are held in refs so they survive re-renders; an expiry timeout
+ * automatically stops polling after {@link QR_EXPIRY_MS}.
+ *
+ * @returns The full login state spread together with action callbacks:
+ *   - `generateNewQrCode` - requests a new QR code and starts polling
+ *   - `stopPolling` - immediately cancels the active polling loop
+ *   - `logout` - clears the server-side session and local state
+ *   - `changeLoginMethod` - switches the preferred login method
+ *   - `resetLogin` - resets the login slice to its initial state
+ *
+ * @example
+ * ```tsx
+ * const { qrCode, qrStatus, generateNewQrCode } = useLogin()
+ * ```
+ */
 export function useLogin() {
   const dispatch = useDispatch()
   const loginState = useSelector((state: RootState) => state.login)
@@ -48,7 +71,7 @@ export function useLogin() {
   /** Clears all polling timers. */
   const clearTimers = useCallback(() => {
     if (pollIntervalRef.current) {
-      clearInterval(pollIntervalRef.current)
+      clearTimeout(pollIntervalRef.current)
       pollIntervalRef.current = null
     }
     if (expiryTimeoutRef.current) {
@@ -81,8 +104,11 @@ export function useLogin() {
         }
       }, QR_EXPIRY_MS)
 
-      // Start polling interval
-      pollIntervalRef.current = window.setInterval(async () => {
+      // Recursive poll — schedules the next poll only after the previous one
+      // completes.  This prevents overlapping requests which can cause a race
+      // condition where a late second poll returns "expired" before the first
+      // (successful) poll finishes processing.
+      const poll = async () => {
         if (!isPollingRef.current) return
 
         try {
@@ -101,6 +127,9 @@ export function useLogin() {
             stopPolling()
           } else if (result.status === 'expired' || result.status === 'error') {
             stopPolling()
+          } else {
+            // Schedule next poll only after this one completes
+            pollIntervalRef.current = window.setTimeout(poll, POLL_INTERVAL_MS)
           }
         } catch (error) {
           if (isPollingRef.current) {
@@ -112,7 +141,10 @@ export function useLogin() {
             stopPolling()
           }
         }
-      }, POLL_INTERVAL_MS)
+      }
+
+      // Start first poll immediately
+      poll()
     },
     [dispatch, clearTimers, stopPolling],
   )


### PR DESCRIPTION
## Summary

- Replace OS keyring (which causes repeated macOS password prompts for unsigned apps) with argon2id + AES-256-GCM encrypted file storage in the Tauri app data directory
- Add `SecureStorage` trait + `EncryptedFileStorage` implementation for clean architecture
- Fix QR code polling race condition where overlapping `setInterval` callbacks caused "expired" status before the successful poll finished processing

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Navigate to QR code login page
- [ ] Scan QR code with Bilibili app
- [ ] Verify login succeeds without "expired" error
- [ ] Restart the app and verify session is restored from encrypted file
- [ ] Verify no macOS password prompt appears on launch

## Breaking Changes

- Users will need to re-login once after this update (keyring sessions are not migrated)

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)