### PR TITLE
fix(subtitle): improve download reliability with retry fallback

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -687,15 +687,16 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         )?;
 
         // Subtitle processing
-        let (subtitle_mode, subtitle_language_labels) = prepare_subtitle_mode(
-            &options.subtitle,
-            &cookies,
-            &options.bvid,
-            options.cid,
-            &options.download_id,
-            &lib_path,
-        )
-        .await?;
+        let (subtitle_mode, subtitle_language_labels, subtitle_failed_labels) =
+            prepare_subtitle_mode(
+                &options.subtitle,
+                &cookies,
+                &options.bvid,
+                options.cid,
+                &options.download_id,
+                &lib_path,
+            )
+            .await?;
 
         // Emit subtitle resolved event to frontend
         let subtitle_mode_str = match &subtitle_mode {
@@ -713,6 +714,18 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             },
         )
         .ok();
+
+        // Emit warning if any subtitle downloads failed
+        if !subtitle_failed_labels.is_empty() {
+            app.emit(
+                "download-subtitle-warning",
+                serde_json::json!({
+                    "downloadId": options.download_id,
+                    "failedLanguages": subtitle_failed_labels,
+                }),
+            )
+            .ok();
+        }
 
         // Keep subtitle file paths for cleanup
         let subtitle_paths: Vec<PathBuf> = match &subtitle_mode {
@@ -2068,25 +2081,26 @@ pub async fn fetch_subtitles_for_part(
     Ok(subtitles)
 }
 
-/// 古いCDNキャッシュの影響を緩和するため、並行リクエストで字幕を取得する。
+/// Fetches subtitles via parallel requests to mitigate stale CDN cache.
 ///
-/// BilibiliのCDNは、AI翻訳字幕（`ai_type: 1`）の完全なセットではなく、
-/// 単一のAI字幕（`ai_type: 0`）のみを含む古いキャッシュを返すことがある。
-/// 逐次リトライではなく、[`PARALLEL_COUNT`] 件のリクエストを並行して
-/// 発行し、CDNノード間に小さなジッターを挟むことで、新鲜な応答を
-/// 取得できる確率を高める。最も件数の多い字幕リストを最適結果として返す。
+/// Bilibili's CDN may return stale cached responses that contain only a single
+/// AI subtitle (`ai_type: 0`) instead of the full set of AI-translated
+/// subtitles (`ai_type: 1`). Rather than retrying sequentially, this function
+/// issues [`PARALLEL_COUNT`] concurrent requests with small inter-request
+/// jitter, increasing the probability of hitting a fresh CDN node.
+/// Returns the subtitle list with the most entries as the best result.
 ///
 /// # Arguments
 ///
-/// * `client` - APIリクエストに使用するHTTPクライアント
-/// * `cookies` - 認証用のCookieエントリ
-/// * `bvid` - Bilibili動画ID（BV識別子）
-/// * `cid` - 特定動画パートのコンテンツID
+/// * `client` - HTTP client used for API requests
+/// * `cookies` - Cookie entries for authentication
+/// * `bvid` - Bilibili video ID (BV identifier)
+/// * `cid` - Content ID for the specific video part
 ///
 /// # Returns
 ///
-/// 並行試行の中で最も件数の多い字幕リストを返す。
-/// すべてのリクエストが失敗した場合は空のベクタを返す。
+/// Returns the subtitle list with the most entries from all parallel attempts.
+/// Returns an empty vector if all requests fail.
 async fn fetch_subtitles_parallel(
     client: &Client,
     cookies: &[CookieEntry],
@@ -2250,33 +2264,33 @@ pub async fn download_subtitle(
     Ok(())
 }
 
-/// 指数バックオフ付きで字幕をダウンロードする。
+/// Downloads a subtitle with exponential backoff retry.
 ///
-/// BilibiliのCDNが古いキャッシュを返す場合に備え、最大 [`MAX_RETRIES`] 回
-/// リトライを行う。遅延は 2s, 4s, 8s, 16s, 32s と指数的に増加する。
-/// 各試行の失敗時には、不完全なファイルを残さないよう出力ファイルを
-/// 削除してから次の試行へ移行する。
+/// Retries up to [`MAX_RETRIES`] times when Bilibili's CDN returns stale
+/// cached responses. The delay increases exponentially: 2s, 4s, 8s, 16s, 32s.
+/// On each failed attempt, the output file is deleted to avoid leaving
+/// partial files before proceeding to the next attempt.
 ///
 /// # Arguments
 ///
-/// * `client` - HTTPリクエストに使用するクライアント
-/// * `subtitle_url` - BCC形式字幕JSONのURL（`//` で始まる場合あり）
-/// * `output_path` - 変換後のSRTファイルの出力パス
+/// * `client` - HTTP client used for the request
+/// * `subtitle_url` - BCC subtitle JSON URL (may start with `//`)
+/// * `output_path` - Output path for the converted SRT file
 ///
 /// # Returns
 ///
-/// ダウンロードとSRT変換に成功した場合は `Ok(())` を返す。
+/// Returns `Ok(())` if the download and SRT conversion succeed.
 ///
 /// # Errors
 ///
-/// すべてのリトライ試行が失敗した場合、最後のエラーメッセージを含む
-/// `Err(String)` を返す。リトライ回数は [`MAX_RETRIES`]（デフォルト5回）。
+/// Returns `Err(String)` with the last error message if all retry attempts
+/// fail. Maximum retry count is [`MAX_RETRIES`] (default: 3).
 async fn download_subtitle_with_retry(
     client: &Client,
     subtitle_url: &str,
     output_path: &std::path::Path,
 ) -> Result<(), String> {
-    const MAX_RETRIES: usize = 5;
+    const MAX_RETRIES: usize = 3;
     const BASE_DELAY_SECS: u64 = 2;
 
     for attempt in 0..MAX_RETRIES {
@@ -2316,41 +2330,45 @@ async fn download_subtitle_with_retry(
     ))
 }
 
-/// ユーザーの字幕オプションに基づいて字幕マージモードを準備する。
+/// Prepares subtitle merge mode based on user subtitle options.
 ///
-/// 選択された字幕をダウンロードし、ffmpeg用の適切なマージモードを返す。
-/// BCC JSON形式の字幕をSRT形式に変換し、一時ファイルとして保存する。
-/// 複数言語の字幕は並行してダウンロードされ、失敗した字幕は
-/// 警告ログとともにスキップされる（ダウンロード全体は失敗しない）。
+/// Downloads selected subtitles and returns the appropriate merge mode for
+/// ffmpeg. Converts BCC JSON subtitles to SRT format and saves them as
+/// temporary files.
 ///
-/// # Processing Flow
+/// # Retry Strategy
 ///
-/// 1. 字幕オプションが "off" または言語未選択なら `MergeMode::None` を返す
-/// 2. フロントエンドから渡された字幕情報を使用、なければAPIから取得
-/// 3. ユーザーが選択した言語で字幕をフィルタリング
-/// 4. 選択された各言語の字幕を **並行** でダウンロード（指数バックオフ付きリトライ）
-/// 5. マージモードと言語ラベルを返す
+/// Subtitle downloads execute up to 3 outer-loop attempts:
+/// 1. Download each subtitle in parallel using current URLs (each with
+///    3 exponential-backoff retries via [`download_subtitle_with_retry`])
+/// 2. If any subtitles fail, re-fetch fresh URLs from the API
+/// 3. Re-download only the failed subtitles using the new URLs
+///
+/// When the same URL fails repeatedly due to stale CDN cache data,
+/// re-fetching from the API provides URLs from a different CDN node,
+/// improving the success rate.
 ///
 /// # Arguments
 ///
-/// * `subtitle_opts` - ユーザーの字幕選択（モードと言語コード）
-/// * `cookies` - 認証用のCookieエントリ
-/// * `bvid` - Bilibili動画ID
-/// * `cid` - コンテンツID
-/// * `download_id` - 一時ファイル名に使用する一意識別子
-/// * `lib_path` - 一時字幕ファイルの出力ディレクトリ
+/// * `subtitle_opts` - User subtitle selection (mode and language codes)
+/// * `cookies` - Cookie entries for authentication
+/// * `bvid` - Bilibili video ID
+/// * `cid` - Content ID
+/// * `download_id` - Unique identifier used for temporary file names
+/// * `lib_path` - Output directory for temporary subtitle files
 ///
 /// # Returns
 ///
-/// `(MergeMode, language_labels)` タプルを返す:
-/// - `MergeMode::None` - 字幕無効、未選択、またはマッチする字幕なし
-/// - `MergeMode::SoftSub` - ソフト字幕モード（複数言語対応）
-/// - `MergeMode::HardSub` - ハード字幕モード（焼き込み、1言語のみ）
-/// - `language_labels` - 選択された字幕の表示名（lan_doc）のリスト
+/// Returns a `(MergeMode, language_labels, failed_labels)` tuple:
+/// - `MergeMode::None` - Subtitles disabled, none selected, or no matching subtitles found
+/// - `MergeMode::SoftSub` - Soft subtitle mode (supports multiple languages)
+/// - `MergeMode::HardSub` - Hard subtitle mode (burned-in, single language only)
+/// - `language_labels` - Display names (`lan_doc`) of successfully downloaded subtitles
+/// - `failed_labels` - Display names of subtitles that failed all 3 outer attempts
 ///
 /// # Errors
 ///
-/// HTTPクライアントの構築に失敗した場合にエラーを返す。
+/// Returns an error if the HTTP client cannot be constructed.
 async fn prepare_subtitle_mode(
     subtitle_opts: &Option<SubtitleOptions>,
     cookies: &[CookieEntry],
@@ -2358,22 +2376,21 @@ async fn prepare_subtitle_mode(
     cid: i64,
     download_id: &str,
     lib_path: &Path,
-) -> Result<(crate::handlers::ffmpeg::MergeMode, Vec<String>), String> {
+) -> Result<(crate::handlers::ffmpeg::MergeMode, Vec<String>, Vec<String>), String> {
     use crate::handlers::ffmpeg::{MergeMode, SubtitleMergeOptions};
     use crate::utils::subtitle::lan_to_iso639;
 
     let sub_opts = match subtitle_opts {
         Some(opts) if opts.mode != "off" && !opts.selected_lans.is_empty() => opts,
-        _ => return Ok((MergeMode::None, vec![])),
+        _ => return Ok((MergeMode::None, vec![], vec![])),
     };
 
-    // Build client for subtitle download (needed regardless of source)
     let client = build_client()?;
 
-    // Use passed subtitles from frontend if available, otherwise fetch from API
-    let available_subs: Vec<_> = if !sub_opts.subtitles.is_empty() {
+    // Initial subtitles from frontend or API
+    let initial_subs: Vec<SubtitleDto> = if !sub_opts.subtitles.is_empty() {
         log::info!(
-            "[BE] prepare_subtitle_mode: using {} subtitles passed from frontend",
+            "[BE] prepare_subtitle_mode: using {} subtitles from frontend",
             sub_opts.subtitles.len()
         );
         sub_opts
@@ -2396,63 +2413,116 @@ async fn prepare_subtitle_mode(
         subs
     };
 
-    let selected_subs: Vec<_> = available_subs
-        .iter()
-        .filter(|s| sub_opts.selected_lans.contains(&s.lan))
-        .collect();
-
-    if selected_subs.is_empty() {
-        return Ok((MergeMode::None, vec![]));
-    }
-
     let mut subtitle_files: Vec<SubtitleMergeOptions> = Vec::new();
     let mut language_labels: Vec<String> = Vec::new();
+    let mut remaining_lans: Vec<String> = sub_opts.selected_lans.clone();
 
-    // 選択された各言語の字幕を並行してダウンロードする。
-    // 各リクエストは download_subtitle_with_retry（指数バックオフ付き）を使用し、
-    // 一部の字幕ダウンロードが失敗しても成功した字幕のみで処理を継続する。
-    let futures: Vec<_> = selected_subs
-        .into_iter()
-        .map(|sub| {
-            let srt_path = lib_path.join(format!("temp_sub_{download_id}_{}.srt", sub.lan));
-            let client = client.clone();
-            let sub = sub.clone();
-            async move {
-                match download_subtitle_with_retry(&client, &sub.subtitle_url, &srt_path).await {
-                    Ok(()) => Some((
-                        SubtitleMergeOptions {
-                            path: srt_path,
-                            language: lan_to_iso639(&sub.lan).to_string(),
-                            title: sub.lan_doc.clone(),
-                        },
-                        sub.lan_doc,
-                    )),
-                    Err(e) => {
-                        log::warn!(
-                            "[BE] download_video: failed to download \
-                             subtitle {}: {}",
-                            sub.lan,
-                            e
-                        );
-                        None
-                    }
+    const MAX_OUTER_ATTEMPTS: usize = 3;
+
+    for attempt in 0..MAX_OUTER_ATTEMPTS {
+        if remaining_lans.is_empty() {
+            break;
+        }
+
+        let subs_for_attempt: Vec<SubtitleDto> = if attempt == 0 {
+            initial_subs
+                .iter()
+                .filter(|s| remaining_lans.contains(&s.lan))
+                .cloned()
+                .collect()
+        } else {
+            log::warn!(
+                "[BE] prepare_subtitle_mode: attempt {}/{}: \
+                 re-fetching URLs for {} failed subtitle(s)",
+                attempt + 1,
+                MAX_OUTER_ATTEMPTS,
+                remaining_lans.len(),
+            );
+            let fresh = fetch_subtitles_parallel(&client, cookies, bvid, cid).await;
+            fresh
+                .into_iter()
+                .filter(|s| remaining_lans.contains(&s.lan))
+                .collect()
+        };
+
+        if subs_for_attempt.is_empty() {
+            log::warn!(
+                "[BE] prepare_subtitle_mode: no subtitles found \
+                 for remaining languages: {:?}",
+                remaining_lans
+            );
+            break;
+        }
+
+        let futures: Vec<_> = subs_for_attempt
+            .into_iter()
+            .map(|sub| {
+                let srt_path = lib_path.join(format!("temp_sub_{download_id}_{}.srt", sub.lan));
+                let client = client.clone();
+                async move {
+                    let result =
+                        download_subtitle_with_retry(&client, &sub.subtitle_url, &srt_path).await;
+                    (sub.lan, sub.lan_doc, srt_path, result)
+                }
+            })
+            .collect();
+
+        let results = futures::future::join_all(futures).await;
+
+        let mut failed_lans = Vec::new();
+        for (lan, lan_doc, srt_path, result) in results {
+            match result {
+                Ok(()) => {
+                    subtitle_files.push(SubtitleMergeOptions {
+                        path: srt_path,
+                        language: lan_to_iso639(&lan).to_string(),
+                        title: lan_doc.clone(),
+                    });
+                    language_labels.push(lan_doc);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[BE] prepare_subtitle_mode: failed to \
+                         download subtitle {}: {}",
+                        lan,
+                        e
+                    );
+                    failed_lans.push(lan);
                 }
             }
-        })
-        .collect();
+        }
 
-    // 並行ダウンロード結果を収集し、成功した字幕のみをマージ対象に追加する
-    for (merge_opt, label) in futures::future::join_all(futures)
-        .await
-        .into_iter()
-        .flatten()
-    {
-        subtitle_files.push(merge_opt);
-        language_labels.push(label);
+        remaining_lans = failed_lans;
+        if remaining_lans.is_empty() {
+            break;
+        }
     }
 
     if subtitle_files.is_empty() {
-        return Ok((MergeMode::None, vec![]));
+        log::warn!("[BE] prepare_subtitle_mode: all subtitle downloads failed");
+    }
+
+    // Resolve display names for languages that failed all outer attempts
+    let failed_labels: Vec<String> = remaining_lans
+        .iter()
+        .filter_map(|lan| {
+            initial_subs
+                .iter()
+                .find(|s| s.lan == *lan)
+                .map(|s| s.lan_doc.clone())
+        })
+        .collect();
+
+    if !failed_labels.is_empty() {
+        log::warn!(
+            "[BE] prepare_subtitle_mode: {} subtitle(s) failed: {:?}",
+            failed_labels.len(),
+            failed_labels
+        );
+    }
+
+    if subtitle_files.is_empty() {
+        return Ok((MergeMode::None, vec![], failed_labels));
     }
 
     let mode = match sub_opts.mode.as_str() {
@@ -2463,7 +2533,7 @@ async fn prepare_subtitle_mode(
             .unwrap_or(MergeMode::None),
         _ => MergeMode::SoftSub(subtitle_files),
     };
-    Ok((mode, language_labels))
+    Ok((mode, language_labels, failed_labels))
 }
 
 // ============================================================================

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -26,6 +26,18 @@ interface DownloadCancelledPayload {
 }
 
 /**
+ * Payload for the `download-subtitle-warning` event.
+ *
+ * Emitted by the backend when one or more subtitle downloads fail after
+ * all retry attempts. Contains the display names of the languages that
+ * could not be downloaded, used to show a warning toast to the user.
+ */
+interface SubtitleWarningPayload {
+  /** Display names of subtitle languages that failed to download (e.g., "日本語", "Español") */
+  failedLanguages: string[]
+}
+
+/**
  * React Context for managing Tauri event listeners.
  *
  * This context enables automatic setup of event listeners for progress
@@ -36,10 +48,16 @@ const ListenerContext = createContext<boolean>(false)
 /**
  * Provider component for Tauri event listeners.
  *
- * Sets up a listener for 'progress' events from the Tauri backend.
- * When progress events are received, it dispatches them to Redux state
- * and displays toast notifications for quality fallback warnings.
- * The listener is automatically cleaned up when the component unmounts.
+ * Sets up listeners for events emitted from the Tauri Rust backend:
+ * - `progress` - Download progress updates dispatched to Redux state,
+ *   with toast notifications for quality fallback warnings
+ * - `history:entry_added` - New history entries dispatched to Redux state
+ * - `download_cancelled` - Clears queue items and progress, shows info toast
+ * - `download-quality-resolved` - Updates resolved video/audio quality in state
+ * - `download-subtitle-resolved` - Updates resolved subtitle mode and labels in state
+ * - `download-subtitle-warning` - Shows a warning toast when subtitle downloads fail
+ *
+ * All listeners are automatically cleaned up when the component unmounts.
  *
  * @param props - Component props
  * @param props.children - Child components to be wrapped by this provider
@@ -58,6 +76,7 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
     let unlistenCancelled: UnlistenFn | undefined
     let unlistenQualityResolved: UnlistenFn | undefined
     let unlistenSubtitleResolved: UnlistenFn | undefined
+    let unlistenSubtitleWarning: UnlistenFn | undefined
 
     const setupListeners = async (): Promise<void> => {
       // Setup progress event listener
@@ -135,6 +154,21 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
           )
         },
       )
+
+      // Setup subtitle warning event listener
+      unlistenSubtitleWarning = await listen<SubtitleWarningPayload>(
+        'download-subtitle-warning',
+        (event) => {
+          const { failedLanguages } = event.payload
+          const langList = failedLanguages.join('・')
+          toast.warning(
+            i18n.t('video.subtitle_download_failed', {
+              languages: langList,
+            }),
+            { duration: 6000 },
+          )
+        },
+      )
     }
 
     setupListeners()
@@ -145,6 +179,7 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
       unlistenCancelled?.()
       unlistenQualityResolved?.()
       unlistenSubtitleResolved?.()
+      unlistenSubtitleWarning?.()
     }
   }, [])
   return (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "Hard Sub ({{lang}})",
     "subtitle_select_multiple": "Select multiple (all selected by default)",
     "subtitle_hard_warning": "Hard sub encoding takes longer to process",
+    "subtitle_download_failed": "Subtitle download failed ({{languages}}). Continuing without those subtitles.",
     "subtitle_description": "Choose how to embed subtitles into the video.",
     "subtitle_note": "※ Soft sub allows toggling subtitles in the player. Hard sub burns subtitles into the video.",
     "options": "Options",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "Hard Sub ({{lang}})",
     "subtitle_select_multiple": "Selección múltiple (todos seleccionados por defecto)",
     "subtitle_hard_warning": "La codificación Hard Sub lleva más tiempo",
+    "subtitle_download_failed": "Error al descargar subtítulos ({{languages}}). Continuando sin esos subtítulos.",
     "subtitle_description": "Elige cómo incrustar subtítulos en el video.",
     "subtitle_note": "※ Soft Sub permite activar/desactivar subtítulos en el reproductor. Hard Sub graba los subtítulos en el video.",
     "options": "Opciones",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "Hard Sub ({{lang}})",
     "subtitle_select_multiple": "Sélection multiple (tous sélectionnés par défaut)",
     "subtitle_hard_warning": "L'encodage Hard Sub prend plus de temps",
+    "subtitle_download_failed": "Échec du téléchargement des sous-titres ({{languages}}). Continuation sans ces sous-titres.",
     "subtitle_description": "Choisissez comment intégrer les sous-titres dans la vidéo.",
     "subtitle_note": "※ Soft Sub permet d'activer/désactiver les sous-titres dans le lecteur. Hard Sub grave les sous-titres dans la vidéo.",
     "options": "Options",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "ハードサブ・{{lang}}",
     "subtitle_select_multiple": "複数選択可（デフォルト全選択）",
     "subtitle_hard_warning": "ハードサブはエンコードに時間がかかります",
+    "subtitle_download_failed": "字幕のダウンロードに失敗しました（{{languages}}）。該当言語は字幕なしで処理を続けます。",
     "subtitle_description": "動画に字幕を埋め込む方法を選択します。",
     "subtitle_note": "※ ソフトサブは再生プレイヤーで字幕のON/OFFが可能。ハードサブは動画に焼き付けられます。",
     "options": "オプション",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "하드 서브 ({{lang}})",
     "subtitle_select_multiple": "다중 선택 가능 (기본 전체 선택)",
     "subtitle_hard_warning": "하드 서브 인코딩은 시간이 더 걸립니다",
+    "subtitle_download_failed": "자막 다운로드에 실패했습니다 ({{languages}}). 해당 언어는 자막 없이 계속 진행합니다.",
     "subtitle_description": "자막을 비디오에 포함하는 방법을 선택합니다.",
     "subtitle_note": "※ 소프트 서브는 플레이어에서 자막 켜기/끄기가 가능합니다. 하드 서브는 비디오에 자막이 굽혀집니다.",
     "options": "옵션",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -122,6 +122,7 @@
     "subtitle_hard_label": "硬字幕 ({{lang}})",
     "subtitle_select_multiple": "可多选（默认全选）",
     "subtitle_hard_warning": "硬字幕编码需要更长时间",
+    "subtitle_download_failed": "字幕下载失败（{{languages}}）。该语言将不含字幕继续处理。",
     "subtitle_description": "选择将字幕嵌入视频的方式。",
     "subtitle_note": "※ 软字幕可以在播放器中开关。硬字幕会烧录到视频中。",
     "options": "选项",


### PR DESCRIPTION
## Summary

- Reduce inner retry count from 5 to 3 to avoid wasted time on bad CDN URLs
- Add outer retry loop (3 attempts) that re-fetches fresh subtitle URLs from API between attempts, increasing the chance of hitting a different CDN node
- Show warning toast listing which languages failed when partial or full subtitle download failure occurs

## Related Issue

No related issue (bug discovered during manual testing)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] Run `npm run tauri dev`
- [x] Download video with soft subtitles selected (multiple languages)
- [x] Verify subtitles merge correctly into the output video
- [x] Verify no false warning toast appears on successful download

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)