### PR TITLE
feat(settings): add in-app release notes viewer

### DIFF
--- a/src-tauri/src/handlers/updater.rs
+++ b/src-tauri/src/handlers/updater.rs
@@ -126,10 +126,7 @@ pub async fn fetch_all_release_notes(
 ///
 /// Unlike `fetch_all_release_notes`, this function returns all published
 /// releases regardless of version, sorted newest-first.
-pub async fn fetch_all_releases_markdown(
-    owner: &str,
-    repo: &str,
-) -> Result<String> {
+pub async fn fetch_all_releases_markdown(owner: &str, repo: &str) -> Result<String> {
     log::info!(
         "[BE] fetch_all_releases_markdown: owner={}, repo={}",
         owner,
@@ -150,9 +147,7 @@ pub async fn fetch_all_releases_markdown(
             .page(page)
             .send()
             .await
-            .map_err(|e| {
-                anyhow::anyhow!("Failed to fetch releases page {page}: {e}")
-            })?;
+            .map_err(|e| anyhow::anyhow!("Failed to fetch releases page {page}: {e}"))?;
 
         if page_releases.items.is_empty() {
             break;
@@ -171,10 +166,7 @@ pub async fn fetch_all_releases_markdown(
 
     releases.sort_by(|a, b| {
         let parse_ver = |r: &octocrab::models::repos::Release| {
-            Version::parse(
-                r.tag_name.strip_prefix('v').unwrap_or(&r.tag_name),
-            )
-            .ok()
+            Version::parse(r.tag_name.strip_prefix('v').unwrap_or(&r.tag_name)).ok()
         };
         match (parse_ver(b), parse_ver(a)) {
             (Some(vb), Some(va)) => vb.cmp(&va),
@@ -183,16 +175,12 @@ pub async fn fetch_all_releases_markdown(
     });
 
     let mut notes = String::new();
-    const DEFAULT_BODY: &str =
-        "See the assets to download this version and install.";
+    const DEFAULT_BODY: &str = "See the assets to download this version and install.";
 
     for release in releases {
         if let Some(body) = &release.body {
             if !body.is_empty() && body != DEFAULT_BODY {
-                notes.push_str(&format!(
-                    "## {}\n\n{}\n\n---\n\n",
-                    release.tag_name, body
-                ));
+                notes.push_str(&format!("## {}\n\n{}\n\n---\n\n", release.tag_name, body));
             }
         }
     }

--- a/src-tauri/src/handlers/updater.rs
+++ b/src-tauri/src/handlers/updater.rs
@@ -121,3 +121,86 @@ pub async fn fetch_all_release_notes(
 
     Ok(notes)
 }
+
+/// Fetches all releases from GitHub as a Markdown document.
+///
+/// Unlike `fetch_all_release_notes`, this function returns all published
+/// releases regardless of version, sorted newest-first.
+pub async fn fetch_all_releases_markdown(
+    owner: &str,
+    repo: &str,
+) -> Result<String> {
+    log::info!(
+        "[BE] fetch_all_releases_markdown: owner={}, repo={}",
+        owner,
+        repo
+    );
+    use semver::Version;
+
+    let github = Octocrab::builder().build()?;
+    const PER_PAGE: u8 = 30;
+    let mut releases = Vec::new();
+
+    for page in 1u32.. {
+        let page_releases = github
+            .repos(owner, repo)
+            .releases()
+            .list()
+            .per_page(PER_PAGE)
+            .page(page)
+            .send()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to fetch releases page {page}: {e}")
+            })?;
+
+        if page_releases.items.is_empty() {
+            break;
+        }
+
+        releases.extend(page_releases.items);
+
+        if releases.len() >= PER_PAGE as usize {
+            break;
+        }
+    }
+
+    if releases.is_empty() {
+        return Ok("No releases found.".to_string());
+    }
+
+    releases.sort_by(|a, b| {
+        let parse_ver = |r: &octocrab::models::repos::Release| {
+            Version::parse(
+                r.tag_name.strip_prefix('v').unwrap_or(&r.tag_name),
+            )
+            .ok()
+        };
+        match (parse_ver(b), parse_ver(a)) {
+            (Some(vb), Some(va)) => vb.cmp(&va),
+            _ => std::cmp::Ordering::Equal,
+        }
+    });
+
+    let mut notes = String::new();
+    const DEFAULT_BODY: &str =
+        "See the assets to download this version and install.";
+
+    for release in releases {
+        if let Some(body) = &release.body {
+            if !body.is_empty() && body != DEFAULT_BODY {
+                notes.push_str(&format!(
+                    "## {}\n\n{}\n\n---\n\n",
+                    release.tag_name, body
+                ));
+            }
+        }
+    }
+
+    notes.push_str(&format!(
+        "*View [all releases](https://github.com/{}/{}/releases) on GitHub*\n",
+        owner, repo
+    ));
+
+    Ok(notes)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1004,10 +1004,7 @@ async fn get_release_notes(
 ///
 /// Returns an error if the GitHub API request fails.
 #[tauri::command]
-async fn get_all_release_notes(
-    owner: String,
-    repo: String,
-) -> Result<String, String> {
+async fn get_all_release_notes(owner: String, repo: String) -> Result<String, String> {
     updater::fetch_all_releases_markdown(&owner, &repo)
         .await
         .map_err(|e| e.to_string())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,7 @@ pub fn run() {
             reveal_in_folder,
             open_file,
             get_release_notes,
+            get_all_release_notes,
             get_repo_stars,
             fetch_favorite_folders,
             fetch_favorite_videos,
@@ -981,6 +982,33 @@ async fn get_release_notes(
     current_version: String,
 ) -> Result<String, String> {
     updater::fetch_all_release_notes(&owner, &repo, &current_version)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Fetches all published releases as a Markdown document.
+///
+/// Unlike `get_release_notes`, this returns all releases regardless
+/// of version, sorted newest-first.
+///
+/// # Arguments
+///
+/// * `owner` - Repository owner (e.g., "j4rviscmd")
+/// * `repo` - Repository name (e.g., "bilibili-downloader-gui")
+///
+/// # Returns
+///
+/// Returns all release notes as a Markdown-formatted string.
+///
+/// # Errors
+///
+/// Returns an error if the GitHub API request fails.
+#[tauri::command]
+async fn get_all_release_notes(
+    owner: String,
+    repo: String,
+) -> Result<String, String> {
+    updater::fetch_all_releases_markdown(&owner, &repo)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -44,6 +44,7 @@ import type { FontSizePreset } from '@/features/settings/type'
 import { DevOptions } from '@/features/settings/ui/DevOptions'
 import { TitleReplacementSettings } from '@/features/settings/ui/TitleReplacementSettings'
 import { UpdateCheckButton } from '@/features/settings/ui/UpdateCheckButton'
+import { ReleaseNotesSection } from '@/features/settings/ui/ReleaseNotesSection'
 import { useSettings } from '@/features/settings/useSettings'
 import {
   RadioGroup,
@@ -440,6 +441,7 @@ function SettingsForm() {
         <div className="space-y-2">
           <Label>{t('settings.app_section_label')}</Label>
           <UpdateCheckButton />
+          <ReleaseNotesSection />
         </div>
         <Separator />
         {/* Login Status Section */}

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -42,9 +42,9 @@ import {
 } from '@/features/settings/lib/fontSize'
 import type { FontSizePreset } from '@/features/settings/type'
 import { DevOptions } from '@/features/settings/ui/DevOptions'
+import { ReleaseNotesSection } from '@/features/settings/ui/ReleaseNotesSection'
 import { TitleReplacementSettings } from '@/features/settings/ui/TitleReplacementSettings'
 import { UpdateCheckButton } from '@/features/settings/ui/UpdateCheckButton'
-import { ReleaseNotesSection } from '@/features/settings/ui/ReleaseNotesSection'
 import { useSettings } from '@/features/settings/useSettings'
 import {
   RadioGroup,

--- a/src/features/settings/ui/ReleaseNotesSection.tsx
+++ b/src/features/settings/ui/ReleaseNotesSection.tsx
@@ -1,0 +1,159 @@
+import { fetchAllReleaseNotes } from '@/features/updater'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/animate-ui/radix/dialog'
+import { logger } from '@/shared/lib/logger'
+import { Button } from '@/shared/ui/button'
+import { FileText } from 'lucide-react'
+import React, { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+const REPO_OWNER = 'j4rviscmd'
+const REPO_NAME = 'bilibili-downloader-gui'
+
+type MdProps = { children?: React.ReactNode }
+
+/**
+ * Custom renderers for ReactMarkdown that apply Tailwind CSS
+ * classes to each Markdown element for consistent styling
+ * within the release notes dialog.
+ */
+const markdownComponents = {
+  h1: ({ children }: MdProps) => (
+    <h1 className="mb-4 text-xl font-bold">{children}</h1>
+  ),
+  h2: ({ children }: MdProps) => (
+    <h2 className="mt-4 mb-3 text-lg font-semibold">{children}</h2>
+  ),
+  h3: ({ children }: MdProps) => (
+    <h3 className="mt-3 mb-2 text-base font-medium">{children}</h3>
+  ),
+  p: ({ children }: MdProps) => (
+    <p className="mb-2 leading-relaxed">{children}</p>
+  ),
+  ul: ({ children }: MdProps) => (
+    <ul className="mb-3 list-inside list-disc space-y-1">{children}</ul>
+  ),
+  ol: ({ children }: MdProps) => (
+    <ol className="mb-3 list-inside list-decimal space-y-1">{children}</ol>
+  ),
+  li: ({ children }: MdProps) => <li className="ml-4">{children}</li>,
+  code: ({ children }: MdProps) => (
+    <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+      {children}
+    </code>
+  ),
+  pre: ({ children }: MdProps) => (
+    <pre className="bg-muted mb-3 overflow-x-auto rounded-md p-3">
+      {children}
+    </pre>
+  ),
+  a: ({ href, children }: { href?: string } & MdProps) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary hover:text-primary/80 underline"
+    >
+      {children}
+    </a>
+  ),
+  strong: ({ children }: MdProps) => (
+    <strong className="font-semibold">{children}</strong>
+  ),
+  blockquote: ({ children }: MdProps) => (
+    <blockquote className="border-muted-foreground/20 my-3 border-l-4 pl-4 italic">
+      {children}
+    </blockquote>
+  ),
+}
+
+/**
+ * Settings section that displays a button which opens a dialog
+ * showing the full release notes for the repository.
+ *
+ * Release notes are fetched once from GitHub on first open and
+ * cached in component state for subsequent views.
+ *
+ * @example
+ * ```tsx
+ * <ReleaseNotesSection />
+ * ```
+ */
+export function ReleaseNotesSection() {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [notes, setNotes] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * Opens the release notes dialog. Fetches notes from GitHub
+   * on first invocation; uses the cached value on subsequent
+   * opens. Sets an error message if the fetch fails.
+   */
+  const handleOpen = useCallback(async () => {
+    if (notes !== null) {
+      setOpen(true)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await fetchAllReleaseNotes(REPO_OWNER, REPO_NAME)
+      setNotes(result)
+      setOpen(true)
+    } catch (e) {
+      logger.error('Failed to fetch release notes', e)
+      setError(t('settings.release_notes.error'))
+      setOpen(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [notes, t])
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleOpen}
+        disabled={loading}
+        aria-label={t('settings.release_notes.button_aria')}
+      >
+        <FileText className="mr-2 size-4" />
+        {loading
+          ? t('settings.release_notes.loading')
+          : t('settings.release_notes.button')}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex max-h-[85vh] w-[800px] max-w-none flex-col overflow-hidden">
+          <DialogHeader>
+            <DialogTitle>{t('settings.release_notes.title')}</DialogTitle>
+          </DialogHeader>
+          <div className="overflow-y-auto p-4">
+            {error ? (
+              <p className="text-destructive text-sm">{error}</p>
+            ) : (
+              <div className="markdown-body text-sm">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={markdownComponents}
+                >
+                  {notes || ''}
+                </ReactMarkdown>
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/features/updater/api/updaterApi.ts
+++ b/src/features/updater/api/updaterApi.ts
@@ -51,9 +51,7 @@ export const fetchAllReleaseNotes = async (
   owner: string,
   repo: string,
 ): Promise<string> => {
-  logger.debug(
-    `fetchAllReleaseNotes: owner=${owner}, repo=${repo}`,
-  )
+  logger.debug(`fetchAllReleaseNotes: owner=${owner}, repo=${repo}`)
   try {
     const result = await invoke<string>('get_all_release_notes', {
       owner,

--- a/src/features/updater/api/updaterApi.ts
+++ b/src/features/updater/api/updaterApi.ts
@@ -46,3 +46,28 @@ export const fetchReleaseNotes = async (
     throw error
   }
 }
+
+export const fetchAllReleaseNotes = async (
+  owner: string,
+  repo: string,
+): Promise<string> => {
+  logger.debug(
+    `fetchAllReleaseNotes: owner=${owner}, repo=${repo}`,
+  )
+  try {
+    const result = await invoke<string>('get_all_release_notes', {
+      owner,
+      repo,
+    })
+    logger.debug(
+      `fetchAllReleaseNotes: Fetched ${result.length} chars of release notes`,
+    )
+    return result
+  } catch (error) {
+    logger.error(
+      `fetchAllReleaseNotes: Failed to fetch release notes for ${owner}/${repo}`,
+      error,
+    )
+    throw error
+  }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -245,6 +245,13 @@
       "unknown_version": "Unknown",
       "dev_mode_disabled": "Update check disabled in development mode"
     },
+    "release_notes": {
+      "title": "Release Notes",
+      "button": "View Release Notes",
+      "button_aria": "View release notes",
+      "loading": "Loading...",
+      "error": "Failed to load release notes. Please check your internet connection."
+    },
     "dev_options": {
       "title": "Developer Options",
       "open_devtools_on_startup": "Open DevTools on startup",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -242,6 +242,13 @@
       "unknown_version": "Desconocido",
       "dev_mode_disabled": "La verificación de actualizaciones está deshabilitada en modo desarrollo"
     },
+    "release_notes": {
+      "title": "Notas de la versión",
+      "button": "Ver notas de la versión",
+      "button_aria": "Ver notas de la versión",
+      "loading": "Cargando...",
+      "error": "Error al cargar las notas de la versión. Verifique su conexión a internet."
+    },
     "dev_options": {
       "title": "Opciones de desarrollo",
       "open_devtools_on_startup": "Abrir DevTools al iniciar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -242,6 +242,13 @@
       "unknown_version": "Inconnu",
       "dev_mode_disabled": "La vérification des mises à jour est désactivée en mode développement"
     },
+    "release_notes": {
+      "title": "Notes de version",
+      "button": "Voir les notes de version",
+      "button_aria": "Voir les notes de version",
+      "loading": "Chargement...",
+      "error": "Échec du chargement des notes de version. Vérifiez votre connexion internet."
+    },
     "dev_options": {
       "title": "Options de développement",
       "open_devtools_on_startup": "Ouvrir DevTools au démarrage",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -245,6 +245,13 @@
       "unknown_version": "不明",
       "dev_mode_disabled": "開発モードではアップデート確認は無効です"
     },
+    "release_notes": {
+      "title": "リリースノート",
+      "button": "リリースノートを見る",
+      "button_aria": "リリースノートを表示",
+      "loading": "読み込み中...",
+      "error": "リリースノートの読み込みに失敗しました。インターネット接続を確認してください。"
+    },
     "dev_options": {
       "title": "開発者オプション",
       "open_devtools_on_startup": "起動時にDevToolsを開く",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -242,6 +242,13 @@
       "unknown_version": "알 수 없음",
       "dev_mode_disabled": "개발 모드에서는 업데이트 확인이 비활성화됩니다"
     },
+    "release_notes": {
+      "title": "릴리스 노트",
+      "button": "릴리스 노트 보기",
+      "button_aria": "릴리스 노트 보기",
+      "loading": "로딩 중...",
+      "error": "릴리스 노트를 불러오지 못했습니다. 인터넷 연결을 확인해 주세요."
+    },
     "dev_options": {
       "title": "개발자 옵션",
       "open_devtools_on_startup": "시작 시 DevTools 열기",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -242,6 +242,13 @@
       "unknown_version": "未知",
       "dev_mode_disabled": "开发模式下更新检查已禁用"
     },
+    "release_notes": {
+      "title": "更新日志",
+      "button": "查看更新日志",
+      "button_aria": "查看更新日志",
+      "loading": "加载中...",
+      "error": "加载更新日志失败，请检查网络连接。"
+    },
     "dev_options": {
       "title": "开发者选项",
       "open_devtools_on_startup": "启动时打开开发者工具",


### PR DESCRIPTION
## Summary

Add a release notes section in the settings dialog that allows users to view all GitHub release notes without leaving the app. The Rust backend fetches releases via the GitHub API (octocrab) and the frontend renders them as formatted markdown using ReactMarkdown.

### Changes
- **Backend**: Add `fetch_all_releases_markdown()` to fetch all releases and `get_all_release_notes` Tauri command
- **Frontend**: Add `ReleaseNotesSection` component with a button that opens a dialog displaying release notes
- **i18n**: Add translation keys for all 6 languages (en, ja, zh, ko, es, fr)

Closes #246

## Type of Change

- [x] ✨ New feature

## Test Plan

- [ ] Run `npm run dev`
- [ ] Navigate to Settings page
- [ ] Click the "Release Notes" button
- [ ] Verify the dialog opens and displays formatted release notes
- [ ] Verify scrolling works within the dialog
- [ ] Verify the dialog shows an error message when offline

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)