### PR TITLE
fix(video): use crypto.randomUUID() for download ID generation

### DIFF
--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -417,6 +417,11 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
    *
    * Starts download process for each selected part, creating queue entries.
    * Shows appropriate toast notifications on errors.
+   *
+   * Download IDs are generated using `crypto.randomUUID()` to guarantee
+   * globally unique identifiers:
+   * - Parent ID: `{videoId}-{uuid}`
+   * - Child ID:  `{videoId}-{uuid}-p{partNumber}`
    */
   const download = useCallback(async () => {
     if (!isForm1Valid || !isForm2ValidAll) return
@@ -449,7 +454,7 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
         store.dispatch(clearQueueItem(completedItem.downloadId))
     }
 
-    const parentId = `${videoId}-${Date.now()}`
+    const parentId = `${videoId}-${crypto.randomUUID()}`
     store.dispatch(
       enqueue({
         downloadId: parentId,

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -475,7 +475,9 @@ const VideoPartCard = memo(function VideoPartCard({
   /**
    * Executes redownload by removing completed item and starting
    * fresh download. Clears the queue item, progress entries, and
-   * initiates a new download with a new ID.
+   * initiates a new download with a new UUID-based ID:
+   * - Download ID: `{videoId}-{uuid}-p{page}`
+   * - Parent ID:   `{videoId}-{uuid}` (derived by stripping the `-p{page}` suffix)
    */
   const handleRedownload = useCallback(async () => {
     const partIndex = page - 1
@@ -493,7 +495,7 @@ const VideoPartCard = memo(function VideoPartCard({
       store.dispatch(clearProgressByDownloadId(completedItem.downloadId))
     }
 
-    const newDownloadId = `${videoId}-${Date.now()}-p${page}`
+    const newDownloadId = `${videoId}-${crypto.randomUUID()}-p${page}`
     const videoQuality = pi.videoQuality || String(pi.videoQualities?.[0]?.id)
     const audioQuality = pi.audioQuality
       ? parseInt(pi.audioQuality, 10)


### PR DESCRIPTION
## Summary

- Replace `Date.now()` with `crypto.randomUUID()` in download ID generation for both bulk download (`VideoInfoContext`) and re-download (`VideoPartCard`)
- Eliminates the risk of ID collision during rapid consecutive clicks

## Related Issue

Closes #87

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Download a single-part video and verify download completes successfully
- [ ] Download a multi-part video and verify all parts complete with correct parent-child relationship
- [ ] Re-download a completed part and verify it works with the new ID

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — N/A: single-line change, no logic change
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A: no i18n changes