### PR TITLE
refactor: replace calc()-based scroll height with pure Flexbox layout

### DIFF
--- a/src/features/favorite/ui/FavoriteList.tsx
+++ b/src/features/favorite/ui/FavoriteList.tsx
@@ -3,17 +3,25 @@ import FavoriteItem from '@/features/favorite/ui/FavoriteItem'
 import { useTranslation } from 'react-i18next'
 import { Virtuoso } from 'react-virtuoso'
 
+/** Props for the FavoriteList component. */
 type Props = {
+  /** Array of favorite videos to display. */
   videos: FavoriteVideo[]
+  /** Whether the video list is currently loading. */
   loading: boolean
+  /** Whether the folder list is currently loading. */
   foldersLoading: boolean
+  /** Whether there are more videos to load via infinite scroll. */
   hasMore: boolean
+  /** Callback invoked when more videos should be loaded. */
   onLoadMore: () => void
+  /** Callback invoked when the user requests to download a video. */
   onDownload: (video: FavoriteVideo) => void
-  height?: string
+  /** Whether download buttons should be disabled. */
   disabled?: boolean
 }
 
+/** Approximate height in pixels for each FavoriteItem (used for virtual scrolling). */
 const DEFAULT_ITEM_HEIGHT = 120
 
 /**
@@ -37,7 +45,24 @@ const EmptyStateIcon = () => (
 )
 
 /**
- * Favorite video list component with infinite scroll.
+ * Virtualized list component for favorite videos.
+ *
+ * Uses react-virtuoso for efficient rendering of large lists with infinite
+ * scroll. Shows a loading skeleton while folders or videos are being fetched,
+ * and an empty state when no videos are available.
+ *
+ * @example
+ * ```tsx
+ * <FavoriteList
+ *   videos={videos}
+ *   loading={loading}
+ *   foldersLoading={foldersLoading}
+ *   hasMore={hasMore}
+ *   onLoadMore={loadMore}
+ *   onDownload={onDownload}
+ *   disabled={hasActiveDownloads}
+ * />
+ * ```
  */
 function FavoriteList({
   videos,
@@ -46,7 +71,6 @@ function FavoriteList({
   hasMore,
   onLoadMore,
   onDownload,
-  height,
   disabled,
 }: Props) {
   const { t } = useTranslation()
@@ -76,7 +100,7 @@ function FavoriteList({
 
   return (
     <Virtuoso
-      style={{ height }}
+      style={{ height: '100%' }}
       data={videos}
       endReached={() => {
         if (hasMore && !loading) {

--- a/src/features/history/ui/HistoryList.tsx
+++ b/src/features/history/ui/HistoryList.tsx
@@ -8,12 +8,16 @@ const DEFAULT_ITEM_HEIGHT = 120
 
 /** Props for the HistoryList component. */
 type Props = {
+  /** Array of history entries to display. */
   entries: HistoryEntry[]
+  /** Whether the list is currently loading. */
   loading: boolean
+  /** Callback invoked when the user requests to delete an entry. */
   onDelete: (id: string) => void
+  /** Optional callback invoked when the user requests to download an entry. */
   onDownload?: (entry: HistoryEntry) => void
+  /** Whether download buttons should be disabled. */
   disabled?: boolean
-  height?: string
 }
 
 /** Empty state icon component. Displays an icon representing no history entries. */
@@ -44,7 +48,6 @@ function HistoryList({
   onDelete,
   onDownload,
   disabled,
-  height,
 }: Props) {
   const { t } = useTranslation()
 
@@ -76,7 +79,7 @@ function HistoryList({
   // Virtualized list for efficient rendering of large datasets
   return (
     <Virtuoso
-      style={{ height }}
+      style={{ height: '100%' }}
       data={entries}
       itemContent={(_index, entry) => (
         <div key={entry.id} className="py-1">

--- a/src/features/watch-history/ui/WatchHistoryList.tsx
+++ b/src/features/watch-history/ui/WatchHistoryList.tsx
@@ -17,8 +17,6 @@ type Props = {
   onLoadMore: () => void
   /** Callback when user clicks download on an entry */
   onDownload: (entry: WatchHistoryEntry) => void
-  /** Fixed height for the list container (e.g., "calc(100dvh - 200px)") */
-  height?: string
   /** Whether download buttons should be disabled */
   disabled?: boolean
 }
@@ -41,7 +39,6 @@ const DEFAULT_ITEM_HEIGHT = 100
  *   hasMore={cursor ? !cursor.isEnd : false}
  *   onLoadMore={fetchMore}
  *   onDownload={handleDownload}
- *   height="calc(100dvh - 2.3rem - 80px)"
  * />
  * ```
  */
@@ -52,7 +49,6 @@ export function WatchHistoryList({
   hasMore,
   onLoadMore,
   onDownload,
-  height,
   disabled,
 }: Props) {
   const { t } = useTranslation()
@@ -75,7 +71,7 @@ export function WatchHistoryList({
 
   return (
     <Virtuoso
-      style={{ height }}
+      style={{ height: '100%' }}
       data={entries}
       itemContent={(_index, entry) => (
         <div className="py-1">

--- a/src/pages/favorite/index.tsx
+++ b/src/pages/favorite/index.tsx
@@ -112,16 +112,17 @@ export function FavoriteContent() {
         </div>
       </div>
 
-      <FavoriteList
-        videos={videos}
-        loading={loading}
-        foldersLoading={foldersLoading}
-        hasMore={hasMore}
-        onLoadMore={loadMore}
-        onDownload={onDownload}
-        height="calc(100dvh - 2.3rem - 80px)"
-        disabled={hasActiveDownloads}
-      />
+      <div className="min-h-0 flex-1">
+        <FavoriteList
+          videos={videos}
+          loading={loading}
+          foldersLoading={foldersLoading}
+          hasMore={hasMore}
+          onLoadMore={loadMore}
+          onDownload={onDownload}
+          disabled={hasActiveDownloads}
+        />
+      </div>
     </div>
   )
 }

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -13,9 +13,9 @@ import { writeTextFile } from '@tauri-apps/plugin-fs'
 import { FileText, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 
 import { logger } from '@/shared/lib/logger'
-import { toast } from 'sonner'
 
 /**
  * History page content component.
@@ -158,14 +158,15 @@ export function HistoryContent() {
         </div>
       </div>
 
-      <HistoryList
-        entries={entries}
-        loading={loading}
-        onDelete={remove}
-        onDownload={onDownload}
-        disabled={hasActiveDownloads}
-        height="calc(100dvh - 2.3rem - 80px)"
-      />
+      <div className="min-h-0 flex-1">
+        <HistoryList
+          entries={entries}
+          loading={loading}
+          onDelete={remove}
+          onDownload={onDownload}
+          disabled={hasActiveDownloads}
+        />
+      </div>
 
       <HistoryExportDialog
         open={exportDialogOpen}

--- a/src/pages/watch-history/index.tsx
+++ b/src/pages/watch-history/index.tsx
@@ -130,16 +130,17 @@ export function WatchHistoryContent() {
       )}
 
       {/* List */}
-      <WatchHistoryList
-        entries={entries}
-        loading={loading}
-        loadingMore={loadingMore}
-        hasMore={!!cursor && !cursor.isEnd}
-        onLoadMore={fetchMore}
-        onDownload={onDownload}
-        height="calc(100dvh - 2.3rem - 80px)"
-        disabled={hasActiveDownloads}
-      />
+      <div className="min-h-0 flex-1">
+        <WatchHistoryList
+          entries={entries}
+          loading={loading}
+          loadingMore={loadingMore}
+          hasMore={!!cursor && !cursor.isEnd}
+          onLoadMore={fetchMore}
+          onDownload={onDownload}
+          disabled={hasActiveDownloads}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `calc(100dvh - 2.3rem - 80px)` height calculations with pure Flexbox layout in History, Favorite, and WatchHistory pages
- Remove `height` prop from `HistoryList`, `FavoriteList`, and `WatchHistoryList` components
- Add `min-h-0 flex-1` wrapper divs around Virtuoso virtual scroll components with `height: 100%`

## Context

The previous implementation used magic numbers in `calc()` expressions that would break whenever the header height changed. The new Flexbox approach is resilient to layout changes and eliminates the need for manual height calculations.

## Test plan

- [x] Verify History page list scrolls correctly and fills viewport
- [x] Verify Favorite page list scrolls correctly with infinite scroll
- [x] Verify WatchHistory page list scrolls correctly with infinite scroll
- [x] Verify window resize maintains correct layout
- [x] Verify search/filter functionality works as expected
- [x] Build and lint pass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)