### PR TITLE
fix: force cookie refresh on session expiry (-101)

### DIFF
--- a/src-tauri/src/handlers/qr_login.rs
+++ b/src-tauri/src/handlers/qr_login.rs
@@ -38,16 +38,22 @@ use crate::models::qr_login::{
 };
 use crate::utils::secure_storage::{EncryptedFileStorage, SecureStorage};
 
+/// Bilibili QR code generation API endpoint.
 const QR_GENERATE_URL: &str = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate";
+/// Bilibili QR code login polling API endpoint.
 const QR_POLL_URL: &str = "https://passport.bilibili.com/x/passport-login/web/qrcode/poll";
+/// Store file name for login method preference (non-sensitive data only).
 const STORE_FILE_NAME: &str = "login_state.json";
+/// Key used within the store file for login state persistence.
 const LOGIN_STATE_KEY: &str = "loginState";
 
-// Encrypted file storage instance
+/// Encrypted file storage instance for persisting session tokens.
 static STORAGE: EncryptedFileStorage = EncryptedFileStorage::new();
 
-// Session cache to avoid repeated file reads and key derivation
-// None = not initialized yet, Some(None) = no session, Some(Some(session)) = session exists
+/// In-memory session cache to avoid repeated file reads and key derivation.
+///
+/// Three-state sentinel: `None` = not initialized, `Some(None)` = no session,
+/// `Some(Some(session))` = session loaded.
 static SESSION_CACHE: RwLock<Option<Option<Session>>> = RwLock::new(None);
 
 /// Returns true if running in E2E test mode (bypasses secure storage).
@@ -642,11 +648,15 @@ pub async fn get_login_state(app: &AppHandle) -> Result<LoginState, String> {
 
 // Cookie Refresh API
 
+/// Bilibili cookie info API endpoint for checking if refresh is needed.
 const COOKIE_INFO_URL: &str = "https://passport.bilibili.com/x/passport-login/web/cookie/info";
+/// Bilibili cookie refresh API endpoint for exchanging refresh tokens.
 const COOKIE_REFRESH_URL: &str =
     "https://passport.bilibili.com/x/passport-login/web/cookie/refresh";
+/// Bilibili confirm refresh endpoint to invalidate the old refresh token.
 const CONFIRM_REFRESH_URL: &str =
     "https://passport.bilibili.com/x/passport-login/web/confirm/refresh";
+/// URL prefix for fetching the CorrespondPath page that contains refresh_csrf.
 const CORRESPOND_URL_PREFIX: &str = "https://www.bilibili.com/correspond/1/";
 
 /// Checks if cookie refresh is needed.
@@ -687,10 +697,14 @@ pub async fn check_cookie_refresh(app: &AppHandle) -> Result<CookieRefreshInfo, 
             .data
             .ok_or_else(|| "No data in cookie info response".to_string()),
         -101 => {
-            log::debug!("[BE] Session expired (code: -101)");
+            let now_ts = chrono::Utc::now().timestamp_millis();
+            log::warn!(
+                "[BE] Session expired (code: -101), forcing refresh with timestamp: {}",
+                now_ts
+            );
             Ok(CookieRefreshInfo {
-                refresh: false,
-                timestamp: 0,
+                refresh: true,
+                timestamp: now_ts,
             })
         }
         _ => Err(format!("Cookie info API error: {}", info_response.message)),
@@ -787,27 +801,21 @@ async fn fetch_refresh_csrf(app: &AppHandle, correspond_path: &str) -> Result<St
 /// Refreshes the cookie using the stored refresh_token.
 ///
 /// This function:
-/// 1. Checks if refresh is needed
-/// 2. Generates CorrespondPath
-/// 3. Fetches refresh_csrf
-/// 4. Calls cookie refresh API
-/// 5. Confirms the refresh
-/// 6. Updates stored session with new cookies and refresh_token
+/// 1. Generates timestamp for CorrespondPath
+/// 2. Fetches refresh_csrf
+/// 3. Calls cookie refresh API
+/// 4. Confirms the refresh
+/// 5. Updates stored session with new cookies and refresh_token
 ///
 /// # Returns
 ///
 /// Returns the new session data on success.
 pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
-    log::debug!("[BE] Starting cookie refresh process...");
+    log::info!("[BE] Starting cookie refresh process...");
 
-    // Step 1: Check if refresh is needed
-    let refresh_info = check_cookie_refresh(app).await?;
-    if !refresh_info.refresh {
-        log::debug!("[BE] Refresh not needed, aborting");
-        return Err("Cookie refresh not needed".to_string());
-    }
-
-    log::debug!("[BE] Refresh needed, timestamp: {}", refresh_info.timestamp);
+    // Generate timestamp for CorrespondPath
+    let timestamp = chrono::Utc::now().timestamp_millis();
+    log::debug!("[BE] Using timestamp: {}", timestamp);
 
     // Get current session for refresh_token and csrf
     let login_state = get_login_state(app).await?;
@@ -821,19 +829,19 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
         session.refresh_token.len()
     );
 
-    // Step 2: Generate CorrespondPath
-    let correspond_path = generate_correspond_path(refresh_info.timestamp)?;
+    // Step 1: Generate CorrespondPath
+    let correspond_path = generate_correspond_path(timestamp)?;
     log::debug!(
         "[BE] Generated CorrespondPath: {} bytes",
         correspond_path.len()
     );
 
-    // Step 3: Fetch refresh_csrf
+    // Step 2: Fetch refresh_csrf
     log::debug!("[BE] Fetching refresh_csrf...");
     let refresh_csrf = fetch_refresh_csrf(app, &correspond_path).await?;
     log::debug!("[BE] Got refresh_csrf: {}", refresh_csrf);
 
-    // Step 4: Call cookie refresh API
+    // Step 3: Call cookie refresh API
     let cookies = get_cookie_header(app);
     let client = Client::new();
 
@@ -890,7 +898,7 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
         new_refresh_token.len()
     );
 
-    // Step 5: Confirm refresh (invalidate old refresh_token)
+    // Step 4: Confirm refresh (invalidate old refresh_token)
     let new_cookies_header = build_cookie_header(&new_cookies);
     let confirm_params = [
         (
@@ -918,7 +926,7 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
         confirm_response.message
     );
 
-    // Step 6: Build new session and save
+    // Step 5: Build new session and save
     let new_session = Session {
         sessdata: new_cookies.get("SESSDATA").cloned().unwrap_or_default(),
         bili_jct: new_cookies.get("bili_jct").cloned().unwrap_or_default(),

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -6,6 +6,7 @@ import {
 import {
   checkCookieRefresh,
   loadQrSession,
+  qrLogout,
   refreshCookie,
 } from '@/features/login'
 import { applyFontSize, parseFontSize } from '@/features/settings'
@@ -20,6 +21,7 @@ import { exit } from '@tauri-apps/plugin-process'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
+/** Languages supported by the application's i18n configuration. */
 const SUPPORTED_LANGS: readonly SupportedLang[] = [
   'en',
   'ja',
@@ -77,6 +79,11 @@ export const useInit = () => {
   const isSupportedLang = (lang: string): lang is SupportedLang =>
     (SUPPORTED_LANGS as readonly string[]).includes(lang)
 
+  /**
+   * Dispatches the initiated flag to the Redux store.
+   *
+   * @param value - True when initialization is complete.
+   */
   const setInitiated = (value: boolean) => {
     store.dispatch(setValue(value))
   }
@@ -218,11 +225,23 @@ export const useInit = () => {
     return false
   }
 
+  /**
+   * Retrieves application settings and updates the init status message.
+   *
+   * @returns The current application settings.
+   */
   const getAppSettings = async () => {
     setMessage(t('init.fetch_settings'))
     return getSettings()
   }
 
+  /**
+   * Retrieves cookies from the local Firefox profile via the Tauri backend.
+   *
+   * This is used as a fallback when no QR session is available.
+   *
+   * @returns Always returns `true` after invocation completes.
+   */
   const checkCookie = async (): Promise<boolean> => {
     logger.debug('checkCookie: Checking Firefox cookies')
     await invoke('get_cookie')
@@ -255,9 +274,15 @@ export const useInit = () => {
           await refreshCookie()
           setMessage(t('init.cookie_refreshed', 'Login session refreshed'))
         } catch (e) {
-          // Refresh failed - session might be expired
-          logger.error('refreshCookie failed', e)
-          // Return false to fall back to unauthenticated state
+          logger.error(
+            'refreshCookie: Cookie refresh failed, clearing session',
+            e,
+          )
+          try {
+            await qrLogout()
+          } catch (logoutErr) {
+            logger.error('refreshCookie: Failed to clear session', logoutErr)
+          }
           return false
         }
       } else {
@@ -270,6 +295,14 @@ export const useInit = () => {
     }
   }
 
+  /**
+   * Dispatches an initialization step message to the Redux store.
+   *
+   * The message is displayed to the user on the initialization screen
+   * to indicate the current progress step.
+   *
+   * @param message - The status message to display.
+   */
   const setMessage = (message: string) => {
     store.dispatch(setProcessingFnc(message))
   }


### PR DESCRIPTION
## Summary

- Fix `-101` (SESSDATA expired) response handling in `check_cookie_refresh()` to return `refresh: true` instead of `refresh: false`, enabling automatic session recovery via `refresh_token`
- Remove redundant `check_cookie_refresh()` call inside `refresh_cookie()` — the caller already determined refresh is needed, so a second API call was wasteful
- Add `qrLogout()` cleanup on refresh failure to prevent stale sessions from accumulating on next launch

## Context

After migrating from OS keyring to encrypted file storage (argon2 + AES-256-GCM), sessions would expire overnight. The root cause was that when Bilibili API returned `-101` (session expired), the code returned `refresh: false`, which prevented the `refresh_token` from being used to restore the session — even though the refresh_token was still valid.

## Test plan

- [ ] Log in via QR code, wait for SESSDATA to expire, restart app — session should auto-refresh via refresh_token
- [ ] Verify normal login flow still works (no regression)
- [ ] Verify that when both SESSDATA and refresh_token are expired, the app gracefully falls back to unauthenticated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)