### PR TITLE
fix: attempt cookie refresh before logout on session expiry

### DIFF
--- a/src/app/lib/invokeErrorHandler.test.ts
+++ b/src/app/lib/invokeErrorHandler.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { mockRefreshCookie } = vi.hoisted(() => ({
+  mockRefreshCookie: vi.fn(),
+}))
+
 // Mock sonner
 vi.mock('sonner', () => ({
   toast: {
@@ -37,6 +41,7 @@ vi.mock('@/features/login', async (importOriginal) => {
       type: 'login/setSession',
       payload,
     })),
+    refreshCookie: mockRefreshCookie,
   }
 })
 
@@ -50,6 +55,7 @@ import {
 } from './invokeErrorHandler'
 
 const mockToastWarning = toast.warning as unknown as ReturnType<typeof vi.fn>
+const mockToastInfo = toast.info as unknown as ReturnType<typeof vi.fn>
 
 /**
  * Creates a mock SessionStore with the given login state.
@@ -115,38 +121,32 @@ describe('invokeErrorHandler', () => {
   })
 
   describe('handleSessionExpiry', () => {
-    it('should show toast when user was logged in', () => {
+    it('should show info toast and NOT log out when refresh succeeds', async () => {
+      mockRefreshCookie.mockResolvedValue({ sessdata: 'new' })
       const mockStore = createMockStore(true)
 
-      handleSessionExpiry(mockStore)
+      await handleSessionExpiry(mockStore)
 
-      expect(mockToastWarning).toHaveBeenCalledWith('login.session_expired')
-    })
-
-    it('should NOT show toast when user was already logged out', () => {
-      const mockStore = createMockStore(false)
-
-      handleSessionExpiry(mockStore)
-
+      expect(mockRefreshCookie).toHaveBeenCalled()
+      expect(mockToastInfo).toHaveBeenCalledWith('login.cookie_refreshed')
       expect(mockToastWarning).not.toHaveBeenCalled()
+      expect(mockStore.dispatched.length).toBe(0)
     })
 
-    it('should dispatch setUser with isLogin=false', () => {
+    it('should show warning toast and log out when refresh fails', async () => {
+      mockRefreshCookie.mockRejectedValue(new Error('refresh failed'))
       const mockStore = createMockStore(true)
 
-      handleSessionExpiry(mockStore)
+      await handleSessionExpiry(mockStore)
+
+      expect(mockRefreshCookie).toHaveBeenCalled()
+      expect(mockToastWarning).toHaveBeenCalledWith('login.session_expired')
 
       const setUserAction = mockStore.dispatched.find(
         (a: unknown) => (a as { type: string }).type === 'user/setUser',
       ) as { type: string; payload: { data: { isLogin: boolean } } }
       expect(setUserAction).toBeDefined()
       expect(setUserAction.payload.data.isLogin).toBe(false)
-    })
-
-    it('should dispatch setSession(null)', () => {
-      const mockStore = createMockStore(true)
-
-      handleSessionExpiry(mockStore)
 
       const setSessionAction = mockStore.dispatched.find(
         (a: unknown) => (a as { type: string }).type === 'login/setSession',
@@ -155,10 +155,21 @@ describe('invokeErrorHandler', () => {
       expect(setSessionAction.payload).toBeNull()
     })
 
-    it('should preserve user data except isLogin', () => {
+    it('should NOT show toast when user was already logged out', async () => {
+      const mockStore = createMockStore(false)
+
+      await handleSessionExpiry(mockStore)
+
+      expect(mockToastWarning).not.toHaveBeenCalled()
+      expect(mockToastInfo).not.toHaveBeenCalled()
+      expect(mockStore.dispatched.length).toBe(0)
+    })
+
+    it('should preserve user data except isLogin on logout', async () => {
+      mockRefreshCookie.mockRejectedValue(new Error('refresh failed'))
       const mockStore = createMockStore(true)
 
-      handleSessionExpiry(mockStore)
+      await handleSessionExpiry(mockStore)
 
       const setUserAction = mockStore.dispatched.find(
         (a: unknown) => (a as { type: string }).type === 'user/setUser',
@@ -169,21 +180,37 @@ describe('invokeErrorHandler', () => {
       expect(setUserAction.payload.data.uname).toBe('TestUser')
       expect(setUserAction.payload.data.isLogin).toBe(false)
     })
+
+    it('should only refresh once for concurrent calls', async () => {
+      mockRefreshCookie.mockResolvedValue({ sessdata: 'new' })
+      const mockStore = createMockStore(true)
+
+      await Promise.all([
+        handleSessionExpiry(mockStore),
+        handleSessionExpiry(mockStore),
+        handleSessionExpiry(mockStore),
+      ])
+
+      expect(mockRefreshCookie).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('interceptInvokeError', () => {
-    it('should return error string for string errors', () => {
+    it('should return error string for string errors', async () => {
       const mockStore = createMockStore(false)
 
-      const result = interceptInvokeError(mockStore, 'ERR::VIDEO_NOT_FOUND')
+      const result = await interceptInvokeError(
+        mockStore,
+        'ERR::VIDEO_NOT_FOUND',
+      )
 
       expect(result).toBe('ERR::VIDEO_NOT_FOUND')
     })
 
-    it('should return error message for Error instances', () => {
+    it('should return error message for Error instances', async () => {
       const mockStore = createMockStore(false)
 
-      const result = interceptInvokeError(
+      const result = await interceptInvokeError(
         mockStore,
         new Error('Something failed'),
       )
@@ -191,44 +218,46 @@ describe('invokeErrorHandler', () => {
       expect(result).toBe('Something failed')
     })
 
-    it('should handle non-string/non-Error values', () => {
+    it('should handle non-string/non-Error values', async () => {
       const mockStore = createMockStore(false)
 
-      const result = interceptInvokeError(mockStore, 42)
+      const result = await interceptInvokeError(mockStore, 42)
 
       expect(result).toBe('42')
     })
 
-    it('should trigger session expiry for ERR::UNAUTHORIZED', () => {
+    it('should trigger session refresh for ERR::UNAUTHORIZED', async () => {
+      mockRefreshCookie.mockResolvedValue({ sessdata: 'new' })
       const mockStore = createMockStore(true)
 
-      const result = interceptInvokeError(mockStore, 'ERR::UNAUTHORIZED')
+      const result = await interceptInvokeError(mockStore, 'ERR::UNAUTHORIZED')
 
       expect(result).toBeNull()
-      expect(mockToastWarning).toHaveBeenCalledWith('login.session_expired')
-      expect(mockStore.dispatched.length).toBe(2)
+      expect(mockRefreshCookie).toHaveBeenCalled()
+      expect(mockToastInfo).toHaveBeenCalledWith('login.cookie_refreshed')
     })
 
-    it('should NOT trigger session expiry for other errors', () => {
+    it('should NOT trigger session expiry for other errors', async () => {
       const mockStore = createMockStore(true)
 
-      const result = interceptInvokeError(mockStore, 'ERR::API_ERROR')
+      const result = await interceptInvokeError(mockStore, 'ERR::API_ERROR')
 
       expect(result).toBe('ERR::API_ERROR')
       expect(mockToastWarning).not.toHaveBeenCalled()
       expect(mockStore.dispatched.length).toBe(0)
     })
 
-    it('should handle ERR::UNAUTHORIZED in Error message', () => {
+    it('should handle ERR::UNAUTHORIZED in Error message', async () => {
+      mockRefreshCookie.mockResolvedValue({ sessdata: 'new' })
       const mockStore = createMockStore(true)
 
-      const result = interceptInvokeError(
+      const result = await interceptInvokeError(
         mockStore,
         new Error('ERR::UNAUTHORIZED (code -101)'),
       )
 
       expect(result).toBeNull()
-      expect(mockToastWarning).toHaveBeenCalled()
+      expect(mockRefreshCookie).toHaveBeenCalled()
     })
   })
 })

--- a/src/app/lib/invokeErrorHandler.ts
+++ b/src/app/lib/invokeErrorHandler.ts
@@ -1,4 +1,4 @@
-import { setSession } from '@/features/login'
+import { refreshCookie, setSession } from '@/features/login'
 import type { User } from '@/features/user'
 import { setUser } from '@/features/user'
 import i18n from '@/i18n'
@@ -32,28 +32,56 @@ export type SessionStore = {
   dispatch: (action: unknown) => void
 }
 
+/** Mutex to prevent concurrent refresh attempts. */
+let refreshInProgress: Promise<boolean> | null = null
+
+/**
+ * Attempts a cookie refresh exactly once per batch of concurrent
+ * `-101` errors. Subsequent callers share the same promise.
+ */
+async function tryRefreshOnce(): Promise<boolean> {
+  if (refreshInProgress) return refreshInProgress
+
+  refreshInProgress = (async () => {
+    try {
+      await refreshCookie()
+      return true
+    } catch {
+      return false
+    } finally {
+      refreshInProgress = null
+    }
+  })()
+
+  return refreshInProgress
+}
+
 /**
  * Handles session expiry when the backend returns ERR::UNAUTHORIZED.
  *
+ * Attempts to refresh the session using the stored refresh_token
+ * before falling back to logout. If the refresh succeeds the user
+ * stays logged in; otherwise the session is cleared.
+ *
  * Only shows a toast notification if the user was previously logged in
  * (`user.data.isLogin === true`), preventing duplicate notifications.
- * Resets login status and session to logged-out state while preserving
- * other user data (uname, face, etc.).
- *
- * This function accesses the Redux store directly (not via hooks) so it
- * can be called from both React component context and non-component
- * code such as RTK Query base queries.
  *
  * @param store - Redux store instance (or compatible subset)
  */
-export function handleSessionExpiry(store: SessionStore): void {
+export async function handleSessionExpiry(store: SessionStore): Promise<void> {
   const state = store.getState()
   const wasLoggedIn = state.user.data.isLogin
 
-  if (wasLoggedIn) {
-    toast.warning(i18n.t('login.session_expired'))
+  if (!wasLoggedIn) return
+
+  const refreshed = await tryRefreshOnce()
+
+  if (refreshed) {
+    toast.info(i18n.t('login.cookie_refreshed'))
+    return
   }
 
+  toast.warning(i18n.t('login.session_expired'))
   store.dispatch(
     setUser({
       ...state.user,
@@ -84,19 +112,19 @@ export function handleSessionExpiry(store: SessionStore): void {
  * try {
  *   const data = await invoke('fetch_watch_history', { max: 20 })
  * } catch (err) {
- *   const errorString = interceptInvokeError(store, err)
+ *   const errorString = await interceptInvokeError(store, err)
  *   if (errorString) dispatch(setError(errorString))
  * }
  * ```
  */
-export function interceptInvokeError(
+export async function interceptInvokeError(
   store: SessionStore,
   error: unknown,
-): string | null {
+): Promise<string | null> {
   const errorString = error instanceof Error ? error.message : String(error)
 
   if (isUnauthorizedError(errorString)) {
-    handleSessionExpiry(store)
+    await handleSessionExpiry(store)
     return null
   }
 

--- a/src/app/store/tauriBaseQuery.ts
+++ b/src/app/store/tauriBaseQuery.ts
@@ -53,12 +53,12 @@ export const tauriBaseQuery: BaseQueryFn<TauriArgs> = async ({
   try {
     const result = await invoke(command, args)
     return { data: result }
-  } catch (error) {
+  } catch (error: unknown) {
     const errorString = String(error)
     logger.error(`API error: ${command}`, error)
 
     if (isUnauthorizedError(errorString)) {
-      handleSessionExpiry(store)
+      await handleSessionExpiry(store)
     }
 
     return { error: errorString }

--- a/src/features/favorite/hooks/useFavorite.ts
+++ b/src/features/favorite/hooks/useFavorite.ts
@@ -44,7 +44,7 @@ async function withErrorHandling<T>(
     onSuccess?.(result)
     return result
   } catch (err) {
-    const message = interceptInvokeError(store, err)
+    const message = await interceptInvokeError(store, err)
     if (message) {
       store.dispatch(setError(message))
       toast.error(message)
@@ -55,21 +55,22 @@ async function withErrorHandling<T>(
 
 /**
  * Custom hook for managing Bilibili favorites.
+ *
+ * On mount, fetches the user's favorite folders (skipping if already
+ * cached) and auto-selects the first folder. Exposes folder selection,
+ * video pagination, and a full refresh operation.
+ *
+ * @param mid - Bilibili member ID, or `null` when logged out
+ * @returns Favorite state combined with action functions
+ *
+ * @example
+ * ```typescript
+ * const { folders, videos, selectFolder, loadMore, refresh } =
+ *   useFavorite(userMid)
+ * ```
  */
 export function useFavorite(mid: number | null) {
   const state = useSelector((state: RootState) => state.favorite)
-
-  const {
-    folders,
-    selectedFolderId,
-    videos,
-    hasMore,
-    totalCount,
-    currentPage,
-    loading,
-    foldersLoading,
-    error,
-  } = state
 
   /**
    * Fetches favorite folders on mount when mid is available.
@@ -92,7 +93,7 @@ export function useFavorite(mid: number | null) {
         () => apiFetchFolders(mid),
         (folders) => {
           store.dispatch(setFolders(folders))
-          if (folders.length > 0 && !selectedFolderId) {
+          if (folders.length > 0 && !state.selectedFolderId) {
             store.dispatch(setSelectedFolder(folders[0].id))
           }
         },
@@ -109,19 +110,19 @@ export function useFavorite(mid: number | null) {
    * Fetches videos when selected folder changes.
    */
   useEffect(() => {
-    if (!selectedFolderId) {
+    if (!state.selectedFolderId) {
       return
     }
 
     store.dispatch(setLoading(true))
     withErrorHandling(
-      () => apiFetchVideos(selectedFolderId, 1, PAGE_SIZE),
+      () => apiFetchVideos(state.selectedFolderId!, 1, PAGE_SIZE),
       (response) => {
         store.dispatch(setVideos(response))
         store.dispatch(setLoading(false))
       },
     )
-  }, [selectedFolderId])
+  }, [state.selectedFolderId])
 
   /**
    * Selects a folder and loads its videos.
@@ -135,15 +136,17 @@ export function useFavorite(mid: number | null) {
    * Loads more videos (pagination).
    */
   const loadMore = useCallback(async () => {
-    if (!selectedFolderId || !hasMore || loading) {
+    if (!state.selectedFolderId || !state.hasMore || state.loading) {
       return
     }
 
-    logger.debug(`useFavorite: Loading more videos, page=${currentPage + 1}`)
+    logger.debug(
+      `useFavorite: Loading more videos, page=${state.currentPage + 1}`,
+    )
     store.dispatch(setLoading(true))
-    const nextPage = currentPage + 1
+    const nextPage = state.currentPage + 1
     const result = await withErrorHandling(
-      () => apiFetchVideos(selectedFolderId, nextPage, PAGE_SIZE),
+      () => apiFetchVideos(state.selectedFolderId!, nextPage, PAGE_SIZE),
       (response: FavoriteVideoListResponse) => {
         store.dispatch(appendVideos(response))
       },
@@ -151,7 +154,7 @@ export function useFavorite(mid: number | null) {
     if (result) {
       store.dispatch(setLoading(false))
     }
-  }, [selectedFolderId, hasMore, loading, currentPage])
+  }, [state.selectedFolderId, state.hasMore, state.loading, state.currentPage])
 
   /**
    * Refreshes both folders and videos.
@@ -167,14 +170,15 @@ export function useFavorite(mid: number | null) {
       () => apiFetchFolders(mid),
       (folders) => {
         store.dispatch(setFolders(folders))
-        const currentExists = folders.some((f) => f.id === selectedFolderId)
+        const currentExists = folders.some(
+          (f) => f.id === state.selectedFolderId,
+        )
         if (!currentExists) {
           if (folders.length > 0) {
             store.dispatch(setSelectedFolder(folders[0].id))
           } else {
             store.dispatch(reset())
           }
-          return
         }
       },
     )
@@ -194,18 +198,10 @@ export function useFavorite(mid: number | null) {
         },
       )
     }
-  }, [mid, selectedFolderId])
+  }, [mid, state.selectedFolderId])
 
   return {
-    folders,
-    selectedFolderId,
-    videos,
-    hasMore,
-    totalCount,
-    currentPage,
-    loading,
-    foldersLoading,
-    error,
+    ...state,
     selectFolder,
     loadMore,
     refresh,

--- a/src/features/user/useUser.ts
+++ b/src/features/user/useUser.ts
@@ -27,17 +27,30 @@ import { setUser } from '@/features/user/userSlice'
 export function useUser() {
   const user = useSelector((state) => state.user)
 
+  /**
+   * Fetches the current user info from the Bilibili API and
+   * updates the Redux store. Re-throws the error after
+   * intercepting it so callers can still handle failures.
+   *
+   * @returns The fetched {@link User} object
+   * @throws The original error if the API call fails
+   */
   async function getUserInfo(): Promise<User> {
     try {
       const res = await fetchUser()
       store.dispatch(setUser(res))
       return res
     } catch (err) {
-      interceptInvokeError(store, err)
+      await interceptInvokeError(store, err)
       throw err
     }
   }
 
+  /**
+   * Replaces the current user state in Redux with the given object.
+   *
+   * @param user - The new {@link User} state to dispatch
+   */
   function onChangeUser(user: User): void {
     store.dispatch(setUser(user))
   }

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -339,7 +339,7 @@ const VideoPartCard = memo(function VideoPartCard({
           }),
         )
       } catch (e) {
-        const message = interceptInvokeError(store, e)
+        const message = await interceptInvokeError(store, e)
         if (message) {
           logger.error('Failed to fetch qualities', message)
         }
@@ -369,7 +369,7 @@ const VideoPartCard = memo(function VideoPartCard({
           setPartSubtitles({ index: partIndex, subtitles: fetchedSubtitles }),
         )
       } catch (e) {
-        const message = interceptInvokeError(store, e)
+        const message = await interceptInvokeError(store, e)
         if (message) {
           logger.error('Failed to fetch subtitles', message)
         }
@@ -400,10 +400,10 @@ const VideoPartCard = memo(function VideoPartCard({
       const shouldFetchQualities =
         videoQualities === undefined && !qualitiesLoading
       const shouldFetchSubtitles = subtitles.length === 0 && !subtitlesLoading
+      const isVipOnly = isBangumi && !epId
 
-      // Mark loading states
       if (shouldFetchQualities) {
-        if (isBangumi && !epId) {
+        if (isVipOnly) {
           // VIP-only bangumi without epId - no qualities available
           store.dispatch(
             setPartQualities({
@@ -424,7 +424,7 @@ const VideoPartCard = memo(function VideoPartCard({
 
       // Fetch data in parallel
       const tasks: Promise<void>[] = []
-      if (shouldFetchQualities && !(isBangumi && !epId)) {
+      if (shouldFetchQualities && !isVipOnly) {
         tasks.push(doFetchQualities(partIndex, isBangumi, epId))
       }
       if (shouldFetchSubtitles) {

--- a/src/features/watch-history/hooks/useWatchHistory.ts
+++ b/src/features/watch-history/hooks/useWatchHistory.ts
@@ -89,7 +89,7 @@ export function useWatchHistory() {
       dispatch(setEntries(response.entries))
       dispatch(setCursor(response.cursor))
     } catch (err) {
-      const message = interceptInvokeError(store, err)
+      const message = await interceptInvokeError(store, err)
       if (message) dispatch(setError(message))
     } finally {
       dispatch(setLoading(false))
@@ -107,22 +107,32 @@ export function useWatchHistory() {
       dispatch(appendEntries(response.entries))
       dispatch(setCursor(response.cursor))
     } catch (err) {
-      const message = interceptInvokeError(store, err)
+      const message = await interceptInvokeError(store, err)
       if (message) dispatch(setError(message))
     } finally {
       dispatch(setLoadingMore(false))
     }
   }, [dispatch, cursor, loadingMore])
 
+  /**
+   * Updates the search query used to filter watch history entries.
+   *
+   * @param query - Search text to filter by (empty string clears the filter)
+   */
   const setSearch = useCallback(
     (query: string) => dispatch(setSearchQuery(query)),
     [dispatch],
   )
 
+  /**
+   * Updates the date filter applied to watch history entries.
+   *
+   * @param filter - Date range filter:
+   *   `'all'` | `'today'` | `'week'` | `'month'`
+   */
   const setDate = useCallback(
-    (filter: 'all' | 'today' | 'week' | 'month') => {
-      dispatch(setDateFilter(filter))
-    },
+    (filter: 'all' | 'today' | 'week' | 'month') =>
+      dispatch(setDateFilter(filter)),
     [dispatch],
   )
 


### PR DESCRIPTION
## Summary

- Modified `handleSessionExpiry()` to attempt `refreshCookie()` via a mutex before logging out when `ERR::UNAUTHORIZED` is detected at runtime
- Previously, any `-101` response from Bilibili API would immediately log out the user, even when a valid refresh token was available
- Updated all callers (`tauriBaseQuery`, `interceptInvokeError`, `useWatchHistory`, `useFavorite`, `useUser`, `VideoPartCard`) to properly await the now-async error handler
- Added comprehensive tests covering: refresh success, refresh failure, concurrent call mutex, already-logged-out state, and data preservation

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] Unit tests pass for `invokeErrorHandler` (17/17 tests)
- [ ] Log in via QR code, wait for session to expire, verify automatic cookie refresh occurs
- [ ] Verify toast notification appears on successful refresh
- [ ] Verify logout only occurs when refresh token is also expired

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no i18n changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)