### PR TITLE
feat(ui): add language switcher to AppBar

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "shadcn": {
       "command": "npx",
-      "args": [
-        "shadcn@latest",
-        "mcp"
-      ]
+      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/src/features/preference/index.ts
+++ b/src/features/preference/index.ts
@@ -2,8 +2,9 @@
  * Public API for the preference feature.
  *
  * Provides UI components for user preference management such as
- * theme toggling (light/dark mode).
+ * theme toggling (light/dark mode) and language switching.
  * @module features/preference
  */
 
+export { default as LanguageSwitcher } from './ui/LanguageSwitcher'
 export { default as ToggleThemeButton } from './ui/ToggleThemeButton'

--- a/src/features/preference/ui/LanguageSwitcher.tsx
+++ b/src/features/preference/ui/LanguageSwitcher.tsx
@@ -1,0 +1,65 @@
+import { languages, useSettings, type SupportedLang } from '@/features/settings'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/shared/animate-ui/radix/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/animate-ui/radix/tooltip'
+import { Languages } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Language selection dropdown for the AppBar.
+ *
+ * Displays a Languages icon that opens a dropdown with available
+ * languages. The current language is indicated with a radio
+ * indicator. Changes are persisted via the settings hook.
+ */
+function LanguageSwitcher() {
+  const { t } = useTranslation()
+  const { settings, updateLanguage, id2Label } = useSettings()
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <DropdownMenu>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="hover:bg-accent/80 text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-md transition-colors"
+                aria-label={t('settings.language')}
+              >
+                <Languages className="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuRadioGroup
+              value={settings.language}
+              onValueChange={(val) => updateLanguage(val as SupportedLang)}
+            >
+              {languages.map((lang) => (
+                <DropdownMenuRadioItem key={lang.id} value={lang.id}>
+                  {id2Label(lang.id)}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <TooltipContent>
+          <p>{id2Label(settings.language)}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export default LanguageSwitcher

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -6,6 +6,7 @@
  * @module features/settings
  */
 
+export { languages } from '@/features/settings/language/languages'
 export {
   FONT_SIZE_DEFAULT,
   FONT_SIZE_MAX,
@@ -15,3 +16,4 @@ export {
 } from '@/features/settings/lib/fontSize'
 export * from '@/features/settings/settingsSlice'
 export * from '@/features/settings/type'
+export { useSettings } from '@/features/settings/useSettings'

--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from '@/app/store'
 import { QRCodeLoginDialog } from '@/features/login'
+import LanguageSwitcher from '@/features/preference/ui/LanguageSwitcher'
 import ToggleThemeButton from '@/features/preference/ui/ToggleThemeButton'
 import type { User } from '@/features/user'
 import {
@@ -41,6 +42,7 @@ type Props = {
  * Displays:
  * - Logged-in username (masked for privacy)
  * - GitHub repository stars (with caching)
+ * - Language switcher
  * - Theme toggle button
  */
 function AppBar({ user, theme, setTheme }: Props) {
@@ -96,6 +98,7 @@ function AppBar({ user, theme, setTheme }: Props) {
           {showGithubStars && (
             <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />
           )}
+          <LanguageSwitcher />
           <ToggleThemeButton theme={theme} setTheme={setTheme} />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add a `LanguageSwitcher` component with a `Languages` icon dropdown menu to the AppBar
- Users can now switch between 6 supported languages directly from the top bar without opening Settings
- Exports `languages` and `useSettings` from settings public API for proper cross-feature imports

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ⚠️ Breaking change
- [ ] 📝 Documentation
- [ ] 🛠 Refactoring
- [ ] 🧹 Chore

## Test Plan

- [x] Run `npm run dev`
- [ ] Click the Languages icon in the AppBar (right side, next to theme toggle)
- [ ] Verify dropdown shows all 6 languages with radio indicator on current language
- [ ] Select a different language and confirm the UI updates immediately
- [ ] Hover over the icon and verify tooltip shows current language name

## Screenshots / Videos (Optional)

<!-- Add screenshots or screen recordings if there are UI changes -->

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for new UI component)
- [x] i18n files synced (no new keys added; uses existing `settings.language` key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)