### PR TITLE
fix(subtitle): merge parallel requests for robust fetching

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -167,7 +167,7 @@ use crate::utils::paths::get_lib_path;
 use crate::{constants::USER_AGENT, models::frontend_dto::User};
 use reqwest::header;
 use reqwest::Client;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
@@ -2081,6 +2081,27 @@ pub async fn fetch_subtitles_for_part(
     Ok(subtitles)
 }
 
+/// Merges multiple subtitle lists, deduplicating by `lan` (language code).
+///
+/// When the same `lan` appears in multiple results, the first occurrence
+/// is kept. This ensures each language appears at most once, which is
+/// required because the downstream download pipeline selects subtitles
+/// by `lan` alone and cannot handle duplicates.
+fn merge_subtitles(results: Vec<Vec<SubtitleDto>>) -> Vec<SubtitleDto> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut merged: Vec<SubtitleDto> = Vec::new();
+
+    for subtitles in results {
+        for sub in subtitles {
+            if seen.insert(sub.lan.clone()) {
+                merged.push(sub);
+            }
+        }
+    }
+
+    merged
+}
+
 /// Fetches subtitles via parallel requests to mitigate stale CDN cache.
 ///
 /// Bilibili's CDN may return stale cached responses that contain only a single
@@ -2088,7 +2109,7 @@ pub async fn fetch_subtitles_for_part(
 /// subtitles (`ai_type: 1`). Rather than retrying sequentially, this function
 /// issues [`PARALLEL_COUNT`] concurrent requests with small inter-request
 /// jitter, increasing the probability of hitting a fresh CDN node.
-/// Returns the subtitle list with the most entries as the best result.
+/// All results are merged and deduplicated via [`merge_subtitles`].
 ///
 /// # Arguments
 ///
@@ -2099,8 +2120,8 @@ pub async fn fetch_subtitles_for_part(
 ///
 /// # Returns
 ///
-/// Returns the subtitle list with the most entries from all parallel attempts.
-/// Returns an empty vector if all requests fail.
+/// Returns the merged and deduplicated subtitle list from all parallel
+/// attempts. Returns an empty vector if all requests fail.
 async fn fetch_subtitles_parallel(
     client: &Client,
     cookies: &[CookieEntry],
@@ -2124,19 +2145,30 @@ async fn fetch_subtitles_parallel(
 
     let results = futures::future::join_all(futures).await;
 
+    for (i, subs) in results.iter().enumerate() {
+        log::info!(
+            "[BE] fetch_subtitles_parallel: request {} returned \
+             {} subtitles for bvid={}, cid={}",
+            i,
+            subs.len(),
+            bvid,
+            cid,
+        );
+    }
+
+    let merged = merge_subtitles(results);
+
     log::info!(
-        "[BE] fetch_subtitles_parallel: got {} results for \
-         bvid={}, cid={}",
-        results.iter().map(|r| r.len()).sum::<usize>(),
+        "[BE] fetch_subtitles_parallel: merged into {} unique \
+         subtitles for bvid={}, cid={}",
+        merged.len(),
         bvid,
         cid,
     );
 
-    results
-        .into_iter()
-        .max_by_key(|subtitles| subtitles.len())
-        .unwrap_or_default()
+    merged
 }
+
 /// Fetches available video and audio qualities for a specific part.
 ///
 /// Used for lazy loading when parts are rendered in the UI

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -234,8 +234,6 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
       selected: isSelected(p),
       duration: p.duration,
       thumbnailUrl: p.thumbnail.url,
-      subtitles: [],
-      subtitlesLoading: false,
       qualitiesLoading: false,
     }))
 

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -215,7 +215,7 @@ const VideoPartCard = memo(function VideoPartCard({
   const subtitle = partInput?.subtitle
   const isSubtitleInvalid =
     subtitle && subtitle.mode !== 'off' && !subtitle.selectedLans?.length
-  const subtitles = partInput?.subtitles ?? []
+  const subtitles = partInput?.subtitles
   const subtitlesLoading = partInput?.subtitlesLoading ?? false
 
   const videoQualities = partInput?.videoQualities
@@ -399,7 +399,7 @@ const VideoPartCard = memo(function VideoPartCard({
       const epId = videoPart.epId
       const shouldFetchQualities =
         videoQualities === undefined && !qualitiesLoading
-      const shouldFetchSubtitles = subtitles.length === 0 && !subtitlesLoading
+      const shouldFetchSubtitles = subtitles === undefined && !subtitlesLoading
       const isVipOnly = isBangumi && !epId
 
       if (shouldFetchQualities) {
@@ -438,7 +438,7 @@ const VideoPartCard = memo(function VideoPartCard({
       videoPart.epId,
       videoQualities,
       qualitiesLoading,
-      subtitles.length,
+      subtitles,
       subtitlesLoading,
       doFetchQualities,
       doFetchSubtitles,
@@ -802,7 +802,7 @@ const VideoPartCard = memo(function VideoPartCard({
                       {/* Unified loading skeleton: shown until all fetches complete */}
                       {qualitiesLoading ||
                       videoQualities === undefined ||
-                      subtitlesLoading ? (
+                      (subtitlesLoading && subtitles === undefined) ? (
                         <>
                           <div className="space-y-2">
                             <Skeleton className="h-4 w-16" />
@@ -943,7 +943,7 @@ const VideoPartCard = memo(function VideoPartCard({
                           )}
 
                           {/* Subtitle Section */}
-                          {subtitles.length > 0 && (
+                          {subtitles && subtitles.length > 0 && (
                             <div>
                               <div className="mb-2 flex items-center gap-1.5">
                                 <span className="text-sm font-medium">


### PR DESCRIPTION
## Summary

- Merge all parallel subtitle API responses instead of picking the one with the most entries (`max_by_key` → `merge_subtitles` with dedup by `lan`)
- Fix frontend state management to distinguish unfetched subtitles (`undefined`) from fetched-empty (`[]`), aligning with the quality selector pattern

Previously, `fetch_subtitles_parallel` issued 3 concurrent requests and selected the response with the most entries. When all requests hit the same stale CDN cache, the result could be incomplete (e.g., missing Japanese subtitles). Now all responses are merged and deduplicated by language code, ensuring the union of all available subtitles is returned.

## Related Issue

Related #381

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Open a video with multiple subtitles (e.g., Japanese + Chinese + English AI translations)
- [ ] Expand the options accordion and verify all expected subtitle languages appear
- [ ] Select 7 soft subtitles and download — verify the video duration is correct and playback works
- [ ] Open/close accordion for a video with no subtitles — verify no re-fetch occurs on reopen

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)