### PR TITLE
feat(settings): add skipSplashAnimation for faster startup

### DIFF
--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -6,12 +6,31 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TitleReplacement {
+    /// Character or text to match for replacement.
     pub from: String,
+    /// Replacement text. Use an empty string to delete the match.
     pub to: String,
+    /// Whether this replacement rule is active.
     pub enabled: bool,
 }
 
 impl TitleReplacement {
+    /// Creates a new title replacement rule.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - The character or text to match for replacement.
+    /// * `to` - The replacement text. Use an empty string to delete the match.
+    /// * `enabled` - Whether this rule is active.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let rule = TitleReplacement::new(":", "_", true);
+    /// assert_eq!(rule.from, ":");
+    /// assert_eq!(rule.to, "_");
+    /// assert!(rule.enabled);
+    /// ```
     pub fn new(from: impl Into<String>, to: impl Into<String>, enabled: bool) -> Self {
         Self {
             from: from.into(),
@@ -62,25 +81,39 @@ pub fn default_title_replacements() -> Vec<TitleReplacement> {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub struct Settings {
+    /// Directory path for downloaded videos.
     #[serde(rename = "dlOutputPath")]
     pub dl_output_path: Option<String>,
+    /// Current application language.
     pub language: Language,
+    /// Custom path for library dependencies (ffmpeg, etc.).
+    ///
+    /// Defaults to `app_data_dir()/lib/` if not specified. Allows users to
+    /// store large dependencies on a different drive or location.
     #[serde(rename = "libPath")]
     pub lib_path: Option<String>,
+    /// Whether the sidebar is expanded. Defaults to true.
     #[serde(rename = "sidebarExpanded")]
     pub sidebar_expanded: Option<bool>,
+    /// Custom title replacement rules for filename sanitization.
+    ///
+    /// If not specified, backend uses default replacements.
+    /// Maximum 20 rules allowed.
     #[serde(
         rename = "titleReplacements",
         default,
         skip_serializing_if = "Option::is_none"
     )]
     pub title_replacements: Option<Vec<TitleReplacement>>,
+    /// Whether to automatically rename duplicate part titles with
+    /// index suffixes. Defaults to true.
     #[serde(
         rename = "autoRenameDuplicates",
         default,
         skip_serializing_if = "Option::is_none"
     )]
     pub auto_rename_duplicates: Option<bool>,
+    /// Whether to show GitHub stars in the app bar. Defaults to true.
     #[serde(
         rename = "showGithubStars",
         default,
@@ -99,17 +132,33 @@ pub struct Settings {
     /// Defaults to 16 (browser default) if not specified.
     #[serde(rename = "fontSize", default, skip_serializing_if = "Option::is_none")]
     pub font_size: Option<u8>,
+    /// Whether to skip the splash screen animation on startup.
+    /// When true, a minimal loading indicator is shown instead of the 3D animation.
+    #[serde(
+        rename = "skipSplashAnimation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub skip_splash_animation: Option<bool>,
 }
 
 /// Supported UI languages.
+///
+/// Each variant maps to a locale file in `src/i18n/locales/`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
+    /// English (default).
     #[default]
     En,
+    /// Japanese.
     Ja,
+    /// French.
     Fr,
+    /// Spanish.
     Es,
+    /// Simplified Chinese.
     Zh,
+    /// Korean.
     Ko,
 }

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -33,8 +33,11 @@ const SUPPORTED_LANGS: readonly SupportedLang[] = [
   'ko',
 ]
 
+/** Result of the application initialization sequence. */
 export interface InitResult {
+  /** Status code: 0 for success, non-zero for failure. */
   code: number
+  /** Optional error detail when initialization fails. */
   detail?: string
 }
 
@@ -134,6 +137,7 @@ export const useInit = () => {
 
     // Version checking is handled by UpdaterProvider (non-blocking dialog)
     const settings = await getAppSettings()
+    const skipSplash = settings?.skipSplashAnimation ?? false
     await applyLanguageSetting(settings?.language)
     applyFontSize(parseFontSize(settings?.fontSize))
 
@@ -145,7 +149,7 @@ export const useInit = () => {
     // Early exit on ffmpeg check failure
     if (!(await checkFfmpeg())) {
       logger.warn('initApp: ffmpeg check failed')
-      await finalizeInit()
+      await finalizeInit(skipSplash)
       return { code: 1 }
     }
 
@@ -161,7 +165,7 @@ export const useInit = () => {
     // Fetch user info and store in Redux (hasCookie=false if no cookie)
     await getUserInfo()
 
-    await finalizeInit()
+    await finalizeInit(skipSplash)
     logger.info('initApp: Initialization completed successfully')
     return { code: 0 }
   }
@@ -169,9 +173,11 @@ export const useInit = () => {
   /**
    * Finalizes initialization by setting flag and sleeping briefly.
    */
-  const finalizeInit = async (): Promise<void> => {
+  const finalizeInit = async (skipSplash: boolean): Promise<void> => {
     logger.debug('finalizeInit: Finalizing initialization')
-    await sleep(500)
+    if (!skipSplash) {
+      await sleep(500)
+    }
     setInitiated(true)
     notifyInitComplete()
   }

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -281,6 +281,14 @@ function SettingsForm() {
 
   const currentFontSize = parseFontSize(settings.fontSize)
 
+  /**
+   * Handles font size slider changes.
+   *
+   * Parses the raw slider value into a valid preset, applies it to the
+   * document root, and persists the setting via the settings hook.
+   *
+   * @param value - Array of slider values (single-element from shadcn Slider).
+   */
   const handleFontSizeChange = useCallback(
     (value: number[]) => {
       const size = parseFontSize(value[0]) as FontSizePreset
@@ -339,21 +347,6 @@ function SettingsForm() {
               {currentFontSize}px
             </span>
           </div>
-        </div>
-        <Separator />
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label>{t('settings.show_github_stars_label')}</Label>
-            <p className="text-muted-foreground text-sm">
-              {t('settings.show_github_stars_description')}
-            </p>
-          </div>
-          <Switch
-            checked={settings.showGithubStars ?? true}
-            onCheckedChange={(checked) => {
-              saveByForm({ ...settings, showGithubStars: checked })
-            }}
-          />
         </div>
         <Separator />
         <FormField
@@ -438,10 +431,42 @@ function SettingsForm() {
           </FormDescription>
         </div>
         <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>{t('settings.show_github_stars_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.show_github_stars_description')}
+            </p>
+          </div>
+          <Switch
+            checked={settings.showGithubStars ?? true}
+            onCheckedChange={(checked) => {
+              saveByForm({ ...settings, showGithubStars: checked })
+            }}
+          />
+        </div>
+        <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>{t('settings.skip_splash_animation_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.skip_splash_animation_description')}
+            </p>
+          </div>
+          <Switch
+            checked={settings.skipSplashAnimation ?? false}
+            onCheckedChange={(checked) => {
+              saveByForm({ ...settings, skipSplashAnimation: checked })
+            }}
+          />
+        </div>
+        <Separator />
         <div className="space-y-2">
           <Label>{t('settings.app_section_label')}</Label>
-          <UpdateCheckButton />
-          <ReleaseNotesSection />
+          <div className="flex w-full items-end gap-2">
+            <UpdateCheckButton />
+            <ReleaseNotesSection />
+          </div>
         </div>
         <Separator />
         {/* Login Status Section */}

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -71,6 +71,14 @@ export interface Settings {
    * Defaults to 16 (browser default) if not specified.
    */
   fontSize?: FontSizePreset
+  /**
+   * Whether to skip the splash screen animation on startup.
+   *
+   * When enabled, a minimal loading indicator is shown instead
+   * of the 3D animation for fastest possible startup.
+   * Defaults to false if not specified.
+   */
+  skipSplashAnimation?: boolean
   // Managed on frontend only, stored in localStorage
   // TODO: manage theme in json
   // theme: 'light' | 'dark'

--- a/src/features/splash/hooks/useSplashLifecycle.ts
+++ b/src/features/splash/hooks/useSplashLifecycle.ts
@@ -20,6 +20,8 @@ interface SplashLifecycle {
   phase: SplashPhase
   /** Callback to invoke when the CSS fade-out transition finishes. */
   onFadeComplete: () => void
+  /** Whether the minimal (skip-animation) mode is active. Null while loading. */
+  skipMode: boolean | null
 }
 
 /**
@@ -43,16 +45,20 @@ function resolveTheme(): 'dark' | 'light' {
  *
  * Orchestrates three phases:
  * 1. **active**  -- splash is visible; waits for both backend initialization
- *    and a minimum display duration before advancing.
+ *    and a minimum display duration before advancing (unless skip mode).
  * 2. **fading**  -- CSS opacity transition is running; the caller is expected
  *    to call `onFadeComplete` when the transition ends.
  * 3. **done**    -- splash is removed from the DOM; the native window theme is
  *    restored and resizing is enabled.
  *
- * @returns The current phase and a fade-completion callback.
+ * When `skipSplashAnimation` is enabled in settings, the minimum display time
+ * and fade animation are skipped for fastest possible startup.
+ *
+ * @returns The current phase, a fade-completion callback, and skip mode flag.
  */
 export function useSplashLifecycle(): SplashLifecycle {
   const [phase, setPhase] = useState<SplashPhase>('active')
+  const [skipMode, setSkipMode] = useState<boolean | null>(null)
   const disposedRef = useRef(false)
 
   // Force light theme during splash
@@ -65,12 +71,33 @@ export function useSplashLifecycle(): SplashLifecycle {
   useEffect(() => {
     disposedRef.current = false
 
-    Promise.all([initCompletePromise, sleep(MIN_DISPLAY_MS)]).then(() => {
-      if (!disposedRef.current) {
-        notifySplashFading()
-        setPhase('fading')
+    const run = async () => {
+      let skip = false
+      try {
+        const s = await invoke<{ skipSplashAnimation?: boolean }>(
+          'get_settings',
+        )
+        skip = s.skipSplashAnimation ?? false
+      } catch {
+        // Default to normal splash on error
       }
-    })
+
+      if (disposedRef.current) return
+      setSkipMode(skip)
+
+      // Skip mode bypasses the minimum display time and fade phase entirely
+      if (skip) {
+        await initCompletePromise
+      } else {
+        await Promise.all([initCompletePromise, sleep(MIN_DISPLAY_MS)])
+      }
+
+      if (disposedRef.current) return
+      notifySplashFading()
+      setPhase(skip ? 'done' : 'fading')
+    }
+
+    run()
 
     return () => {
       disposedRef.current = true
@@ -108,5 +135,5 @@ export function useSplashLifecycle(): SplashLifecycle {
     setPhase('done')
   }, [])
 
-  return { phase, onFadeComplete }
+  return { phase, onFadeComplete, skipMode }
 }

--- a/src/features/splash/ui/SplashScreen.tsx
+++ b/src/features/splash/ui/SplashScreen.tsx
@@ -10,20 +10,37 @@ import { FADE_DURATION_MS } from '../lib/constants'
 /**
  * Full-screen splash overlay displayed while the application initializes.
  *
- * Renders a Three.js particle-and-TV animation, a title heading, the current
- * initialization step label, and an optional progress bar. Once initialization
- * completes (and the minimum display time elapses) the component fades out and
- * unmounts itself.
+ * In normal mode, renders a Three.js particle-and-TV animation, a title
+ * heading, the current initialization step label, and an optional progress
+ * bar. Once initialization completes (and the minimum display time elapses)
+ * the component fades out and unmounts itself.
+ *
+ * When `skipSplashAnimation` is enabled, renders only a minimal CSS spinner
+ * and the initialization step label for fastest possible startup.
  */
 export function SplashScreen() {
-  const { phase, onFadeComplete } = useSplashLifecycle()
+  const { phase, onFadeComplete, skipMode } = useSplashLifecycle()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const processingFnc = useSelector((state) => state.init.processingFnc)
   const progress = useSelector((state) => state.progress)
 
-  useThreeScene(canvasRef, phase !== 'done')
+  useThreeScene(canvasRef, skipMode === false && phase !== 'done')
 
   if (phase === 'done') return null
+
+  // Show minimal spinner while loading settings or when skip mode is active
+  if (skipMode === null || skipMode === true) {
+    return (
+      <div className="bg-background fixed inset-0 z-50 flex flex-col items-center justify-center">
+        <div className="border-foreground/20 border-t-foreground h-8 w-8 animate-spin rounded-full border-2" />
+        {processingFnc && (
+          <p className="text-muted-foreground mt-4 text-sm select-none">
+            {processingFnc}
+          </p>
+        )}
+      </div>
+    )
+  }
 
   const activeProgress = progress.find((p) => !p.isComplete)
   const pct = activeProgress?.percentage ?? 0

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -228,6 +228,8 @@
     "lib_path_error": "Failed to get path",
     "lib_path_change_success": "Library storage location updated successfully",
     "lib_path_change_error": "Failed to change library storage location",
+    "skip_splash_animation_label": "Skip Startup Animation",
+    "skip_splash_animation_description": "Show a minimal loading indicator instead of the 3D animation for faster startup",
     "app_section_label": "Application",
     "show_github_stars_label": "Show GitHub Stars",
     "show_github_stars_description": "Display the star count in the app bar",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -228,6 +228,8 @@
     "lib_path_error": "Error al obtener la ruta",
     "lib_path_change_success": "Ubicación de almacenamiento de biblioteca actualizada correctamente",
     "lib_path_change_error": "Error al cambiar la ubicación de almacenamiento de biblioteca",
+    "skip_splash_animation_label": "Omitir animación de inicio",
+    "skip_splash_animation_description": "Mostrar un indicador de carga mínimo en lugar de la animación 3D para un inicio más rápido",
     "app_section_label": "Aplicación",
     "show_github_stars_label": "Mostrar GitHub Stars",
     "show_github_stars_description": "Mostrar el recuento de estrellas en la barra de la aplicación",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -228,6 +228,8 @@
     "lib_path_error": "Échec de l'obtention du chemin",
     "lib_path_change_success": "Emplacement de stockage de la bibliothèque mis à jour avec succès",
     "lib_path_change_error": "Échec de la modification de l'emplacement de stockage de la bibliothèque",
+    "skip_splash_animation_label": "Ignorer l'animation de démarrage",
+    "skip_splash_animation_description": "Afficher un indicateur de chargement minimal au lieu de l'animation 3D pour un démarrage plus rapide",
     "app_section_label": "Application",
     "show_github_stars_label": "Afficher les GitHub Stars",
     "show_github_stars_description": "Afficher le nombre d'étoiles dans la barre d'application",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -228,6 +228,8 @@
     "lib_path_error": "パスの取得に失敗しました",
     "lib_path_change_success": "ライブラリ保存先を変更しました",
     "lib_path_change_error": "ライブラリ保存先の変更に失敗しました",
+    "skip_splash_animation_label": "起動アニメーションをスキップ",
+    "skip_splash_animation_description": "3Dアニメーションの代わりに最小限のローディング表示で高速起動",
     "app_section_label": "アプリケーション",
     "show_github_stars_label": "GitHub Stars を表示",
     "show_github_stars_description": "アプリバーにスター数を表示します",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -228,6 +228,8 @@
     "lib_path_error": "경로를 가져오지 못했습니다",
     "lib_path_change_success": "라이브러리 저장 위치가 성공적으로 업데이트되었습니다",
     "lib_path_change_error": "라이브러리 저장 위치 변경 실패",
+    "skip_splash_animation_label": "시작 애니메이션 건너뛰기",
+    "skip_splash_animation_description": "3D 애니메이션 대신 최소 로딩 표시로 빠른 시작",
     "app_section_label": "애플리케이션",
     "show_github_stars_label": "GitHub Stars 표시",
     "show_github_stars_description": "앱 바에 스타 수를 표시합니다",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -228,6 +228,8 @@
     "lib_path_error": "获取路径失败",
     "lib_path_change_success": "库存储位置已成功更新",
     "lib_path_change_error": "更改库存储位置失败",
+    "skip_splash_animation_label": "跳过启动动画",
+    "skip_splash_animation_description": "使用简洁的加载指示器代替3D动画，实现更快的启动速度",
     "app_section_label": "应用程序",
     "show_github_stars_label": "显示 GitHub Stars",
     "show_github_stars_description": "在应用栏中显示星标数",


### PR DESCRIPTION
## Summary

- Add `skipSplashAnimation` setting (default OFF) to skip the 3D splash animation on startup
- When enabled: replaces Three.js splash with a minimal CSS spinner, skips all artificial delays (MIN_DISPLAY_MS 2000ms, fade transition 700ms, init sleep 500ms) for ~3200ms faster startup
- Adds Rust Settings struct field, TypeScript type, lifecycle hook changes, UI Switch, and i18n keys for all 6 languages

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore

## Test Plan

- [ ] Run `npm run dev`
- [ ] Navigate to Settings page
- [ ] Verify "Skip Splash Animation" toggle appears below "Show GitHub Stars"
- [ ] Enable the toggle, restart the app
- [ ] Confirm minimal CSS spinner appears instead of 3D splash
- [ ] Confirm app starts significantly faster (no 2s delay)
- [ ] Disable the toggle, restart the app
- [ ] Confirm normal 3D splash returns

## Checklist

- [x] `/review-all` executed (code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A for settings UI)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)