### PR TITLE
refactor: unify loading indicators with shared CircleIndicator component

### DIFF
--- a/src/features/favorite/ui/FavoriteList.tsx
+++ b/src/features/favorite/ui/FavoriteList.tsx
@@ -1,5 +1,6 @@
 import type { FavoriteVideo } from '@/features/favorite/types'
 import FavoriteItem from '@/features/favorite/ui/FavoriteItem'
+import CircleIndicator from '@/shared/ui/CircleIndicator'
 import { useTranslation } from 'react-i18next'
 import { Virtuoso } from 'react-virtuoso'
 
@@ -77,10 +78,8 @@ function FavoriteList({
 
   if ((loading || foldersLoading) && videos.length === 0) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center">
-        <div className="text-muted-foreground animate-pulse">
-          {t('init.initializing')}
-        </div>
+      <div className="flex h-full items-center justify-center">
+        <CircleIndicator size="lg" />
       </div>
     )
   }
@@ -108,7 +107,7 @@ function FavoriteList({
         }
       }}
       itemContent={(_index, video) => (
-        <div key={video.id} className="py-1">
+        <div className="py-1">
           <FavoriteItem
             video={video}
             onDownload={onDownload}

--- a/src/features/favorite/ui/FolderSelector.tsx
+++ b/src/features/favorite/ui/FolderSelector.tsx
@@ -1,4 +1,5 @@
 import type { FavoriteFolder } from '@/features/favorite/types'
+import CircleIndicator from '@/shared/ui/CircleIndicator'
 import {
   Select,
   SelectContent,
@@ -6,36 +7,63 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/shared/ui/select'
-import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 /** Bilibili API default folder name (Chinese). */
 const DEFAULT_FOLDER_API_NAME = '默认收藏夹'
 
+/** Props for the FolderSelector component. */
 type Props = {
+  /** Array of favorite folders to display in the dropdown. */
   folders: FavoriteFolder[]
+  /** ID of the currently selected folder, or null if none is selected. */
   selectedId: number | null
+  /** Callback invoked when the user selects a folder from the dropdown. */
   onSelect: (id: number) => void
+  /** Whether folder data is currently being fetched. */
   loading?: boolean
 }
 
 /**
- * Folder selector dropdown component.
+ * Replace the Bilibili API default folder name with a localized label.
+ *
+ * The Bilibili API returns a Chinese string for the default folder.
+ * This function swaps it with the localized default folder name from i18n.
+ *
+ * @param title - The raw folder title returned by the Bilibili API.
+ * @param localizedDefault - The localized label for the default folder
+ *   (e.g., the value of the `favorite.defaultFolder` translation key).
+ * @returns The localized display name for the folder.
+ */
+function getDisplayName(title: string, localizedDefault: string): string {
+  return title === DEFAULT_FOLDER_API_NAME ? localizedDefault : title
+}
+
+/**
+ * Folder selector dropdown component for choosing a favorite folder.
+ *
+ * Displays a Select dropdown populated with the user's favorite folders.
+ * Each item shows the folder name (with the API default folder name localized)
+ * and the media count. Shows a loading spinner while folders are being fetched,
+ * and renders nothing when the folder list is empty.
+ *
+ * @example
+ * ```tsx
+ * <FolderSelector
+ *   folders={folders}
+ *   selectedId={selectedFolderId}
+ *   onSelect={(id) => setSelectedFolder(id)}
+ *   loading={foldersLoading}
+ * />
+ * ```
  */
 function FolderSelector({ folders, selectedId, onSelect, loading }: Props) {
   const { t } = useTranslation()
 
-  /** Replace API default folder name with i18n label. */
-  const displayName = useCallback(
-    (title: string) =>
-      title === DEFAULT_FOLDER_API_NAME ? t('favorite.defaultFolder') : title,
-    [t],
-  )
-
   if (loading) {
     return (
-      <div className="text-muted-foreground animate-pulse text-sm">
-        {t('init.initializing')}
+      <div className="flex items-center">
+        <CircleIndicator size="sm" />
       </div>
     )
   }
@@ -56,7 +84,9 @@ function FolderSelector({ folders, selectedId, onSelect, loading }: Props) {
         {folders.map((folder) => (
           <SelectItem key={folder.id} value={folder.id.toString()}>
             <div className="flex items-center gap-2">
-              <span>{displayName(folder.title)}</span>
+              <span>
+                {getDisplayName(folder.title, t('favorite.defaultFolder'))}
+              </span>
               <span className="text-muted-foreground text-xs">
                 ({folder.mediaCount})
               </span>

--- a/src/features/watch-history/ui/WatchHistoryList.tsx
+++ b/src/features/watch-history/ui/WatchHistoryList.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import CircleIndicator from '@/shared/ui/CircleIndicator'
 import { useTranslation } from 'react-i18next'
 import { Virtuoso } from 'react-virtuoso'
 import type { WatchHistoryEntry } from '../types'
@@ -55,8 +55,8 @@ export function WatchHistoryList({
 
   if (loading) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center">
-        <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+      <div className="flex h-full items-center justify-center">
+        <CircleIndicator size="lg" />
       </div>
     )
   }
@@ -92,7 +92,7 @@ export function WatchHistoryList({
         Footer: () =>
           loadingMore ? (
             <div className="flex items-center justify-center py-4">
-              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+              <CircleIndicator size="md" />
             </div>
           ) : null,
       }}

--- a/src/shared/ui/CircleIndicator/CircleIndicator.tsx
+++ b/src/shared/ui/CircleIndicator/CircleIndicator.tsx
@@ -1,36 +1,35 @@
 import { cn } from '@/shared/lib/utils'
+import { Loader2 } from 'lucide-react'
 
-/**
- * Props for CircleIndicator component.
- */
+/** Props for the CircleIndicator component. */
 type Props = {
-  /** Radius of the spinner in pixels. Defaults to 30. */
-  r?: number
+  /** Size variant: 'sm' (16px), 'md' (24px), or 'lg' (32px). */
+  size?: 'sm' | 'md' | 'lg'
+  /** Additional CSS class names to apply. */
+  className?: string
 }
 
+/** Tailwind CSS class mapping for each size variant. */
+const sizeClasses = {
+  sm: 'h-4 w-4',
+  md: 'h-6 w-6',
+  lg: 'h-8 w-8',
+} as const
+
 /**
- * Animated circular loading spinner.
+ * Circular loading spinner using lucide-react Loader2 icon.
  *
- * Displays a spinning circle with a transparent top border to create
- * the loading animation effect.
- *
- * @param props - Component props
- *
- * @example
- * ```tsx
- * <CircleIndicator r={20} /> // Small spinner
- * <CircleIndicator /> // Default size (r=30)
- * ```
+ * @param size - 'sm' (16px), 'md' (24px), or 'lg' (32px). Defaults to 'lg'.
+ * @param className - Additional CSS classes.
  */
-export default function CircleIndicator({ r = 30 }: Props) {
+export default function CircleIndicator({ size = 'lg', className }: Props) {
   return (
-    <div className="flex justify-center p-3">
-      <div
-        className={cn(
-          'animate-spin rounded-full border-4 border-blue-500 border-t-transparent',
-        )}
-        style={{ width: r * 2, height: r * 2 }}
-      />
-    </div>
+    <Loader2
+      className={cn(
+        'text-muted-foreground animate-spin',
+        sizeClasses[size],
+        className,
+      )}
+    />
   )
 }


### PR DESCRIPTION
## Summary

- Replace inline loading states (animate-pulse text, direct Loader2 usage) with a shared `CircleIndicator` component
- Update `CircleIndicator` to use `Loader2` from lucide-react with `size` prop (`sm`/`md`/`lg`)
- Center loading indicators vertically in full available space (`h-full`) instead of fixed `min-h-[400px]`

## Changes

| File | Change |
|------|--------|
| `shared/ui/CircleIndicator/` | Rewritten: CSS border → Loader2, added size prop |
| `features/favorite/ui/FavoriteList.tsx` | animate-pulse text → CircleIndicator |
| `features/favorite/ui/FolderSelector.tsx` | animate-pulse text → CircleIndicator |
| `features/watch-history/ui/WatchHistoryList.tsx` | direct Loader2 → CircleIndicator |

## Test plan

- [ ] Open favorites page and verify spinner appears during loading
- [ ] Open watch history page and verify same spinner appears
- [ ] Verify folder selector shows small spinner during initial load
- [ ] Confirm spinners are vertically centered in the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)