### PR TITLE
feat: add video concatenation feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -643,6 +647,73 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.71.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-beta.2",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/src-tauri/src/handlers/concat.rs
+++ b/src-tauri/src/handlers/concat.rs
@@ -1,0 +1,425 @@
+//! Video Concatenation
+//!
+//! Concatenates multiple MP4 files into one using ffmpeg's concat demuxer.
+//! First attempts stream copy (fast, lossless). If that fails due to
+//! incompatible codecs/resolutions, automatically retries with re-encoding.
+
+use crate::utils::ffmpeg_probe::probe_duration_sec;
+use crate::utils::ffmpeg_progress::parse_out_time;
+use crate::utils::paths::get_ffmpeg_path;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Stdio;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command as AsyncCommand;
+
+const CONCAT_PROGRESS_EVENT: &str = "concat://progress";
+const CONCAT_FALLBACK_EVENT: &str = "concat://fallback";
+
+/// Options for the video concatenation command.
+///
+/// Serialized from the frontend via `serde(rename_all = "camelCase")`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConcatOptions {
+    /// Absolute file paths of the MP4 videos to concatenate, in order.
+    pub input_paths: Vec<String>,
+    /// Absolute file path for the output MP4 file.
+    pub output_path: String,
+}
+
+/// Result returned on successful video concatenation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConcatResult {
+    /// Absolute file path of the concatenated output video.
+    pub output_path: String,
+}
+
+/// Payload emitted via Tauri events to report concatenation progress.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConcatProgressPayload {
+    /// Concatenation progress as a percentage (0.0 to 100.0).
+    pub progress: f64,
+    /// Current processing time in seconds.
+    pub current_time_sec: f64,
+    /// Total duration of all input files combined, in seconds.
+    pub total_duration_sec: f64,
+}
+
+/// Returns `true` if the file extension is `.mp4` (case-insensitive).
+fn is_mp4(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("mp4"))
+}
+
+/// Compares two paths for equality, preferring canonicalized forms when
+/// available. Falls back to lexical comparison if either path cannot be
+/// canonicalized (e.g. the output file does not yet exist).
+fn is_same_file(a: &Path, b: &Path) -> bool {
+    let cb = std::fs::canonicalize(b)
+        .ok()
+        .or_else(|| canonicalize_with_parent(b));
+    match (std::fs::canonicalize(a).ok(), cb) {
+        (Some(x), Some(y)) => x == y,
+        _ => a == b,
+    }
+}
+
+/// Canonicalizes the parent directory and rejoins the file name. Used when
+/// `b` does not exist yet (e.g. an output path that hasn't been written).
+fn canonicalize_with_parent(path: &Path) -> Option<std::path::PathBuf> {
+    let parent = path.parent()?;
+    let canon = std::fs::canonicalize(parent).ok()?;
+    path.file_name().map(|n| canon.join(n))
+}
+
+/// Builds ffmpeg arguments for stream-copy concatenation.
+///
+/// Uses the concat demuxer with `-c copy` for a fast, lossless merge.
+fn build_concat_copy_args(list_path: &str, output_path: &str) -> Vec<String> {
+    [
+        "-nostats",
+        "-stats_period",
+        "1",
+        "-progress",
+        "pipe:2",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        list_path,
+        "-c",
+        "copy",
+        "-y",
+        output_path,
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+/// Builds ffmpeg arguments for re-encode concatenation.
+///
+/// Falls back to this when stream copy fails due to incompatible
+/// codecs or resolutions. Uses libx264 (CRF 23) and AAC 192k.
+fn build_concat_reencode_args(list_path: &str, output_path: &str) -> Vec<String> {
+    [
+        "-nostats",
+        "-stats_period",
+        "1",
+        "-progress",
+        "pipe:2",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        list_path,
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "23",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "192k",
+        "-y",
+        output_path,
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+/// Creates a temporary file listing input paths for ffmpeg's concat demuxer.
+fn write_concat_list(input_paths: &[String]) -> Result<std::path::PathBuf, String> {
+    let dir = std::env::temp_dir().join("bilibili-dl-concat");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("ERR::CONCAT_FFMPEG_FAILED: create temp dir {e}"))?;
+
+    let list_path = dir.join(format!(
+        "filelist_{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    ));
+
+    let content = input_paths
+        .iter()
+        .map(|p| {
+            let escaped = p.replace('\\', "/").replace("'", "'\\''");
+            format!("file '{escaped}'")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    std::fs::write(&list_path, content)
+        .map_err(|e| format!("ERR::CONCAT_FFMPEG_FAILED: write filelist {e}"))?;
+
+    Ok(list_path)
+}
+
+/// Removes the temporary concat list file and its parent directory
+/// (`bilibili-dl-concat`) if empty.
+fn cleanup_list(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    if let Some(parent) = path.parent() {
+        if parent
+            .file_name()
+            .is_some_and(|n| n == "bilibili-dl-concat")
+        {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+}
+
+/// Runs ffmpeg with the given args, emitting progress events.
+/// Returns the full stderr output on success, or an error string on failure.
+async fn run_ffmpeg_with_progress(
+    app: &AppHandle,
+    ffmpeg_path: &Path,
+    args: &[String],
+    total_duration_sec: Option<f64>,
+    error_prefix: &str,
+) -> Result<String, String> {
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
+    cmd.args(args);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("{error_prefix}: spawn {e}"))?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("{error_prefix}: no stderr"))?;
+
+    let mut reader = BufReader::new(stderr);
+    let app_clone = app.clone();
+    let stderr_task = tokio::spawn(async move {
+        let mut stderr_output = String::new();
+        let mut line = String::new();
+        while reader.read_line(&mut line).await.unwrap_or(0) > 0 {
+            stderr_output.push_str(&line);
+
+            if let Some(total) = total_duration_sec.filter(|t| *t > 0.0) {
+                if let Some(current) = parse_out_time(&line) {
+                    let progress = (current / total * 100.0).clamp(0.0, 100.0);
+                    let _ = app_clone.emit(
+                        CONCAT_PROGRESS_EVENT,
+                        ConcatProgressPayload {
+                            progress,
+                            current_time_sec: current,
+                            total_duration_sec: total,
+                        },
+                    );
+                }
+            }
+
+            line.clear();
+        }
+        stderr_output
+    });
+
+    let status = match child.wait().await {
+        Ok(s) => s,
+        Err(e) => {
+            stderr_task.abort();
+            return Err(format!("{error_prefix}: wait {e}"));
+        }
+    };
+
+    let stderr_output = stderr_task.await.unwrap_or_default();
+
+    if !status.success() {
+        return Err(format!(
+            "{error_prefix}\nExit code: {:?}\nstderr: {}",
+            status.code(),
+            stderr_output
+        ));
+    }
+
+    Ok(stderr_output)
+}
+
+/// Validates inputs and output paths, returning an `ERR::*` code on failure.
+fn validate_inputs(input_paths: &[String], output_path: &Path) -> Result<(), String> {
+    if input_paths.len() < 2 {
+        return Err("ERR::CONCAT_TOO_FEW_FILES".to_string());
+    }
+    for p in input_paths {
+        let path = Path::new(p);
+        if !path.exists() {
+            return Err("ERR::CONCAT_FILE_NOT_FOUND".to_string());
+        }
+        if !is_mp4(path) {
+            return Err("ERR::CONCAT_UNSUPPORTED_FORMAT".to_string());
+        }
+        if is_same_file(path, output_path) {
+            return Err("ERR::CONCAT_OUTPUT_COLLISION".to_string());
+        }
+    }
+    if !is_mp4(output_path) {
+        return Err("ERR::CONCAT_UNSUPPORTED_OUTPUT_FORMAT".to_string());
+    }
+    Ok(())
+}
+
+/// Concatenates multiple MP4 video files into a single output file.
+///
+/// First attempts stream copy (fast, lossless). If that fails due to
+/// incompatible codecs/resolutions, automatically retries with re-encoding
+/// and emits a `concat://fallback` event to notify the frontend.
+///
+/// Progress is reported via `concat://progress` events containing a
+/// [`ConcatProgressPayload`].
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle, used for emitting events and
+///   resolving the ffmpeg binary path.
+/// * `options` - Concatenation options including input paths and output path.
+///
+/// # Errors
+///
+/// Returns an `ERR::*`-prefixed error string on validation failure,
+/// ffmpeg spawn failure, or when both copy and re-encode attempts fail.
+pub async fn concat_videos(
+    app: &AppHandle,
+    options: &ConcatOptions,
+) -> Result<ConcatResult, String> {
+    let output_path = Path::new(&options.output_path);
+
+    validate_inputs(&options.input_paths, output_path)?;
+
+    let ffmpeg_path = get_ffmpeg_path(app);
+
+    // Probe total duration across all input files
+    let mut total_duration: f64 = 0.0;
+    for p in &options.input_paths {
+        if let Some(d) = probe_duration_sec(&ffmpeg_path, p).await {
+            total_duration += d;
+        }
+    }
+    let total_duration = (total_duration > 0.0).then_some(total_duration);
+
+    let list_path = write_concat_list(&options.input_paths)?;
+    let list_str = list_path.to_str().unwrap_or_default().to_string();
+    let output_str = options.output_path.clone();
+
+    // Try stream copy first; fall back to re-encode on failure.
+    let copy_args = build_concat_copy_args(&list_str, &output_str);
+    let copy_result = run_ffmpeg_with_progress(
+        app,
+        &ffmpeg_path,
+        &copy_args,
+        total_duration,
+        "ERR::CONCAT_FFMPEG_FAILED",
+    )
+    .await;
+
+    if copy_result.is_ok() {
+        cleanup_list(&list_path);
+        return Ok(ConcatResult {
+            output_path: options.output_path.clone(),
+        });
+    }
+
+    // Notify frontend that we're falling back to re-encode
+    let _ = app.emit(CONCAT_FALLBACK_EVENT, ());
+    let _ = app.emit(
+        CONCAT_PROGRESS_EVENT,
+        ConcatProgressPayload {
+            progress: 0.0,
+            current_time_sec: 0.0,
+            total_duration_sec: 0.0,
+        },
+    );
+
+    let reencode_args = build_concat_reencode_args(&list_str, &output_str);
+    let reencode_result = run_ffmpeg_with_progress(
+        app,
+        &ffmpeg_path,
+        &reencode_args,
+        total_duration,
+        "ERR::CONCAT_REENCODE_FAILED",
+    )
+    .await;
+
+    cleanup_list(&list_path);
+
+    reencode_result.map(|_| ConcatResult {
+        output_path: options.output_path.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_concat_copy_args_structure() {
+        let args = build_concat_copy_args("/tmp/list.txt", "out.mp4");
+        assert!(args.contains(&"-f".to_string()));
+        assert!(args.contains(&"concat".to_string()));
+        assert!(args.contains(&"-safe".to_string()));
+        assert!(args.contains(&"0".to_string()));
+        assert!(args.contains(&"-c".to_string()));
+        assert!(args.contains(&"copy".to_string()));
+        assert!(args.contains(&"-y".to_string()));
+        assert!(args.last().is_some_and(|a| a == "out.mp4"));
+    }
+
+    #[test]
+    fn build_concat_reencode_args_structure() {
+        let args = build_concat_reencode_args("/tmp/list.txt", "out.mp4");
+        assert!(args.contains(&"-f".to_string()));
+        assert!(args.contains(&"concat".to_string()));
+        assert!(args.contains(&"-c:v".to_string()));
+        assert!(args.contains(&"libx264".to_string()));
+        assert!(args.contains(&"-c:a".to_string()));
+        assert!(args.contains(&"aac".to_string()));
+        assert!(
+            !args.contains(&"-c".to_string()) || args.iter().any(|a| a == "-c:v" || a == "-c:a")
+        );
+    }
+
+    #[test]
+    fn is_mp4_checks_extension() {
+        assert!(is_mp4(Path::new("video.mp4")));
+        assert!(is_mp4(Path::new("VIDEO.MP4")));
+        assert!(!is_mp4(Path::new("video.mkv")));
+    }
+
+    #[test]
+    fn write_concat_list_content() {
+        let list = write_concat_list(&[
+            "C:\\Videos\\a.mp4".to_string(),
+            "D:\\clips\\b's file.mp4".to_string(),
+        ])
+        .unwrap();
+
+        let content = std::fs::read_to_string(&list).unwrap();
+        assert!(content.contains("file 'C:/Videos/a.mp4'"));
+        assert!(content.contains("file 'D:/clips/b'\\''s file.mp4'"));
+
+        cleanup_list(&list);
+    }
+}

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -4,6 +4,7 @@
 //! - **bilibili**: Video info retrieval and download operations
 //! - **cleanup**: Orphaned temp file cleanup on app init
 //! - **concurrency**: Semaphore management for parallel downloads
+//! - **concat**: Local MP4 file concatenation via ffmpeg concat demuxer
 //! - **cookie**: Firefox cookie extraction and caching
 //! - **favorites**: Bilibili favorite folder and video retrieval
 //! - **ffmpeg**: Binary validation and installation, A/V merging
@@ -14,6 +15,7 @@
 
 pub mod bilibili;
 pub mod cleanup;
+pub mod concat;
 pub mod concurrency;
 pub mod cookie;
 pub mod favorites;

--- a/src-tauri/src/handlers/trim.rs
+++ b/src-tauri/src/handlers/trim.rs
@@ -10,6 +10,8 @@
 //! This module is independent of the Bilibili download pipeline: it operates
 //! only on local files specified by absolute paths.
 
+use crate::utils::ffmpeg_probe::probe_duration_sec;
+use crate::utils::ffmpeg_progress::parse_out_time;
 use crate::utils::paths::get_ffmpeg_path;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -233,54 +235,6 @@ fn compute_total_duration(start: Option<f64>, end: Option<f64>) -> Option<f64> {
     }
 }
 
-/// Parses an `out_time=HH:MM:SS.fraction` line from ffmpeg's `-progress`
-/// output into seconds. Returns `None` for unrelated lines or malformed
-/// timestamps.
-fn parse_out_time(line: &str) -> Option<f64> {
-    let s = line.strip_prefix("out_time=")?.trim();
-    parse_hhmmss(s)
-}
-
-/// Parses an `HH:MM:SS.fraction` timestamp into seconds.
-fn parse_hhmmss(s: &str) -> Option<f64> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-    let h: f64 = parts[0].parse().ok()?;
-    let m: f64 = parts[1].parse().ok()?;
-    let sec: f64 = parts[2].parse().ok()?;
-    Some(h * 3600.0 + m * 60.0 + sec)
-}
-
-/// Probes the duration of `input_path` in seconds by running `ffmpeg -i`
-/// and parsing the `Duration: HH:MM:SS.xx` line from stderr.
-///
-/// Used when only a start time is supplied so we can still compute a
-/// progress percentage. Returns `None` on any parse failure — the caller
-/// falls back to no progress events.
-async fn probe_input_duration_sec(ffmpeg_path: &Path, input_path: &str) -> Option<f64> {
-    let mut cmd = AsyncCommand::new(ffmpeg_path);
-    cmd.arg("-i").arg(input_path);
-
-    #[cfg(target_os = "windows")]
-    {
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
-
-    let output = cmd.output().await.ok()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    for line in stderr.lines() {
-        if let Some(idx) = line.find("Duration:") {
-            let rest = &line[idx + "Duration:".len()..];
-            let token = rest.trim().split([',', ' ']).next()?;
-            return parse_hhmmss(token);
-        }
-    }
-    None
-}
-
 /// Validates inputs and runs ffmpeg to produce the trimmed output.
 ///
 /// # Errors
@@ -346,7 +300,7 @@ pub async fn trim_video(app: &AppHandle, options: &TrimOptions) -> Result<TrimRe
             // start-only case: probe input duration, then subtract start
             // so the bar reflects the actual trim length.
             if let Some(start) = options.start_time {
-                probe_input_duration_sec(&ffmpeg_path, &input_str)
+                probe_duration_sec(&ffmpeg_path, &input_str)
                     .await
                     .map(|d| (d - start).max(0.0))
             } else {
@@ -580,32 +534,5 @@ mod tests {
     #[test]
     fn compute_total_duration_clamps_negative() {
         assert_eq!(compute_total_duration(Some(100.0), Some(50.0)), Some(0.0));
-    }
-
-    #[test]
-    fn parse_out_time_seconds() {
-        assert_eq!(parse_out_time("out_time=00:00:12.500000\n"), Some(12.5));
-    }
-
-    #[test]
-    fn parse_out_time_with_hours() {
-        assert_eq!(parse_out_time("out_time=01:02:03.000000\n"), Some(3723.0));
-    }
-
-    #[test]
-    fn parse_out_time_ignores_other_keys() {
-        assert_eq!(parse_out_time("frame=123\n"), None);
-        assert_eq!(parse_out_time("out_time_ms=12345678\n"), None);
-    }
-
-    #[test]
-    fn parse_hhmmss_with_fraction() {
-        assert_eq!(parse_hhmmss("00:01:23.450000"), Some(83.45));
-    }
-
-    #[test]
-    fn parse_hhmmss_rejects_short_input() {
-        assert_eq!(parse_hhmmss("01:23"), None);
-        assert_eq!(parse_hhmmss("not a time"), None);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use tauri::Manager;
 
 use crate::handlers::bilibili;
 use crate::handlers::cleanup;
+use crate::handlers::concat;
 use crate::handlers::cookie;
 use crate::handlers::favorites;
 use crate::handlers::ffmpeg;
@@ -184,6 +185,7 @@ pub fn run() {
             expand_short_url,
             cleanup_temp_files,
             trim_video,
+            concat_videos,
             generate_qr_code,
             poll_qr_status,
             qr_logout,
@@ -1189,6 +1191,14 @@ async fn trim_video(
     options: trim::TrimOptions,
 ) -> Result<trim::TrimResult, String> {
     trim::trim_video(&app, &options).await
+}
+
+#[tauri::command]
+async fn concat_videos(
+    app: AppHandle,
+    options: concat::ConcatOptions,
+) -> Result<concat::ConcatResult, String> {
+    concat::concat_videos(&app, &options).await
 }
 
 /// Sets the simulate logout flag for development mode.

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -1,0 +1,33 @@
+//! FFmpeg Probe Utilities
+//!
+//! Helpers for probing media file metadata (duration, etc.) using ffmpeg.
+
+use super::ffmpeg_progress::parse_hhmmss;
+use std::path::Path;
+use tokio::process::Command as AsyncCommand;
+
+/// Probes the duration of `input_path` in seconds by running `ffmpeg -i`
+/// and parsing the `Duration: HH:MM:SS.xx` line from stderr.
+///
+/// Returns `None` on any parse failure.
+pub async fn probe_duration_sec(ffmpeg_path: &Path, input_path: &str) -> Option<f64> {
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
+    cmd.arg("-i").arg(input_path);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let output = cmd.output().await.ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stderr.lines() {
+        if let Some(idx) = line.find("Duration:") {
+            let rest = &line[idx + "Duration:".len()..];
+            let token = rest.trim().split([',', ' ']).next()?;
+            return parse_hhmmss(token);
+        }
+    }
+    None
+}

--- a/src-tauri/src/utils/ffmpeg_progress.rs
+++ b/src-tauri/src/utils/ffmpeg_progress.rs
@@ -1,0 +1,56 @@
+//! FFmpeg Progress Parsing Utilities
+//!
+//! Shared parsers for ffmpeg's `-progress` output format. Used by both
+//! trim and concat handlers to parse timestamps and progress lines.
+
+/// Parses an `HH:MM:SS.fraction` timestamp into seconds.
+pub fn parse_hhmmss(s: &str) -> Option<f64> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let h: f64 = parts[0].parse().ok()?;
+    let m: f64 = parts[1].parse().ok()?;
+    let sec: f64 = parts[2].parse().ok()?;
+    Some(h * 3600.0 + m * 60.0 + sec)
+}
+
+/// Parses an `out_time=HH:MM:SS.fraction` line from ffmpeg's `-progress`
+/// output into seconds. Returns `None` for unrelated lines or malformed
+/// timestamps.
+pub fn parse_out_time(line: &str) -> Option<f64> {
+    let s = line.strip_prefix("out_time=")?.trim();
+    parse_hhmmss(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_out_time_seconds() {
+        assert_eq!(parse_out_time("out_time=00:00:12.500000\n"), Some(12.5));
+    }
+
+    #[test]
+    fn parse_out_time_with_hours() {
+        assert_eq!(parse_out_time("out_time=01:02:03.000000\n"), Some(3723.0));
+    }
+
+    #[test]
+    fn parse_out_time_ignores_other_keys() {
+        assert_eq!(parse_out_time("frame=123\n"), None);
+        assert_eq!(parse_out_time("out_time_ms=12345678\n"), None);
+    }
+
+    #[test]
+    fn parse_hhmmss_with_fraction() {
+        assert_eq!(parse_hhmmss("00:01:23.450000"), Some(83.45));
+    }
+
+    #[test]
+    fn parse_hhmmss_rejects_short_input() {
+        assert_eq!(parse_hhmmss("01:23"), None);
+        assert_eq!(parse_hhmmss("not a time"), None);
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -7,6 +7,8 @@
 pub mod analytics;
 pub mod downloads;
 pub mod error_handler;
+pub mod ffmpeg_probe;
+pub mod ffmpeg_progress;
 pub mod log_cleanup;
 pub mod paths;
 pub mod sanitize;

--- a/src/features/concat/api/concatApi.ts
+++ b/src/features/concat/api/concatApi.ts
@@ -1,0 +1,16 @@
+import { invoke } from '@tauri-apps/api/core'
+
+import type { ConcatOptions, ConcatResult } from '../types'
+
+/**
+ * Invokes the Tauri backend to concatenate multiple video files.
+ *
+ * @param options - Input file paths and the desired output path.
+ * @returns A promise that resolves to the result containing the output path.
+ * @throws When ffmpeg fails or validation errors occur (backend `ERR::*` codes).
+ */
+export async function concatVideos(
+  options: ConcatOptions,
+): Promise<ConcatResult> {
+  return invoke<ConcatResult>('concat_videos', { options })
+}

--- a/src/features/concat/hooks/useConcat.ts
+++ b/src/features/concat/hooks/useConcat.ts
@@ -1,0 +1,251 @@
+import { concatVideos } from '../api/concatApi'
+import {
+  validateConcatFiles,
+  type ConcatValidationError,
+} from '../lib/validation'
+import type { ConcatProgress } from '../types'
+
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { error as logError } from '@tauri-apps/plugin-log'
+import type { TFunction } from 'i18next'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+/** Status of the concatenation operation. */
+export type ConcatStatus = 'idle' | 'concatting' | 'success' | 'error'
+
+/** Return type of the {@link useConcat} hook exposing all state and handlers. */
+export type UseConcatResult = {
+  files: string[]
+  outputPath: string | null
+  status: ConcatStatus
+  validationError: ConcatValidationError | null
+  progress: ConcatProgress | null
+  elapsedSec: number
+  remainingSec: number | null
+  handleAddFiles: () => Promise<void>
+  handleRemoveFile: (index: number) => void
+  handleReorderFiles: (fromIndex: number, toIndex: number) => void
+  handleChooseOutput: () => Promise<void>
+  handleConcat: () => Promise<void>
+  handleReveal: () => Promise<void>
+  reset: () => void
+}
+
+/**
+ * Custom hook that manages the video concatenation workflow.
+ *
+ * Handles file selection, output path, validation, progress tracking,
+ * elapsed/remaining time calculation, and cleanup. Listens to Tauri
+ * events (`concat://progress`, `concat://fallback`) emitted by the
+ * backend during ffmpeg execution.
+ */
+export function useConcat(): UseConcatResult {
+  const { t } = useTranslation()
+  const [files, setFiles] = useState<string[]>([])
+  const [outputPath, setOutputPath] = useState<string | null>(null)
+  const [status, setStatus] = useState<ConcatStatus>('idle')
+  const [validationError, setValidationError] =
+    useState<ConcatValidationError | null>(null)
+  const [progress, setProgress] = useState<ConcatProgress | null>(null)
+  const [startedAtMs, setStartedAtMs] = useState<number | null>(null)
+  const [finalElapsedSec, setFinalElapsedSec] = useState<number | null>(null)
+  const [, setTick] = useState(0)
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const unlisteners: UnlistenFn[] = []
+
+    void listen<ConcatProgress>('concat://progress', (event) => {
+      setProgress(event.payload)
+    }).then((fn) => {
+      if (cancelled) fn()
+      else unlisteners.push(fn)
+    })
+
+    void listen('concat://fallback', () => {
+      setProgress(null)
+      setStartedAtMs(Date.now())
+      toast.info(t('concat.fallbackNotice'))
+    }).then((fn) => {
+      if (cancelled) fn()
+      else unlisteners.push(fn)
+    })
+
+    return () => {
+      cancelled = true
+      unlisteners.forEach((fn) => fn())
+    }
+  }, [t])
+
+  const resetStatus = useCallback(() => {
+    setStatus('idle')
+    setValidationError(null)
+  }, [])
+
+  const handleAddFiles = useCallback(async () => {
+    const selected = await open({
+      multiple: true,
+      filters: [{ name: 'MP4 Video', extensions: ['mp4'] }],
+    })
+    if (Array.isArray(selected) && selected.length > 0) {
+      setFiles((prev) => [...prev, ...selected])
+      resetStatus()
+    }
+  }, [resetStatus])
+
+  const handleRemoveFile = useCallback(
+    (index: number) => {
+      setFiles((prev) => prev.filter((_, i) => i !== index))
+      resetStatus()
+    },
+    [resetStatus],
+  )
+
+  const handleReorderFiles = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      setFiles((prev) => {
+        const next = [...prev]
+        const [moved] = next.splice(fromIndex, 1)
+        next.splice(toIndex, 0, moved)
+        return next
+      })
+      resetStatus()
+    },
+    [resetStatus],
+  )
+
+  const handleChooseOutput = useCallback(async () => {
+    const selected = await save({
+      filters: [{ name: 'MP4 Video', extensions: ['mp4'] }],
+      defaultPath: 'concat_output.mp4',
+    })
+    if (typeof selected === 'string') {
+      setOutputPath(selected)
+      resetStatus()
+    }
+  }, [resetStatus])
+
+  const handleReveal = useCallback(async () => {
+    if (!outputPath) return
+    await invoke('reveal_in_folder', { path: outputPath }).catch((e) => {
+      logError(`Failed to reveal in folder: ${e}`)
+    })
+  }, [outputPath])
+
+  const handleConcat = useCallback(async () => {
+    const error = validateConcatFiles(files)
+    if (error) {
+      setValidationError(error)
+      return
+    }
+    if (!outputPath) return
+    setValidationError(null)
+    setProgress(null)
+    setFinalElapsedSec(null)
+    const startedAt = Date.now()
+    setStartedAtMs(startedAt)
+    setStatus('concatting')
+    tickRef.current = setInterval(() => setTick((n) => n + 1), 1000)
+    try {
+      await concatVideos({ inputPaths: files, outputPath })
+      setStatus('success')
+      setFinalElapsedSec((Date.now() - startedAt) / 1000)
+      setProgress((prev) => ({
+        progress: 100,
+        currentTimeSec: prev?.currentTimeSec ?? 0,
+        totalDurationSec: prev?.totalDurationSec ?? 0,
+      }))
+      toast.success(t('concat.success'), {
+        action: {
+          label: t('concat.openFolder'),
+          onClick: () => {
+            void handleReveal()
+          },
+        },
+      })
+    } catch (e) {
+      setStatus('error')
+      setProgress(null)
+      setFinalElapsedSec(null)
+      const raw = e instanceof Error ? e.message : String(e)
+      toast.error(t('concat.failed'), {
+        description: mapConcatError(raw, t),
+      })
+    } finally {
+      if (tickRef.current) {
+        clearInterval(tickRef.current)
+        tickRef.current = null
+      }
+      setStartedAtMs(null)
+    }
+  }, [files, outputPath, t, handleReveal])
+
+  const reset = useCallback(() => {
+    setFiles([])
+    setOutputPath(null)
+    setStatus('idle')
+    setValidationError(null)
+    setProgress(null)
+    setStartedAtMs(null)
+    setFinalElapsedSec(null)
+  }, [])
+
+  const elapsedSec =
+    startedAtMs !== null
+      ? Math.max(0, (Date.now() - startedAtMs) / 1000)
+      : (finalElapsedSec ?? 0)
+  const remainingSec =
+    progress && progress.progress > 1
+      ? (elapsedSec * (100 - progress.progress)) / progress.progress
+      : null
+
+  return {
+    files,
+    outputPath,
+    status,
+    validationError,
+    progress,
+    elapsedSec,
+    remainingSec,
+    handleAddFiles,
+    handleRemoveFile,
+    handleReorderFiles,
+    handleChooseOutput,
+    handleConcat,
+    handleReveal,
+    reset,
+  }
+}
+
+/** Maps backend `ERR::*` error codes to i18n translation keys. */
+const CONCAT_ERROR_MAP: Record<string, string> = {
+  'ERR::CONCAT_TOO_FEW_FILES': 'concat.error.too_few_files',
+  'ERR::CONCAT_FILE_NOT_FOUND': 'concat.error.file_not_found',
+  'ERR::CONCAT_UNSUPPORTED_FORMAT': 'concat.error.unsupported_format',
+  'ERR::CONCAT_UNSUPPORTED_OUTPUT_FORMAT':
+    'concat.error.unsupported_output_format',
+  'ERR::CONCAT_OUTPUT_COLLISION': 'concat.error.output_collision',
+  'ERR::CONCAT_FFMPEG_FAILED': 'concat.error.ffmpeg_failed',
+  'ERR::CONCAT_REENCODE_FAILED': 'concat.error.reencode_failed',
+}
+
+/**
+ * Translates a raw backend error string into a localized user-facing
+ * message. Matches known `ERR::*` codes against `CONCAT_ERROR_MAP`;
+ * falls back to the raw string if no mapping is found.
+ *
+ * @param raw - The raw error string from the backend.
+ * @param t - The i18next translation function.
+ * @returns A localized error message string.
+ */
+function mapConcatError(raw: string, t: TFunction): string {
+  for (const [code, key] of Object.entries(CONCAT_ERROR_MAP)) {
+    if (raw.includes(code)) return t(key)
+  }
+  return raw
+}

--- a/src/features/concat/index.ts
+++ b/src/features/concat/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Video concatenation feature — public API barrel.
+ *
+ * Re-exports the hook, types, and main UI component for external consumers.
+ */
+export {
+  useConcat,
+  type ConcatStatus,
+  type UseConcatResult,
+} from './hooks/useConcat'
+export type { ConcatOptions, ConcatProgress, ConcatResult } from './types'
+export { default as ConcatForm } from './ui/ConcatForm'

--- a/src/features/concat/lib/format.ts
+++ b/src/features/concat/lib/format.ts
@@ -1,0 +1,18 @@
+/**
+ * Formats a duration in seconds into a human-readable string.
+ *
+ * Durations under one hour are rendered as `M:SS`, while durations
+ * of an hour or more use `H:MM:SS`. Negative values are clamped to zero.
+ *
+ * @param seconds - The duration in seconds (may be fractional).
+ * @returns A formatted duration string.
+ */
+export function formatDuration(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  if (h > 0)
+    return `${h}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+  return `${m}:${String(sec).padStart(2, '0')}`
+}

--- a/src/features/concat/lib/validation.ts
+++ b/src/features/concat/lib/validation.ts
@@ -1,0 +1,24 @@
+/** Discriminated union of client-side validation error kinds. */
+export type ConcatValidationError =
+  | 'no_files'
+  | 'single_file'
+  | 'duplicate_paths'
+
+/**
+ * Validates the file list for concatenation on the client side.
+ *
+ * Checks that at least two files are provided and that no duplicate
+ * paths exist. Returns a {@link ConcatValidationError} on the first
+ * failing check, or `null` if all checks pass.
+ *
+ * @param files - Array of absolute file path strings.
+ * @returns A validation error code, or `null` if the input is valid.
+ */
+export function validateConcatFiles(
+  files: string[],
+): ConcatValidationError | null {
+  if (files.length === 0) return 'no_files'
+  if (files.length === 1) return 'single_file'
+  if (new Set(files).size !== files.length) return 'duplicate_paths'
+  return null
+}

--- a/src/features/concat/types.ts
+++ b/src/features/concat/types.ts
@@ -1,0 +1,23 @@
+/** Progress payload received from the backend via `concat://progress` events. */
+export type ConcatProgress = {
+  /** Concatenation progress as a percentage (0 to 100). */
+  progress: number
+  /** Current processing time in seconds. */
+  currentTimeSec: number
+  /** Total duration of all input files combined, in seconds. */
+  totalDurationSec: number
+}
+
+/** Options sent to the Tauri backend `concat_videos` command. */
+export type ConcatOptions = {
+  /** Absolute file paths of the MP4 videos to concatenate, in order. */
+  inputPaths: string[]
+  /** Absolute file path for the output MP4 file. */
+  outputPath: string
+}
+
+/** Result returned by the backend on successful concatenation. */
+export type ConcatResult = {
+  /** Absolute file path of the concatenated output video. */
+  outputPath: string
+}

--- a/src/features/concat/ui/ConcatForm.tsx
+++ b/src/features/concat/ui/ConcatForm.tsx
@@ -1,0 +1,160 @@
+import { useConcat } from '../hooks/useConcat'
+import { formatDuration } from '../lib/format'
+import { FileList } from './FileList'
+
+import { Button } from '@/shared/ui/button'
+import { Combine, FolderOpen, Loader2, Plus, RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Main form component for the video concatenation feature.
+ *
+ * Renders the file list (with drag-and-drop reordering), output path
+ * selector, progress bar, and action buttons. Delegates all state
+ * management to the {@link useConcat} hook.
+ */
+export function ConcatForm() {
+  const { t } = useTranslation()
+  const {
+    files,
+    outputPath,
+    status,
+    validationError,
+    progress,
+    elapsedSec,
+    remainingSec,
+    handleAddFiles,
+    handleRemoveFile,
+    handleReorderFiles,
+    handleChooseOutput,
+    handleConcat,
+    handleReveal,
+    reset,
+  } = useConcat()
+
+  const isConcatting = status === 'concatting'
+  const isSuccess = status === 'success'
+  const canConcat =
+    files.length >= 2 && Boolean(outputPath) && !isConcatting && !isSuccess
+  const validationErrorKey = validationError
+    ? `concat.error.${validationError}`
+    : null
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section className="overflow-hidden rounded-lg border p-3">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium">{t('concat.fileList')}</h2>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAddFiles}
+            disabled={isConcatting}
+          >
+            <Plus className="size-4" />
+            {t('concat.addFiles')}
+          </Button>
+        </div>
+        {files.length > 0 ? (
+          <>
+            <FileList
+              files={files}
+              isProcessing={isConcatting}
+              onRemove={handleRemoveFile}
+              onReorder={handleReorderFiles}
+            />
+            <p className="text-muted-foreground mt-2 text-xs">
+              {t('concat.dragToReorder')}
+            </p>
+          </>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            {t('concat.noFilesSelected')}
+          </p>
+        )}
+        {validationErrorKey && (
+          <p className="text-destructive mt-2 text-sm">
+            {t(validationErrorKey)}
+          </p>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">{t('concat.outputFile')}</h2>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleChooseOutput}
+            disabled={isConcatting}
+          >
+            <FolderOpen className="size-4" />
+            {t('concat.chooseOutput')}
+          </Button>
+          {outputPath ? (
+            <p
+              className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+              title={outputPath}
+            >
+              {outputPath}
+            </p>
+          ) : (
+            <span className="text-muted-foreground text-sm">
+              {t('concat.noOutputSelected')}
+            </span>
+          )}
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3">
+        {(isConcatting || isSuccess) && progress && (
+          <>
+            <div className="bg-primary/20 relative h-2 flex-1 overflow-hidden rounded-full">
+              <div
+                className="bg-primary h-full transition-[width] duration-1000 ease-linear"
+                style={{ width: `${progress.progress}%` }}
+              />
+            </div>
+            <span className="text-sm font-medium whitespace-nowrap tabular-nums">
+              {Math.round(progress.progress)}%
+            </span>
+            <span className="text-muted-foreground text-sm whitespace-nowrap tabular-nums">
+              {t('concat.elapsed')} {formatDuration(elapsedSec)}
+              {remainingSec !== null && (
+                <>
+                  {' / '}
+                  {t('concat.remaining')} {formatDuration(remainingSec)}
+                </>
+              )}
+            </span>
+          </>
+        )}
+        <div className="ml-auto flex gap-3">
+          <Button
+            variant="outline"
+            onClick={handleReveal}
+            disabled={!isSuccess || !outputPath}
+            className={isSuccess && outputPath ? '' : 'invisible'}
+          >
+            <FolderOpen className="size-4" />
+            {t('concat.openFolder')}
+          </Button>
+          <Button variant="ghost" onClick={reset} disabled={isConcatting}>
+            <RotateCcw className="size-4" />
+            {t('concat.clear')}
+          </Button>
+          <Button onClick={handleConcat} disabled={!canConcat}>
+            {isConcatting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Combine className="size-4" />
+            )}
+            {isConcatting ? t('concat.concatting') : t('concat.concat')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ConcatForm

--- a/src/features/concat/ui/FileList.tsx
+++ b/src/features/concat/ui/FileList.tsx
@@ -1,0 +1,84 @@
+import { SortableItem } from './SortableItem'
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+
+type FileListProps = {
+  /** Absolute file paths to display in the list. */
+  files: string[]
+  /** Whether a concatenation operation is in progress (disables interaction). */
+  isProcessing: boolean
+  /** Callback invoked with the index of the file to remove. */
+  onRemove: (index: number) => void
+  /** Callback invoked with `(fromIndex, toIndex)` when a file is reordered via drag-and-drop. */
+  onReorder: (fromIndex: number, toIndex: number) => void
+}
+
+/**
+ * Drag-and-drop sortable list of video files.
+ *
+ * Wraps `@dnd-kit` to provide vertical-axis-only reordering.
+ * Each item is rendered as a {@link SortableItem}.
+ */
+export function FileList({
+  files,
+  isProcessing,
+  onRemove,
+  onReorder,
+}: FileListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  /** Resolves the source and target indices from the drag event and calls `onReorder`. */
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const fromIndex = files.findIndex((f) => f === active.id)
+      const toIndex = files.findIndex((f) => f === over.id)
+      if (fromIndex !== -1 && toIndex !== -1) {
+        onReorder(fromIndex, toIndex)
+      }
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      modifiers={[restrictToVerticalAxis]}
+    >
+      <SortableContext items={files} strategy={verticalListSortingStrategy}>
+        <div className="flex flex-col gap-1">
+          {files.map((path, index) => (
+            <SortableItem
+              key={path}
+              id={path}
+              path={path}
+              index={index}
+              onRemove={() => onRemove(index)}
+              disabled={isProcessing}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  )
+}

--- a/src/features/concat/ui/SortableItem.tsx
+++ b/src/features/concat/ui/SortableItem.tsx
@@ -1,0 +1,88 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+type SortableItemProps = {
+  /** Unique identifier used by `@dnd-kit` for sorting (typically the file path). */
+  id: string
+  /** Absolute file path displayed in the item. */
+  path: string
+  /** 0-based position index shown as a numbered label. */
+  index: number
+  /** Callback invoked when the remove button is clicked. */
+  onRemove: () => void
+  /** Whether drag-and-drop and remove interactions are disabled. */
+  disabled: boolean
+}
+
+/**
+ * A single draggable row in the file list.
+ *
+ * Renders a grip handle, position number, truncated file name, and a
+ * remove button. Uses `useSortable` from `@dnd-kit` to manage drag state.
+ */
+export function SortableItem({
+  id,
+  path,
+  index,
+  onRemove,
+  disabled,
+}: SortableItemProps) {
+  const { t } = useTranslation()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  const filename = path.split(/[\\/]/).pop() ?? path
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="bg-background flex items-center gap-2 rounded-md border px-2 py-1.5"
+    >
+      <button
+        type="button"
+        className="text-muted-foreground cursor-grab touch-none active:cursor-grabbing"
+        disabled={disabled}
+        aria-label={t('concat.dragToReorderAria', {
+          index: index + 1,
+        })}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <span className="text-muted-foreground w-5 shrink-0 text-xs tabular-nums">
+        {index + 1}.
+      </span>
+      <p
+        className="text-foreground min-w-0 flex-1 truncate text-sm"
+        title={path}
+      >
+        {filename}
+      </p>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        className="text-muted-foreground hover:text-foreground shrink-0"
+        aria-label={t('concat.removeFileAria', { filename })}
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -10,6 +10,7 @@
     "watchHistory": "Watch History",
     "favorite": "Favorites",
     "trim": "Trim",
+    "concat": "Concat",
     "init": "Init",
     "error": "Error",
     "favoriteLoginRequired": "Available after login",
@@ -24,6 +25,7 @@
       "watchHistory": "Navigate to watch history",
       "favorite": "Navigate to favorites page",
       "trim": "Navigate to trim page",
+      "concat": "Navigate to concat page",
       "toggleSidebar": "Toggle Sidebar",
       "openSidebar": "Open sidebar",
       "closeSidebar": "Close sidebar"
@@ -73,6 +75,40 @@
       "fastBadge": "Recommended",
       "accurate": "Accurate (Re-encode)",
       "accurateHint": "Slower due to re-encoding"
+    }
+  },
+  "concat": {
+    "title": "Concatenate Videos",
+    "description": "Combine multiple video files into one.",
+    "addFiles": "Add files",
+    "noFilesSelected": "No files selected",
+    "fileList": "File list",
+    "dragToReorder": "Drag to reorder",
+    "outputFile": "Output file",
+    "chooseOutput": "Choose output",
+    "noOutputSelected": "No output path selected",
+    "concat": "Concatenate",
+    "concatting": "Concatenating...",
+    "clear": "Clear",
+    "success": "Concatenation completed",
+    "failed": "Concatenation failed",
+    "fallbackNotice": "Stream copy failed. Retrying with re-encode...",
+    "dragToReorderAria": "Drag to reorder item {{index}}",
+    "removeFileAria": "Remove {{filename}}",
+    "openFolder": "Open folder",
+    "elapsed": "Elapsed",
+    "remaining": "Remaining",
+    "error": {
+      "no_files": "No files selected",
+      "single_file": "At least two files are required",
+      "duplicate_paths": "Duplicate file paths detected",
+      "too_few_files": "At least two files are required",
+      "file_not_found": "File not found",
+      "unsupported_format": "Unsupported file format (MP4 only)",
+      "unsupported_output_format": "Output file must be MP4 format",
+      "output_collision": "Output path conflicts with an input file",
+      "ffmpeg_failed": "ffmpeg execution failed",
+      "reencode_failed": "Re-encoding failed"
     }
   },
   "actions": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -10,6 +10,7 @@
     "watchHistory": "Historial de visualización",
     "favorite": "Favoritos",
     "trim": "Recortar",
+    "concat": "Concatenar",
     "init": "Inicialización",
     "error": "Error",
     "favoriteLoginRequired": "Disponible tras iniciar sesión",
@@ -24,6 +25,7 @@
       "watchHistory": "Ir al historial de visualización",
       "favorite": "Ir a la página de favoritos",
       "trim": "Ir a la página de recorte",
+      "concat": "Ir a la página de concatenación",
       "toggleSidebar": "Alternar barra lateral",
       "openSidebar": "Abrir barra lateral",
       "closeSidebar": "Cerrar barra lateral"
@@ -73,6 +75,40 @@
       "fastBadge": "Recomendado",
       "accurate": "Preciso (Recodificar)",
       "accurateHint": "Más lento por recodificación"
+    }
+  },
+  "concat": {
+    "title": "Concatenar vídeos",
+    "description": "Combina varios archivos de vídeo en uno.",
+    "addFiles": "Añadir archivos",
+    "noFilesSelected": "Ningún archivo seleccionado",
+    "fileList": "Lista de archivos",
+    "dragToReorder": "Arrastra para reordenar",
+    "outputFile": "Archivo de salida",
+    "chooseOutput": "Elegir destino",
+    "noOutputSelected": "No se ha seleccionado destino",
+    "concat": "Concatenar",
+    "concatting": "Concatenando...",
+    "clear": "Limpiar",
+    "success": "Concatenación completada",
+    "failed": "Error al concatenar",
+    "fallbackNotice": "La copia de flujo falló. Reintentando con recodificación...",
+    "dragToReorderAria": "Arrastra para reordenar el elemento {{index}}",
+    "removeFileAria": "Eliminar {{filename}}",
+    "openFolder": "Abrir carpeta",
+    "elapsed": "Transcurrido",
+    "remaining": "Restante",
+    "error": {
+      "no_files": "Ningún archivo seleccionado",
+      "single_file": "Se necesitan al menos dos archivos",
+      "duplicate_paths": "Se detectaron rutas de archivo duplicadas",
+      "too_few_files": "Se necesitan al menos dos archivos",
+      "file_not_found": "Archivo no encontrado",
+      "unsupported_format": "Formato de archivo no compatible (solo MP4)",
+      "unsupported_output_format": "El archivo de salida debe ser MP4",
+      "output_collision": "La ruta de salida coincide con un archivo de entrada",
+      "ffmpeg_failed": "Error al ejecutar ffmpeg",
+      "reencode_failed": "Error al recodificar"
     }
   },
   "actions": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -10,6 +10,7 @@
     "watchHistory": "Historique de visionnage",
     "favorite": "Favoris",
     "trim": "Découper",
+    "concat": "Concaténer",
     "init": "Initialisation",
     "error": "Erreur",
     "favoriteLoginRequired": "Disponible après connexion",
@@ -24,6 +25,7 @@
       "watchHistory": "Accéder à l'historique de visionnage",
       "favorite": "Accéder aux favoris",
       "trim": "Accéder à la page de découpage",
+      "concat": "Accéder à la page de concaténation",
       "toggleSidebar": "Basculer la barre latérale",
       "openSidebar": "Ouvrir la barre latérale",
       "closeSidebar": "Fermer la barre latérale"
@@ -73,6 +75,40 @@
       "fastBadge": "Recommandé",
       "accurate": "Précis (Réencodage)",
       "accurateHint": "Plus lent en raison du réencodage"
+    }
+  },
+  "concat": {
+    "title": "Concaténer les vidéos",
+    "description": "Combine plusieurs fichiers vidéo en un seul.",
+    "addFiles": "Ajouter des fichiers",
+    "noFilesSelected": "Aucun fichier sélectionné",
+    "fileList": "Liste des fichiers",
+    "dragToReorder": "Glisser pour réorganiser",
+    "outputFile": "Fichier de sortie",
+    "chooseOutput": "Choisir la destination",
+    "noOutputSelected": "Aucune destination sélectionnée",
+    "concat": "Concaténer",
+    "concatting": "Concaténation...",
+    "clear": "Effacer",
+    "success": "Concaténation terminée",
+    "failed": "Échec de la concaténation",
+    "fallbackNotice": "La copie de flux a échoué. Nouvelle tentative avec réencodage...",
+    "dragToReorderAria": "Glisser pour réordonner l'élément {{index}}",
+    "removeFileAria": "Supprimer {{filename}}",
+    "openFolder": "Ouvrir le dossier",
+    "elapsed": "Écoulé",
+    "remaining": "Restant",
+    "error": {
+      "no_files": "Aucun fichier sélectionné",
+      "single_file": "Au moins deux fichiers sont requis",
+      "duplicate_paths": "Des chemins de fichier en double ont été détectés",
+      "too_few_files": "Au moins deux fichiers sont requis",
+      "file_not_found": "Fichier introuvable",
+      "unsupported_format": "Format de fichier non pris en charge (MP4 uniquement)",
+      "unsupported_output_format": "Le fichier de sortie doit être au format MP4",
+      "output_collision": "Le chemin de sortie est en conflit avec un fichier d'entrée",
+      "ffmpeg_failed": "Échec de l'exécution de ffmpeg",
+      "reencode_failed": "Échec du réencodage"
     }
   },
   "actions": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -10,6 +10,7 @@
     "watchHistory": "視聴履歴",
     "favorite": "お気に入り",
     "trim": "トリム",
+    "concat": "結合",
     "init": "初期化",
     "error": "エラー",
     "favoriteLoginRequired": "ログインすると利用できます",
@@ -24,6 +25,7 @@
       "watchHistory": "視聴履歴に移動",
       "favorite": "お気に入り画面へ移動",
       "trim": "トリム画面へ移動",
+      "concat": "結合画面へ移動",
       "toggleSidebar": "サイドバーを切り替え",
       "openSidebar": "サイドバーを開く",
       "closeSidebar": "サイドバーを閉じる"
@@ -73,6 +75,40 @@
       "fastBadge": "推奨",
       "accurate": "高精度（再エンコード）",
       "accurateHint": "再エンコードで時間がかかります"
+    }
+  },
+  "concat": {
+    "title": "動画結合",
+    "description": "複数の動画ファイルを1つに結合します。",
+    "addFiles": "ファイルを追加",
+    "noFilesSelected": "ファイルが選択されていません",
+    "fileList": "ファイル一覧",
+    "dragToReorder": "ドラッグで並べ替え",
+    "outputFile": "出力ファイル",
+    "chooseOutput": "保存先を選択",
+    "noOutputSelected": "保存先が選択されていません",
+    "concat": "結合",
+    "concatting": "結合中...",
+    "clear": "クリア",
+    "success": "結合が完了しました",
+    "failed": "結合に失敗しました",
+    "fallbackNotice": "ストリームコピーに失敗しました。再エンコードでリトライしています...",
+    "dragToReorderAria": "{{index}}番目の項目をドラッグして並べ替え",
+    "removeFileAria": "{{filename}}を削除",
+    "openFolder": "フォルダを開く",
+    "elapsed": "経過",
+    "remaining": "残り",
+    "error": {
+      "no_files": "ファイルが選択されていません",
+      "single_file": "2つ以上のファイルが必要です",
+      "duplicate_paths": "重複したファイルパスが検出されました",
+      "too_few_files": "2つ以上のファイルが必要です",
+      "file_not_found": "ファイルが見つかりません",
+      "unsupported_format": "対応していないファイル形式です（MP4のみ対応）",
+      "unsupported_output_format": "出力ファイルはMP4形式にしてください",
+      "output_collision": "出力パスが入力ファイルと重複しています",
+      "ffmpeg_failed": "ffmpegの実行に失敗しました",
+      "reencode_failed": "再エンコードに失敗しました"
     }
   },
   "actions": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -10,6 +10,7 @@
     "watchHistory": "시청 기록",
     "favorite": "즐겨찾기",
     "trim": "트림",
+    "concat": "병합",
     "init": "초기화",
     "error": "오류",
     "favoriteLoginRequired": "로그인 후 이용할 수 있습니다",
@@ -24,6 +25,7 @@
       "watchHistory": "시청 기록으로 이동",
       "favorite": "즐겨찾기 페이지로 이동",
       "trim": "트림 페이지로 이동",
+      "concat": "병합 페이지로 이동",
       "toggleSidebar": "사이드바 토글",
       "openSidebar": "사이드바 열기",
       "closeSidebar": "사이드바 닫기"
@@ -73,6 +75,40 @@
       "fastBadge": "권장",
       "accurate": "정밀 (재인코딩)",
       "accurateHint": "재인코딩으로 시간이 걸립니다"
+    }
+  },
+  "concat": {
+    "title": "비디오 병합",
+    "description": "여러 비디오 파일을 하나로 병합합니다.",
+    "addFiles": "파일 추가",
+    "noFilesSelected": "선택된 파일이 없습니다",
+    "fileList": "파일 목록",
+    "dragToReorder": "드래그하여 순서 변경",
+    "outputFile": "출력 파일",
+    "chooseOutput": "저장 위치 선택",
+    "noOutputSelected": "저장 경로가 선택되지 않았습니다",
+    "concat": "병합",
+    "concatting": "병합 중...",
+    "clear": "지우기",
+    "success": "병합이 완료되었습니다",
+    "failed": "병합에 실패했습니다",
+    "fallbackNotice": "스트림 복사에 실패했습니다. 재인코딩으로 재시도 중...",
+    "dragToReorderAria": "{{index}}번 항목을 드래그하여 순서 변경",
+    "removeFileAria": "{{filename}} 삭제",
+    "openFolder": "폴더 열기",
+    "elapsed": "경과",
+    "remaining": "남음",
+    "error": {
+      "no_files": "선택된 파일이 없습니다",
+      "single_file": "최소 두 개의 파일이 필요합니다",
+      "duplicate_paths": "중복된 파일 경로가 감지되었습니다",
+      "too_few_files": "최소 두 개의 파일이 필요합니다",
+      "file_not_found": "파일을 찾을 수 없습니다",
+      "unsupported_format": "지원하지 않는 파일 형식입니다 (MP4만 지원)",
+      "unsupported_output_format": "출력 파일은 MP4 형식이어야 합니다",
+      "output_collision": "출력 경로가 입력 파일과 충돌합니다",
+      "ffmpeg_failed": "ffmpeg 실행에 실패했습니다",
+      "reencode_failed": "재인코딩에 실패했습니다"
     }
   },
   "actions": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -10,6 +10,7 @@
     "watchHistory": "观看历史",
     "favorite": "收藏",
     "trim": "裁剪",
+    "concat": "合并",
     "init": "初始化",
     "error": "错误",
     "favoriteLoginRequired": "登录后可用",
@@ -24,6 +25,7 @@
       "watchHistory": "转到观看历史",
       "favorite": "前往收藏页面",
       "trim": "前往裁剪页面",
+      "concat": "前往合并页面",
       "toggleSidebar": "切换侧边栏",
       "openSidebar": "打开侧边栏",
       "closeSidebar": "关闭侧边栏"
@@ -73,6 +75,40 @@
       "fastBadge": "推荐",
       "accurate": "精确（重编码）",
       "accurateHint": "因重新编码耗时较长"
+    }
+  },
+  "concat": {
+    "title": "合并视频",
+    "description": "将多个视频文件合并为一个。",
+    "addFiles": "添加文件",
+    "noFilesSelected": "未选择文件",
+    "fileList": "文件列表",
+    "dragToReorder": "拖拽以排序",
+    "outputFile": "输出文件",
+    "chooseOutput": "选择保存位置",
+    "noOutputSelected": "未选择保存路径",
+    "concat": "合并",
+    "concatting": "合并中...",
+    "clear": "清除",
+    "success": "合并完成",
+    "failed": "合并失败",
+    "fallbackNotice": "流复制失败，正在使用重新编码重试...",
+    "dragToReorderAria": "拖拽以重新排列第{{index}}项",
+    "removeFileAria": "删除{{filename}}",
+    "openFolder": "打开文件夹",
+    "elapsed": "已用",
+    "remaining": "剩余",
+    "error": {
+      "no_files": "未选择文件",
+      "single_file": "至少需要两个文件",
+      "duplicate_paths": "检测到重复的文件路径",
+      "too_few_files": "至少需要两个文件",
+      "file_not_found": "文件未找到",
+      "unsupported_format": "不支持的文件格式（仅支持MP4）",
+      "unsupported_output_format": "输出文件必须为MP4格式",
+      "output_collision": "输出路径与输入文件冲突",
+      "ffmpeg_failed": "ffmpeg执行失败",
+      "reencode_failed": "重新编码失败"
     }
   },
   "actions": {

--- a/src/pages/concat/index.tsx
+++ b/src/pages/concat/index.tsx
@@ -1,0 +1,33 @@
+import { ConcatForm } from '@/features/concat'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Page-level component for the video concatenation feature.
+ *
+ * Sets the document title and renders the header (title + description)
+ * along with the {@link ConcatForm} inside a scrollable content area.
+ */
+export function ConcatContent() {
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    document.title = `${t('concat.title')} - ${t('app.title')}`
+  }, [t])
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-border shrink-0 border-b p-3">
+        <h1 className="text-xl font-semibold">{t('concat.title')}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          {t('concat.description')}
+        </p>
+      </div>
+      <div className="min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto px-4 pt-2 pb-4 sm:px-6 sm:pt-3 sm:pb-6">
+        <ConcatForm />
+      </div>
+    </div>
+  )
+}
+
+export default ConcatContent

--- a/src/shared/layout/PersistentPageLayout.tsx
+++ b/src/shared/layout/PersistentPageLayout.tsx
@@ -4,6 +4,7 @@ import type { FC, ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router'
 
+import { ConcatContent } from '@/pages/concat'
 import { FavoriteContent } from '@/pages/favorite'
 import { HistoryContent } from '@/pages/history'
 import { HomeContent } from '@/pages/home'
@@ -25,6 +26,11 @@ const PAGES: readonly PageConfig[] = [
   {
     path: '/trim',
     Component: TrimContent,
+    maxWidth: true,
+  },
+  {
+    path: '/concat',
+    Component: ConcatContent,
     maxWidth: true,
   },
 ] as const

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -18,7 +18,7 @@ import {
 import { cn } from '@/shared/lib/utils'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import type { LucideIcon } from 'lucide-react'
-import { Eye, Home, Combine, Scissors, Star } from 'lucide-react'
+import { Combine, Eye, Home, Scissors, Star } from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -18,7 +18,7 @@ import {
 import { cn } from '@/shared/lib/utils'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import type { LucideIcon } from 'lucide-react'
-import { Eye, Home, Scissors, Star } from 'lucide-react'
+import { Eye, Home, Combine, Scissors, Star } from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
@@ -51,6 +51,7 @@ type MenuGroup = {
  *   - Watch History (/watch-history) - requires login
  * - Tool category:
  *   - Trim (/trim) - Trim local MP4 files by start/end time
+ *   - Concat (/concat) - Concatenate multiple MP4 files into one
  *
  * Note: Download history (/history) is provided separately in SidebarFooter.
  *
@@ -110,6 +111,13 @@ export function NavigationSidebarHeader({
           icon: Scissors,
           label: t('nav.trim'),
           ariaLabel: t('nav.aria.trim'),
+          requiresAuth: false,
+        },
+        {
+          path: '/concat',
+          icon: Combine,
+          label: t('nav.concat'),
+          ariaLabel: t('nav.aria.concat'),
           requiresAuth: false,
         },
       ],


### PR DESCRIPTION
## Summary

- Add `/concat` page for concatenating multiple MP4 files into one using ffmpeg's concat demuxer
- Support drag-and-drop reordering via @dnd-kit with vertical axis restriction
- First attempts stream copy (fast, lossless), then automatically falls back to re-encode with user notification via toast
- Extract shared ffmpeg utilities (progress parsing, duration probing) from trim handler for reuse

Closes #390

## Test plan

- [ ] Verify `/concat` page appears in sidebar under Tool category
- [ ] Add multiple MP4 files and verify list display
- [ ] Drag-and-drop reorder files, confirm order changes
- [ ] Choose output path via save dialog
- [ ] Run concat with compatible files (same codec) - verify stream copy succeeds
- [ ] Run concat with incompatible files (different codecs) - verify re-encode fallback with toast notification
- [ ] Verify progress bar updates during processing
- [ ] Verify elapsed/remaining time display
- [ ] Verify output file opens from success toast
- [ ] Verify error handling for invalid inputs (too few files, non-MP4)
- [ ] Verify aria-labels are translated across all 6 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)