### PR TITLE
fix: resolve network errors and UI lock during playlist downloads

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1663,22 +1663,24 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
 
 /// Retries download operations up to 3 times with linear backoff.
 ///
-/// Implements retry logic for transient network failures.
-/// Only retries when error contains specific keywords, otherwise fails immediately.
+/// Implements retry logic for transient network failures originating from
+/// `download_url`. Errors are classified by prefix:
 ///
-/// # Retry Conditions
-///
-/// Only retries on errors containing these keywords:
-/// - "segment" - Segment download error
-/// - "request error" - Request error
-/// - "timeout" - Timeout
-/// - "connect" - Connection error
+/// - `ERR::` prefix: Business logic errors (e.g. `ERR::DISK_FULL`,
+///   `ERR::CANCELLED`, `ERR::FILE_EXISTS`) are passed through immediately
+///   without retry.
+/// - All other errors: Treated as transient network failures and retried.
+///   `download_url` only produces non-`ERR::` errors for network-related
+///   causes (request failures, connection resets, timeouts, segment issues),
+///   so retrying them unconditionally is safer than keyword matching which
+///   previously missed common cases like `connection reset by peer`, DNS
+///   failures, and TLS errors.
 ///
 /// # Retry Settings
 ///
 /// - Maximum attempts: 3
 /// - Backoff strategy: Linear (500ms, 1000ms, 1500ms)
-/// - Errors with `ERR::` prefix are passed through (no retry)
+/// - Final failure is wrapped as `ERR::NETWORK::{original_message}`
 ///
 /// # Arguments
 ///
@@ -1691,33 +1693,37 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
 /// # Errors
 ///
 /// Returns errors in the following cases:
-/// - All retry attempts failed
-/// - Error is not retryable (keyword mismatch)
-/// - Error contains `ERR::` prefix
+/// - All retry attempts failed (wrapped as `ERR::NETWORK::*`)
+/// - Error contains `ERR::` prefix (passed through unchanged)
 async fn retry_download<F, Fut>(mut f: F) -> Result<(), String>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<(), anyhow::Error>>,
 {
     const MAX_ATTEMPTS: u8 = 3;
-    const RETRYABLE_KEYWORDS: &[&str] = &["segment", "request error", "timeout", "connect"];
+    const BACKOFF_BASE_MS: u64 = 500;
 
     for attempt in 1..=MAX_ATTEMPTS {
         match f().await {
             Ok(_) => return Ok(()),
             Err(e) => {
                 let msg = e.to_string();
-                let is_retryable = RETRYABLE_KEYWORDS.iter().any(|&kw| msg.contains(kw));
 
-                if attempt >= MAX_ATTEMPTS || !is_retryable {
-                    return Err(if msg.contains("ERR::") {
-                        msg
-                    } else {
-                        format!("ERR::NETWORK::{msg}")
-                    });
+                // ERR:: prefix = business logic error, never retry
+                if msg.contains("ERR::") {
+                    log::warn!("[BE] retry_download: non-retryable: {msg}");
+                    return Err(msg);
                 }
 
-                tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
+                // Non-ERR:: errors from download_url are network-related.
+                // Retry unconditionally; final attempt wraps as ERR::NETWORK.
+                if attempt >= MAX_ATTEMPTS {
+                    log::error!("[BE] retry_download: exhausted {MAX_ATTEMPTS} attempts: {msg}");
+                    return Err(format!("ERR::NETWORK::{msg}"));
+                }
+
+                log::warn!("[BE] retry_download: attempt {attempt}/{MAX_ATTEMPTS} failed: {msg}");
+                tokio::time::sleep(Duration::from_millis(BACKOFF_BASE_MS * attempt as u64)).await;
             }
         }
     }

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -58,7 +58,15 @@ fn map_io_error(e: std::io::Error) -> anyhow::Error {
     }
 }
 
-/// Adds cookie header to a request builder if provided.
+/// Adds a Cookie header to a request builder when credentials are supplied.
+///
+/// This is a no-op when `cookie` is `None` or empty. Returns the modified
+/// `RequestBuilder` for chaining.
+///
+/// # Arguments
+///
+/// * `req` - Request builder to attach the header to
+/// * `cookie` - Optional cookie header value
 fn apply_cookie(mut req: RequestBuilder, cookie: &Option<String>) -> RequestBuilder {
     if let Some(c) = cookie {
         req = req.header(header::COOKIE, c);
@@ -66,8 +74,22 @@ fn apply_cookie(mut req: RequestBuilder, cookie: &Option<String>) -> RequestBuil
     req
 }
 
-/// Checks if cancellation has been requested.
-/// Returns an error if the token exists and is cancelled.
+/// Checks whether a download cancellation has been requested.
+///
+/// Returns `Err` with `ERR::CANCELLED` when a cancellation token exists and
+/// has already been triggered. Used at strategic checkpoints (file
+/// existence, before each chunk write, before retry attempts) to short
+/// circuit in-flight downloads.
+///
+/// # Arguments
+///
+/// * `token` - Optional cancellation token registered via
+///   `DOWNLOAD_CANCEL_REGISTRY`
+///
+/// # Returns
+///
+/// - `Ok(())` if no token is registered or the token is not cancelled.
+/// - `Err` containing `ERR::CANCELLED` when cancellation has been requested.
 fn check_cancelled(token: &Option<CancellationToken>) -> Result<()> {
     if let Some(t) = token {
         if t.is_cancelled() {
@@ -77,11 +99,18 @@ fn check_cancelled(token: &Option<CancellationToken>) -> Result<()> {
     Ok(())
 }
 
-/// Speed check result.
+/// Outcome of a time-based download speed check.
+///
+/// Produced by [`check_download_speed`] to signal whether the current
+/// throughput should continue, trigger a CDN rotation, or wait for more
+/// data before evaluating.
 enum SpeedCheckResult {
-    Acceptable,       // Speed is acceptable, continue download
-    Slow,             // Speed is too slow, should reconnect
-    InsufficientData, // Not enough data or time for speed check
+    /// Throughput is at or above [`MIN_SPEED_THRESHOLD`]; continue as-is.
+    Acceptable,
+    /// Throughput is below threshold and CDN rotations remain; reconnect.
+    Slow,
+    /// Not enough elapsed time or bytes received yet for a reliable check.
+    InsufficientData,
 }
 
 /// Checks if download speed meets minimum threshold.
@@ -135,10 +164,60 @@ fn check_download_speed(
     SpeedCheckResult::Acceptable
 }
 
-/// Downloads a file from URL with CDN rotation support.
+/// Downloads a file from a URL with automatic CDN rotation and retry.
+///
+/// Orchestrates the full segmented download pipeline used for audio and
+/// video streams:
+///
+/// 1. Resolves and registers a cancellation token via
+///    `DOWNLOAD_CANCEL_REGISTRY`.
+/// 2. Handles existing file (override or error) and probes total size
+///    using [`fetch_total_size`].
+/// 3. Falls back to [`single_stream_fallback`] when the server does not
+///    advertise `Accept-Ranges`/Content-Length.
+/// 4. Splits the payload into 8 MB segments (concurrency pinned to 1
+///    because Bilibili's CDN is unstable with parallel range requests).
+/// 5. Pre-allocates the output file and emits progress updates via
+///    [`Emits`] to the frontend.
+/// 6. Streams each segment through [`download_segment_with_speed_check`],
+///    transparently rotating CDN URLs when throughput drops below
+///    [`MIN_SPEED_THRESHOLD`] and rolling back any progress that was
+///    already reported for a segment being retried.
+/// 7. Verifies the final byte count against the advertised total and
+///    emits either `complete` or `stop` to the frontend.
 ///
 /// When download speed drops below threshold, automatically switches to
 /// backup CDN URLs if provided. Supports cancellation via global registry.
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle used for event emission
+/// * `url` - Primary CDN URL to download from
+/// * `backup_urls` - Optional list of backup CDN URLs for rotation
+/// * `output_path` - Destination file path
+/// * `cookie` - Optional Cookie header value for authenticated requests
+/// * `is_override` - When `true`, overwrites an existing file; otherwise
+///   returns `ERR::FILE_EXISTS`
+/// * `download_id` - Optional unique ID used to register a cancellation
+///   token and scope emitted events
+/// * `override_stage` - Optional stage label (e.g., `"audio"`, `"video"`)
+///   forced onto the emitter regardless of filename
+/// * `emit_complete` - When `true`, emits the `complete` event on success;
+///   when `false`, calls `Emits::stop` to terminate the progress task
+///   without notifying the frontend (used for intermediate temp files
+///   that are merged later)
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful download and verification.
+///
+/// # Errors
+///
+/// Returns an anyhow error in the following cases:
+/// - `ERR::FILE_EXISTS` - File already exists and `is_override` is `false`
+/// - `ERR::CANCELLED` - Download was cancelled via the registry
+/// - Segment or final size mismatch after exhausting retries
+/// - Disk I/O failure (mapped to `ERR::DISK_FULL` for ENOSPC)
 #[allow(clippy::too_many_arguments)]
 pub async fn download_url(
     app: &AppHandle,
@@ -261,6 +340,8 @@ pub async fn download_url(
             const MAX_SEG_RETRIES: u8 = 3;
             let size = e - s + 1;
             let mut cdn_rotation_count: u8 = 0;
+            let max_cdn_rotations: u8 =
+                (cdn_urls_c.len().min(255) as u8).saturating_mul(MAX_CDN_LOOPS);
             // Track bytes this segment has added to dl_total_c
             // for rollback on retry
             let seg_bytes_added = Arc::new(AtomicU64::new(0));
@@ -303,6 +384,14 @@ pub async fn download_url(
                                 && size == resp.content_length().unwrap_or(size));
 
                         if !is_valid_response {
+                            log::warn!(
+                                "[BE] download_url: segment {} invalid status {} (attempt {}/{}, cdn_idx={})",
+                                idx,
+                                resp.status(),
+                                attempt + 1,
+                                MAX_SEG_RETRIES,
+                                cdn_idx
+                            );
                             if attempt < MAX_SEG_RETRIES {
                                 backoff_sleep(attempt).await;
                                 continue;
@@ -347,23 +436,59 @@ pub async fn download_url(
                                     cdn_idx,
                                     next_cdn_idx,
                                     cdn_rotation_count + 1,
-                                    (cdn_urls_c.len().min(255) as u8).saturating_mul(MAX_CDN_LOOPS)
+                                    max_cdn_rotations
                                 );
                                 cdn_rotation_count += 1;
                                 backoff_sleep(cdn_rotation_count).await;
                                 continue;
                             }
                             Err(_) => {
+                                log::warn!(
+                                    "[BE] download_url: segment {} download failed (attempt {}/{}, cdn_idx={})",
+                                    idx,
+                                    attempt + 1,
+                                    MAX_SEG_RETRIES,
+                                    cdn_idx
+                                );
                                 return Err(anyhow::anyhow!("segment {} download failed", idx))
                             }
                         };
 
                         // Verify size
                         if received != size {
-                            if attempt < MAX_SEG_RETRIES {
-                                backoff_sleep(attempt).await;
+                            log::warn!(
+                                "[BE] download_url: segment {} size mismatch: expected {}, got {} (attempt {}/{}, cdn_idx={})",
+                                idx,
+                                size,
+                                received,
+                                attempt + 1,
+                                MAX_SEG_RETRIES,
+                                cdn_idx
+                            );
+                            // Size mismatch typically indicates CDN edge cache
+                            // corruption or rate-limit cutoff. Rotate to a
+                            // different CDN immediately instead of retrying
+                            // the same node, which tends to reproduce the
+                            // same truncated response.
+                            if cdn_rotation_count < max_cdn_rotations {
+                                let next_cdn_idx =
+                                    (cdn_rotation_count as usize + 1) % cdn_urls_c.len();
+                                log::info!(
+                                    "[BE] download_url: segment {} rotating CDN #{} → #{} due to size mismatch (rotation {}/{})",
+                                    idx,
+                                    cdn_idx,
+                                    next_cdn_idx,
+                                    cdn_rotation_count + 1,
+                                    max_cdn_rotations
+                                );
+                                cdn_rotation_count += 1;
+                                backoff_sleep(cdn_rotation_count).await;
                                 continue;
                             }
+                            log::warn!(
+                                "[BE] download_url: segment {} CDN rotation exhausted, giving up",
+                                idx
+                            );
                             return Err(anyhow::anyhow!("segment {} size mismatch", idx));
                         }
 
@@ -373,6 +498,13 @@ pub async fn download_url(
                         return Ok(());
                     }
                     Err(e) => {
+                        log::warn!(
+                            "[BE] download_url: segment {} request error: {e} (attempt {}/{}, cdn_idx={})",
+                            idx,
+                            attempt + 1,
+                            MAX_SEG_RETRIES,
+                            cdn_idx
+                        );
                         if attempt < MAX_SEG_RETRIES {
                             backoff_sleep(attempt).await;
                             continue;
@@ -510,7 +642,22 @@ async fn download_segment_with_speed_check(
     Ok((buf, received, false))
 }
 
-/// Writes a segment buffer to the file at the specified position.
+/// Writes a downloaded segment buffer at the specified byte offset.
+///
+/// Opens the pre-allocated file for random-access write, seeks to `pos`,
+/// and flushes `buf`. Disk errors are translated via [`map_io_error`] so
+/// that `ENOSPC` surfaces as `ERR::DISK_FULL`.
+///
+/// # Arguments
+///
+/// * `path` - Pre-allocated output file path
+/// * `pos` - Absolute byte offset where the segment should be written
+/// * `buf` - Segment bytes to persist
+///
+/// # Errors
+///
+/// Returns an anyhow error on open, seek, or write failure (including
+/// `ERR::DISK_FULL`).
 async fn write_segment(path: &PathBuf, pos: u64, buf: &[u8]) -> Result<(), anyhow::Error> {
     let mut file = tokio::fs::OpenOptions::new()
         .write(true)
@@ -527,8 +674,36 @@ async fn write_segment(path: &PathBuf, pos: u64, buf: &[u8]) -> Result<(), anyho
 
 /// Fallback single-stream download for when Range requests are not supported.
 ///
+/// Used when [`fetch_total_size`] returns `None`, which typically means the
+/// server did not return `Content-Length` or `Content-Range` headers. The
+/// entire response is streamed sequentially into a single file with
+/// per-chunk cancellation checks and progress emission.
+///
 /// Note: CDN rotation is not implemented in fallback mode since parallel
 /// downloads are not possible without Range support.
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle used for event emission
+/// * `url` - URL to download (CDN rotation is not applied in fallback mode)
+/// * `_backup_urls` - Unused; backup URLs cannot be used without range support
+/// * `output_path` - Destination file path
+/// * `cookie` - Optional Cookie header value for authenticated requests
+/// * `is_override` - When `true`, overwrites an existing file; otherwise
+///   returns `ERR::FILE_EXISTS`
+/// * `download_id` - Optional unique ID used for cancellation registration
+///   and event scoping
+/// * `override_stage` - Optional stage label forced onto the emitter
+/// * `emit_complete` - When `true`, emits `complete`; otherwise calls
+///   `Emits::stop` after the stream ends
+///
+/// # Errors
+///
+/// Returns an anyhow error in the following cases:
+/// - `ERR::FILE_EXISTS` - File already exists and `is_override` is `false`
+/// - `ERR::CANCELLED` - Download was cancelled via the registry
+/// - Disk I/O failure (mapped to `ERR::DISK_FULL` for ENOSPC)
+/// - HTTP/streaming failure from the underlying reqwest response
 #[allow(clippy::too_many_arguments)]
 async fn single_stream_fallback(
     app: &AppHandle,
@@ -609,7 +784,16 @@ async fn single_stream_fallback(
     Ok(())
 }
 
-/// Implements exponential backoff sleep for retry logic.
+/// Implements capped exponential backoff sleep for retry logic.
+///
+/// Sleep durations double per attempt, capped at 3000 ms:
+/// 500 ms (attempt 1), 1000 ms (attempt 2), 2000 ms (attempt 3+).
+/// Used between segment download retries to throttle reconnection
+/// attempts to unstable CDN nodes.
+///
+/// # Arguments
+///
+/// * `attempt` - 1-indexed retry attempt number
 async fn backoff_sleep(attempt: u8) {
     // Cap at 3000ms: 500ms (attempt 1), 1000ms (attempt 2), 2000ms (attempt 3+)
     let ms = (500u64 << attempt.saturating_sub(1)).min(3000);
@@ -617,6 +801,26 @@ async fn backoff_sleep(attempt: u8) {
 }
 
 /// Attempts to fetch total file size via HEAD request or Range probe.
+///
+/// Probes the remote resource to determine its full Content-Length. Tries
+/// a HEAD request first and falls back to a single-byte Range request
+/// (`bytes=0-0`) when the HEAD response lacks a usable header. The
+/// fallback parses the `Content-Range` header of the form
+/// `bytes START-END/TOTAL` to recover the total size.
+///
+/// A `None` return signals to the caller that segmented download is not
+/// possible and that [`single_stream_fallback`] should be used instead.
+///
+/// # Arguments
+///
+/// * `client` - HTTP client used for the probe
+/// * `url` - Resource URL
+/// * `cookie` - Optional Cookie header value for authenticated requests
+///
+/// # Returns
+///
+/// Returns `Some(total_bytes)` when a valid Content-Length or
+/// Content-Range header was observed, otherwise `None`.
 async fn fetch_total_size(
     client: &reqwest::Client,
     url: &str,
@@ -652,11 +856,22 @@ async fn fetch_total_size(
         .and_then(|v| v.parse::<u64>().ok())
 }
 
-/// Calculates segment ranges for segmented download.
+/// Calculates segment byte ranges for segmented download.
 ///
-/// Divides the total file size into segments of the specified size.
-/// Each segment is represented as a (start, end) byte range tuple.
-/// The last segment may be smaller if the total size is not evenly divisible.
+/// Divides the total file size into segments of the specified size,
+/// each represented as an inclusive `(start, end)` byte range tuple.
+/// The last segment is shorter when the total size is not evenly
+/// divisible by `segment_size`. Returns an empty vector when
+/// `total == 0`.
+///
+/// # Arguments
+///
+/// * `total` - Total file size in bytes
+/// * `segment_size` - Maximum size of each segment in bytes
+///
+/// # Returns
+///
+/// Vector of `(start, end)` inclusive byte ranges, ascending order.
 fn calculate_segments(total: u64, segment_size: u64) -> Vec<(u64, u64)> {
     let mut segments = Vec::new();
     let mut start = 0;
@@ -668,7 +883,24 @@ fn calculate_segments(total: u64, segment_size: u64) -> Vec<(u64, u64)> {
     segments
 }
 
-/// Pre-allocates file with specified size, checking for disk space.
+/// Pre-allocates the output file to the requested size.
+///
+/// Creates (or truncates) the file and invokes `set_len` so that the OS
+/// reserves the required space up front. This both validates that enough
+/// disk space is available and enables parallel segments to seek and
+/// write into specific offsets without growing the file each time. I/O
+/// errors are translated via [`map_io_error`] so that `ENOSPC` surfaces
+/// as `ERR::DISK_FULL`.
+///
+/// # Arguments
+///
+/// * `path` - Output file path to create
+/// * `size` - Final file size in bytes
+///
+/// # Errors
+///
+/// Returns an anyhow error on open or `set_len` failure (including
+/// `ERR::DISK_FULL`).
 async fn preallocate_file(path: &PathBuf, size: u64) -> Result<()> {
     let file = tokio::fs::OpenOptions::new()
         .create(true)

--- a/src/features/video/api/downloadVideo.ts
+++ b/src/features/video/api/downloadVideo.ts
@@ -105,6 +105,10 @@ export const downloadVideo = async (
       `downloadVideo: completed id=${downloadId}, outputPath=${outputPath}`,
     )
     store.dispatch(updateQueueItem({ downloadId, outputPath, title: filename }))
+    // Mark queue item as done immediately on successful invoke to avoid
+    // relying on the 'complete' progress event, which can race with the
+    // invoke response and cause the UI to stay locked in "downloading".
+    store.dispatch(updateQueueStatus({ downloadId, status: 'done' }))
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     logger.error(`downloadVideo: failed id=${downloadId}`, error)

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -161,7 +161,11 @@ export function useVideoInfo(): VideoInfoContextValue {
   return context
 }
 
+/**
+ * Props for {@linkcode VideoInfoProvider}.
+ */
 type VideoInfoProviderProps = {
+  /** React nodes rendered inside the provider's context scope. */
   children: React.ReactNode
 }
 
@@ -433,14 +437,9 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
         : `av${video.parts[0]?.aid ?? ''}`
 
     // Extract selected parts with their indices for download processing
-    const selectedParts = input.partInputs
-      .map((pi, idx) => (pi.selected ? { pi, idx } : null))
-      .filter(
-        (
-          item,
-        ): item is { pi: (typeof input.partInputs)[number]; idx: number } =>
-          item !== null,
-      )
+    const selectedParts = input.partInputs.flatMap((pi, idx) =>
+      pi.selected ? [{ pi, idx }] : [],
+    )
 
     // Clear previous resolved quality/subtitle info before starting new download
     store.dispatch(clearResolvedInfo())
@@ -487,19 +486,29 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
         )
       } catch (e) {
         const raw = String(e)
-        if (raw.includes('ERR::CANCELLED')) continue
+
+        // User-initiated cancel stops the entire playlist to avoid
+        // the next part auto-starting (which looks like a restart).
+        if (raw.includes('ERR::CANCELLED')) break
 
         const description = getErrorMessage(raw, t)
         if (description) {
           toast.error(t('video.download_failed'), {
             duration: Infinity,
-            description,
+            description: t('video.download_failed_part_description', {
+              page: pi.page,
+              title: pi.title,
+              description,
+            }),
             closeButton: true,
           })
           store.dispatch(setError(description))
         }
         logger.error('Download failed', raw)
-        break
+
+        // Transient failures (e.g. network errors) should not block
+        // the remaining selected parts from being attempted.
+        continue
       }
     }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -183,6 +183,7 @@
     "redownload": "Redownload",
     "retry": "Retry",
     "download_failed_part": "Download failed",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} remaining",
     "quality_limited_title": "Quality Limited",
     "quality_limited_description": "If not logged in (no cookies), only 480p or below is available.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -183,6 +183,7 @@
     "redownload": "Descargar de nuevo",
     "retry": "Reintentar",
     "download_failed_part": "Descarga fallida",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} restante",
     "quality_limited_title": "Calidad Limitada",
     "quality_limited_description": "Si no ha iniciado sesión (sin cookies), solo 480p o inferior está disponible.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -183,6 +183,7 @@
     "redownload": "Télécharger à nouveau",
     "retry": "Réessayer",
     "download_failed_part": "Échec du téléchargement",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} restante",
     "quality_limited_title": "Qualité Limitée",
     "quality_limited_description": "Si non connecté (sans cookies), seule la qualité 480p ou moins est disponible.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -183,6 +183,7 @@
     "redownload": "再ダウンロード",
     "retry": "再試行",
     "download_failed_part": "ダウンロードに失敗しました",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "残{{time}}",
     "quality_limited_title": "画質制限あり",
     "quality_limited_description": "未ログイン（Cookieがない）の場合は480p以下の画質のみになります。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -183,6 +183,7 @@
     "redownload": "다시 다운로드",
     "retry": "재시도",
     "download_failed_part": "다운로드 실패",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} 남음",
     "quality_limited_title": "화질 제한됨",
     "quality_limited_description": "미로그인（Cookie 없음）시 480p 이하의 화질만 이용할 수 있습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -183,6 +183,7 @@
     "redownload": "重新下载",
     "retry": "重试",
     "download_failed_part": "下载失败",
+    "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "剩余 {{time}}",
     "quality_limited_title": "画质受限",
     "quality_limited_description": "未登录（没有Cookie）的情况下，仅可用480p或以下画质。",

--- a/src/shared/queue/queueSlice.ts
+++ b/src/shared/queue/queueSlice.ts
@@ -4,6 +4,16 @@ import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit'
 import type { RootState } from '@/app/store'
 import { callCancelAllDownloads, callCancelDownload } from './api/cancelApi'
 
+/**
+ * Lifecycle state of a single {@linkcode QueueItem}.
+ *
+ * - `pending` - Enqueued but not yet started by the backend.
+ * - `running` - Actively downloading.
+ * - `cancelling` - User requested cancellation; awaiting backend confirmation.
+ * - `cancelled` - Backend confirmed cancellation via the `download_cancelled` event.
+ * - `done` - Download finished successfully.
+ * - `error` - Download failed; see `errorMessage` for details.
+ */
 type QueueItemStatus =
   | 'pending'
   | 'running'
@@ -87,6 +97,10 @@ export type QueueItem = {
   title?: string
 }
 
+/**
+ * Empty initial state for the queue slice. The queue is populated at
+ * runtime as downloads are enqueued.
+ */
 const initialState: QueueItem[] = []
 
 /**
@@ -176,6 +190,12 @@ export const queueSlice = createSlice({
     /**
      * Updates the status of a queue item.
      * Automatically aggregates parent status based on children.
+     *
+     * Protected states (done, error, cancelled, cancelling) reject downgrade
+     * to running/pending. This prevents stale progress events that arrive
+     * after invoke resolve (or during cancellation) from reviving a finished
+     * item and locking the UI — Tauri IPC does not guarantee event-listener
+     * vs invoke-resolve ordering.
      */
     updateQueueStatus(
       state,
@@ -187,10 +207,25 @@ export const queueSlice = createSlice({
     ) {
       const { downloadId, status, errorMessage } = action.payload
       const target = state.find((i) => i.downloadId === downloadId)
-      if (target) {
-        target.status = status
-        if (errorMessage) target.errorMessage = errorMessage
+      if (!target) {
+        aggregateParentStatuses(state)
+        return
       }
+
+      const PROTECTED_STATUSES = ['done', 'error', 'cancelled', 'cancelling']
+      const DOWNGRADE_STATUSES = ['running', 'pending']
+      // Ignore stale progress event arriving after completion or
+      // during cancellation. This prevents the UI from briefly
+      // snapping back to "downloading" when the user just cancelled.
+      if (
+        PROTECTED_STATUSES.includes(target.status ?? '') &&
+        DOWNGRADE_STATUSES.includes(status)
+      ) {
+        return
+      }
+
+      target.status = status
+      if (errorMessage) target.errorMessage = errorMessage
       aggregateParentStatuses(state)
     },
     /**


### PR DESCRIPTION
## Summary

Closes #406.

- **Retry transient network errors**: `retry_download` now retries any non-`ERR::` error up to 3 times with linear backoff, wrapping the final failure as `ERR::NETWORK::{msg}`. `ERR::` errors remain non-retryable.
- **Rotate CDN on size mismatch**: When a segment returns fewer bytes than expected (typically CDN edge cache corruption or rate-limit cutoff), immediately rotate to the next CDN instead of backing off on the same node. The same node tends to reproduce the same truncated response.
- **Mark queue done on invoke success**: `downloadVideo` now dispatches `updateQueueStatus({status:'done'})` on successful invoke, so the queue reflects completion without relying on the `complete` progress event (which can race with invoke resolve).
- **Playlist error handling**: `ERR::CANCELLED` breaks the playlist loop; other transient errors continue to the next part with a localized, detailed toast.
- **Protect terminal/cancelling states**: `updateQueueStatus` rejects downgrades from `done`/`error`/`cancelled`/`cancelling` to `running`/`pending`. Stale progress events that arrive after invoke resolve (or during cancellation) can no longer revive a finished item and lock the UI — Tauri IPC does not guarantee event-listener vs invoke-resolve ordering.

## Test plan

- [x] Downloaded a 10-part playlist: all parts succeeded; 5 size-mismatch events recovered via CDN rotation.
- [x] Cancelled a download mid-flight: `ERR::CANCELLED` propagated cleanly, playlist loop broke.
- [x] Verified UI unlocks (page navigation, redownload button) after completion.
- [x] Confirmed no regression in single-part downloads.
- [x] Locale key `video.download_failed_part_description` added to all 6 locales (en/ja/zh/ko/es/fr) with equal key counts.