### PR TITLE
fix(home): preserve current page when returning home during active download

### DIFF
--- a/src/features/video/index.ts
+++ b/src/features/video/index.ts
@@ -29,7 +29,9 @@ export {
   inputSlice,
   selectAll,
   selectHasSelectedParts,
+  selectHomePage,
   selectPageAll,
+  setHomePage,
   setPendingDownload,
   updatePartSelected,
 } from './model/inputSlice'

--- a/src/features/video/model/inputSlice.test.ts
+++ b/src/features/video/model/inputSlice.test.ts
@@ -2,6 +2,8 @@ import inputReducer, {
   defaultSubtitleConfig,
   initPartInputs,
   resetInput,
+  selectHomePage,
+  setHomePage,
   setPartQualities,
   setPartSubtitles,
   setQualitiesLoading,
@@ -16,6 +18,7 @@ describe('inputSlice', () => {
     url: '',
     partInputs: [],
     pendingDownload: null,
+    homePage: 1,
   }
 
   describe('defaultSubtitleConfig', () => {
@@ -378,11 +381,41 @@ describe('inputSlice', () => {
           },
         ],
         pendingDownload: { bvid: 'BV123', cid: 123, page: 1 },
+        homePage: 3,
       }
 
       const state = inputReducer(stateWithData, resetInput())
 
       expect(state).toEqual(initialState)
+    })
+  })
+
+  describe('setHomePage', () => {
+    it('should update the home page number', () => {
+      const state = inputReducer(initialState, setHomePage(3))
+      expect(state.homePage).toBe(3)
+    })
+
+    it('should preserve other state fields', () => {
+      const stateWithData = {
+        ...initialState,
+        url: 'https://bilibili.com/video/BV123',
+        homePage: 2,
+      }
+      const state = inputReducer(stateWithData, setHomePage(5))
+      expect(state.url).toBe('https://bilibili.com/video/BV123')
+      expect(state.homePage).toBe(5)
+    })
+  })
+
+  describe('selectHomePage', () => {
+    it('should return the stored home page', () => {
+      const state = inputReducer(initialState, setHomePage(4))
+      expect(selectHomePage({ input: state })).toBe(4)
+    })
+
+    it('should default to 1 when homePage is unset', () => {
+      expect(selectHomePage({ input: initialState })).toBe(1)
     })
   })
 })

--- a/src/features/video/model/inputSlice.ts
+++ b/src/features/video/model/inputSlice.ts
@@ -24,6 +24,7 @@ const initialState: Input = {
   url: '',
   partInputs: [],
   pendingDownload: null,
+  homePage: 1,
 }
 
 /**
@@ -202,6 +203,19 @@ export const inputSlice = createSlice({
      */
     clearPendingDownload: (state) => {
       state.pendingDownload = null
+    },
+    /**
+     * Updates the last viewed home page number.
+     *
+     * Persisted when the user navigates pagination on the home page,
+     * and read by the sidebar Home button to restore the page when
+     * returning during an active download.
+     *
+     * @param state - Current input state
+     * @param action - Action containing the page number (1-indexed)
+     */
+    setHomePage: (state, action: PayloadAction<number>) => {
+      state.homePage = action.payload
     },
     /**
      * Updates subtitle configuration for a specific part.
@@ -402,6 +416,7 @@ export const {
   selectAll,
   selectPageAll,
   setAccordionOpen,
+  setHomePage,
   setInput,
   setPartQualities,
   setPartSubtitles,
@@ -424,5 +439,14 @@ export const {
  */
 export const selectHasSelectedParts = (state: { input: Input }) =>
   state.input.partInputs.some((p) => p.selected)
+
+/**
+ * Selector for the last viewed home page number.
+ *
+ * @param state - The Redux root state
+ * @returns The last viewed page number (1-indexed), default 1
+ */
+export const selectHomePage = (state: { input: Input }) =>
+  state.input.homePage ?? 1
 
 export default inputSlice.reducer

--- a/src/features/video/types.ts
+++ b/src/features/video/types.ts
@@ -72,6 +72,8 @@ export type Input = {
   partInputs: PartInput[]
   /** Pending download from watch history navigation */
   pendingDownload: PendingDownload | null
+  /** Last viewed home page number (1-indexed). Used to restore page on home button click during downloads. */
+  homePage: number
 }
 
 /**

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -9,6 +9,7 @@ import {
   DownloadButton,
   selectHasSelectedParts,
   selectPageAll,
+  setHomePage,
   useVideoInfo,
   VideoForm1,
   VideoInfoProvider,
@@ -479,10 +480,13 @@ function HomeContentInner() {
 
     if (prevPending && !input.pendingDownload) {
       const targetIndex = prevPending.page - 1
+      const targetPage = Math.ceil(prevPending.page / PARTS_PER_PAGE)
+      // Persist target page so the sidebar Home button restores it
+      dispatch(setHomePage(targetPage))
       setScrollToPartIndex(targetIndex)
       setScrollRequestId((prev) => prev + 1)
     }
-  }, [input.pendingDownload, video.parts.length, isFetching])
+  }, [input.pendingDownload, video.parts.length, isFetching, dispatch])
 
   /**
    * Performs the actual page change without confirmation.
@@ -495,12 +499,14 @@ function HomeContentInner() {
       newParams.delete('p')
       newParams.set('page', String(page))
       setSearchParams(newParams, { replace: true })
+      // Persist page so the sidebar Home button restores it
+      dispatch(setHomePage(page))
       const cardContent = document.querySelector('[data-part-list]')
       if (cardContent) {
         cardContent.scrollTop = 0
       }
     },
-    [searchParams, setSearchParams],
+    [searchParams, setSearchParams, dispatch],
   )
 
   /**

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from '@/app/store'
+import { selectHomePage } from '@/features/video'
 import { Download } from '@/shared/animate-ui/icons/download'
 import {
   SidebarGroup,
@@ -68,6 +69,7 @@ export function NavigationSidebarHeader({
   const user = useSelector((state) => state.user)
   const isLoggedIn = user.hasCookie && user.data?.isLogin
   const hasActiveDownloads = useSelector(selectHasActiveDownloads)
+  const homePage = useSelector(selectHomePage)
 
   const groups: MenuGroup[] = [
     {
@@ -130,11 +132,32 @@ export function NavigationSidebarHeader({
     const isDisabled = item.requiresAuth && !isLoggedIn
     const isHome = item.path === '/home'
 
+    /**
+     * Click handler for navigation menu items.
+     *
+     * For the Home item, navigates with the last viewed `?page` parameter
+     * restored from Redux state, so the sidebar Home button returns the
+     * user to the pagination page they were on (rather than page 1).
+     * The `?page` param is always set (even for page 1) so it takes
+     * URL resolution priority over any stale `?p` embedded in `input.url`.
+     *
+     * For other items, performs a plain path navigation.
+     * Disabled items (auth required but not logged in) are no-ops.
+     */
+    const handleClick = () => {
+      if (isDisabled) return
+      if (isHome) {
+        navigate({ pathname: '/home', search: `?page=${homePage}` })
+      } else {
+        navigate(item.path)
+      }
+    }
+
     const button = (
       <SidebarMenuButton
         isActive={isActive}
         tooltip={isDisabled ? undefined : item.label}
-        onClick={() => !isDisabled && navigate(item.path)}
+        onClick={handleClick}
         aria-label={item.ariaLabel}
         aria-current={isActive ? 'page' : undefined}
         aria-disabled={isDisabled || undefined}


### PR DESCRIPTION
## Summary

When a download was initiated from favorites/watch-history (which sets `input.url` with `?p=N`), navigating to favorites and clicking the Home button would reset the page to the initial `?p=N`-derived page instead of the page the user was viewing.

**Root cause**: `currentPage`'s 4th-priority fallback to `input.url`'s `?p=N` in `pages/home/index.tsx:411-432`. Since `navigate('/home')` (sidebar Home button) doesn't preserve query params, the URL's `?page` would disappear on Home return and the fallback kicked in, restoring the stale initial page.

**Fix**: Added `homePage` state to `inputSlice` to track the last viewed home page. Dispatch `setHomePage` in both `performPageChange` and the `pendingDownload` effect. The Home button now always navigates with `?page=N` so the URL's first-priority param overrides the stale `input.url` ?p fallback.

### Changes
- `src/features/video/types.ts`: Added `homePage: number` to `Input` type
- `src/features/video/model/inputSlice.ts`: Added `setHomePage` reducer and `selectHomePage` selector
- `src/features/video/index.ts`: Exported new action/selector via Public API
- `src/pages/home/index.tsx`: Dispatch `setHomePage` in `performPageChange` and the `pendingDownload` effect
- `src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx`: Home button always navigates with `?page=N`
- `src/features/video/model/inputSlice.test.ts`: Added unit tests for `setHomePage`/`selectHomePage`

## Related Issue

N/A (reported via chat)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Open a video with 10+ parts
- [ ] Start a download from favorites/watch-history (e.g., part 15 = page 2)
- [ ] Verify home shows page 2 (DL start)
- [ ] Paginate to page 3
- [ ] Start another download
- [ ] Navigate to favorites
- [ ] Click Home button
- [ ] Verify page 3 is restored (not page 2)
- [ ] Edge case: After favorites DL (page 2 shown via fallback), go to favorites → Home: page 2 restored
- [ ] Edge case: After favorites DL, manually navigate to page 1, go to favorites → Home: page 1 restored

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A (no user-facing text changes)