### PR TITLE
fix: hide transfer rate display during CDN rotation and retry

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -43,6 +43,16 @@ pub struct Progress {
     /// Whether the download has completed
     #[serde(rename = "isComplete")]
     pub is_complete: bool,
+    /// Whether the download is currently retrying (e.g., CDN rotation).
+    /// When true, the frontend hides transfer rate display to avoid flicker
+    /// between pre-retry and post-retry speed values.
+    ///
+    /// `None` means "no explicit signal" — the frontend preserves the
+    /// previous value. This allows retry_download's new `Emits` instance
+    /// (which defaults to `None`) to not clobber a retrying state set
+    /// via the separate `download-retrying` event.
+    #[serde(rename = "isRetrying")]
+    pub is_retrying: Option<bool>,
 }
 
 /// Internal state for progress tracking.
@@ -191,6 +201,41 @@ impl Emits {
         // Get current bytes from watch channel for immediate update
         let bytes = *self.progress_tx.subscribe().borrow();
         // Send immediate update reflecting stage change
+        Self::send_progress_locked(&self.app, &mut guard, bytes);
+    }
+
+    /// Resets speed tracking state after CDN rotation or retry.
+    ///
+    /// Clears the EMA-smoothed speed and recalibrates the speed measurement
+    /// baseline to the current byte count. This prevents the previous CDN's
+    /// low speed from being carried over to the new CDN via EMA smoothing,
+    /// which would otherwise cause speed display flicker.
+    ///
+    /// Note: `last_downloaded_bytes` is intentionally not reset because the
+    /// frontend clamps `downloaded`/`percentage` monotonically; resetting it
+    /// here would cause the next tick to treat rolled-back bytes as new data.
+    pub async fn reset_speed_tracking(&self) {
+        let mut guard = self.inner.lock().await;
+        let current_bytes = *self.progress_tx.subscribe().borrow();
+        guard.smoothed_speed_kbps = 0.0;
+        guard.last_speed_calc_instant = Instant::now();
+        guard.last_speed_calc_bytes = current_bytes;
+    }
+
+    /// Sets the retrying flag and emits an immediate update.
+    ///
+    /// When `retrying` is true, the frontend hides the transfer rate display
+    /// to avoid flicker between pre-retry and post-retry speed values. When
+    /// set back to false (e.g., on first chunk from the new CDN), normal
+    /// speed display resumes.
+    ///
+    /// # Arguments
+    ///
+    /// * `retrying` - Whether the download is currently retrying
+    pub async fn set_retrying(&self, retrying: bool) {
+        let mut guard = self.inner.lock().await;
+        guard.progress.is_retrying = Some(retrying);
+        let bytes = *self.progress_tx.subscribe().borrow();
         Self::send_progress_locked(&self.app, &mut guard, bytes);
     }
 

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -159,8 +159,8 @@ use crate::models::bilibili_api::{
 };
 use crate::models::cookie::CookieEntry;
 use crate::models::frontend_dto::{
-    Quality, SubtitleDto, Thumbnail, UserData, Video, VideoPart, WatchHistoryCursor,
-    WatchHistoryEntry,
+    DownloadRetrying, Quality, SubtitleDto, Thumbnail, UserData, Video, VideoPart,
+    WatchHistoryCursor, WatchHistoryEntry,
 };
 use crate::utils::downloads::download_url;
 use crate::utils::paths::get_lib_path;
@@ -408,7 +408,7 @@ async fn download_bangumi_durl(
     }
 
     // Download directly
-    retry_download(|| {
+    retry_download(app, &options.download_id, Some("video"), || {
         download_url(
             app,
             video_url.clone(),
@@ -556,7 +556,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 ensure_free_space(&output_path, vs + 5 * 1024 * 1024)?;
             }
 
-            retry_download(|| {
+            retry_download(app, &options.download_id, Some("video"), || {
                 download_url(
                     app,
                     video_url.clone(),
@@ -658,7 +658,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
         // Download audio and video in parallel (cancel immediately if either fails)
         tokio::try_join!(
-            retry_download(|| {
+            retry_download(app, &options.download_id, Some("audio"), || {
                 download_url(
                     app,
                     audio_url.clone(),
@@ -671,7 +671,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                     false, // emit_complete: will be emitted after merge
                 )
             }),
-            retry_download(|| {
+            retry_download(app, &options.download_id, Some("video"), || {
                 download_url(
                     app,
                     video_url.clone(),
@@ -1682,8 +1682,20 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
 /// - Backoff strategy: Linear (500ms, 1000ms, 1500ms)
 /// - Final failure is wrapped as `ERR::NETWORK::{original_message}`
 ///
+/// # Retry State Notification
+///
+/// Emits `download-retrying` events to notify the frontend of retry state
+/// changes. Before each retry attempt (attempt > 1), an event with
+/// `is_retrying: true` is sent so the frontend can hide the transfer rate
+/// display. On success or final failure, `is_retrying: false` is sent to
+/// resume normal display.
+///
 /// # Arguments
 ///
+/// * `app` - Tauri application handle for event emission
+/// * `download_id` - Unique identifier for this download
+/// * `stage` - Current download stage ("audio" or "video"); when `None`,
+///   the frontend applies retry state to all stages for this download
 /// * `f` - Async closure that performs the download operation
 ///
 /// # Returns
@@ -1695,7 +1707,12 @@ fn ensure_free_space(target_path: &Path, needed_bytes: u64) -> Result<(), String
 /// Returns errors in the following cases:
 /// - All retry attempts failed (wrapped as `ERR::NETWORK::*`)
 /// - Error contains `ERR::` prefix (passed through unchanged)
-async fn retry_download<F, Fut>(mut f: F) -> Result<(), String>
+async fn retry_download<F, Fut>(
+    app: &AppHandle,
+    download_id: &str,
+    stage: Option<&str>,
+    mut f: F,
+) -> Result<(), String>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<(), anyhow::Error>>,
@@ -1703,15 +1720,38 @@ where
     const MAX_ATTEMPTS: u8 = 3;
     const BACKOFF_BASE_MS: u64 = 500;
 
+    let emit_retrying = |is_retrying: bool| {
+        let _ = app.emit(
+            "download-retrying",
+            DownloadRetrying {
+                download_id: download_id.to_string(),
+                stage: stage.map(|s| s.to_string()),
+                is_retrying,
+            },
+        );
+    };
+
     for attempt in 1..=MAX_ATTEMPTS {
+        if attempt > 1 {
+            // Notify frontend to hide transfer rate display during retry.
+            emit_retrying(true);
+        }
         match f().await {
-            Ok(_) => return Ok(()),
+            Ok(_) => {
+                if attempt > 1 {
+                    emit_retrying(false);
+                }
+                return Ok(());
+            }
             Err(e) => {
                 let msg = e.to_string();
 
                 // ERR:: prefix = business logic error, never retry
                 if msg.contains("ERR::") {
                     log::warn!("[BE] retry_download: non-retryable: {msg}");
+                    if attempt > 1 {
+                        emit_retrying(false);
+                    }
                     return Err(msg);
                 }
 
@@ -1719,6 +1759,9 @@ where
                 // Retry unconditionally; final attempt wraps as ERR::NETWORK.
                 if attempt >= MAX_ATTEMPTS {
                     log::error!("[BE] retry_download: exhausted {MAX_ATTEMPTS} attempts: {msg}");
+                    if attempt > 1 {
+                        emit_retrying(false);
+                    }
                     return Err(format!("ERR::NETWORK::{msg}"));
                 }
 

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -227,3 +227,25 @@ pub struct SubtitleDto {
     /// None for manually created subtitles.
     pub ai_type: Option<u8>,
 }
+
+/// Retry state notification sent to the frontend.
+///
+/// Emitted via the `download-retrying` event when `retry_download` starts
+/// a new attempt after a failure. Unlike the `progress` event, this only
+/// carries retry state, leaving all other progress fields untouched on the
+/// frontend. This avoids side effects where re-sending a full `Progress`
+/// payload would reset `filesize`/`downloaded` to `None`.
+///
+/// CDN rotation inside `download_url` does NOT use this event; it sets
+/// `is_retrying` directly on the `Progress` payload via `Emits::set_retrying`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadRetrying {
+    /// Unique identifier for this download operation
+    pub download_id: String,
+    /// Current download stage (e.g., "audio", "video"). When `None`, the
+    /// frontend applies the retry state to all stages for this download.
+    pub stage: Option<String>,
+    /// Whether the download is currently retrying
+    pub is_retrying: bool,
+}

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -22,7 +22,7 @@ use futures::StreamExt;
 use reqwest::header;
 use reqwest::RequestBuilder;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
@@ -345,6 +345,9 @@ pub async fn download_url(
             // Track bytes this segment has added to dl_total_c
             // for rollback on retry
             let seg_bytes_added = Arc::new(AtomicU64::new(0));
+            // Track retry state for this segment to clear isRetrying flag
+            // exactly once on the first chunk from the new CDN.
+            let seg_is_retrying = Arc::new(AtomicBool::new(false));
 
             loop {
                 attempt += 1;
@@ -362,6 +365,13 @@ pub async fn download_url(
                     dl_total_c.fetch_sub(prev, Ordering::Relaxed);
                     // Reset progress display after rollback
                     emits_c.update_progress(dl_total_c.load(Ordering::Relaxed));
+                    // Reset speed tracking so the previous CDN's low speed
+                    // doesn't bleed into the new CDN via EMA smoothing,
+                    // and notify the frontend to hide transfer rate display
+                    // until the new CDN's first chunk arrives.
+                    emits_c.reset_speed_tracking().await;
+                    emits_c.set_retrying(true).await;
+                    seg_is_retrying.store(true, Ordering::Relaxed);
                 }
 
                 // Select CDN URL based on rotation count (CDN rotation with loop)
@@ -407,6 +417,7 @@ pub async fn download_url(
                         let emits_cb = emits_c.clone();
                         let dl_total_cb = dl_total_c.clone();
                         let seg_bytes_cb = seg_bytes_added.clone();
+                        let seg_is_retrying_cb = seg_is_retrying.clone();
                         let download_result = download_segment_with_speed_check(
                             &mut resp,
                             idx,
@@ -416,6 +427,15 @@ pub async fn download_url(
                             cdn_rotation_count,
                             cdn_urls_c.len(),
                             |chunk_len| {
+                                // On first chunk after retry, clear isRetrying flag.
+                                // swap returns the previous value and sets to false atomically,
+                                // so this only fires once per retry cycle.
+                                if seg_is_retrying_cb.swap(false, Ordering::Relaxed) {
+                                    let emits_for_retry = emits_cb.clone();
+                                    tokio::spawn(async move {
+                                        emits_for_retry.set_retrying(false).await;
+                                    });
+                                }
                                 seg_bytes_cb.fetch_add(chunk_len, Ordering::Relaxed);
                                 let new_total =
                                     dl_total_cb.fetch_add(chunk_len, Ordering::Relaxed) + chunk_len;

--- a/src/__tests__/unit/progressSlice.test.ts
+++ b/src/__tests__/unit/progressSlice.test.ts
@@ -5,6 +5,7 @@ import {
   clearProgressByDownloadId,
   progressSlice,
   setProgress,
+  setRetrying,
 } from '@/shared/progress/progressSlice'
 import type { Progress } from '@/shared/ui/Progress'
 
@@ -211,6 +212,179 @@ describe('progressSlice', () => {
 
       expect(state).toHaveLength(1)
       expect(state[0].downloadId).toBe('dl-2')
+    })
+  })
+
+  describe('isRetrying propagation', () => {
+    it('should preserve previous isRetrying when payload is undefined', () => {
+      // Simulate retry_download flow: existing entry has isRetrying=true
+      // (set via setRetrying), then a new Emits instance sends Progress
+      // without isRetrying (Rust Option<bool> = None). The existing
+      // isRetrying state must be preserved to avoid flicker.
+      let state = progressSlice.reducer(
+        [],
+        setProgress({ ...baseProgress, percentage: 50 }),
+      )
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'test-dl-1',
+          stage: 'video',
+          isRetrying: true,
+        }),
+      )
+      expect(state[0].isRetrying).toBe(true)
+
+      // New Emits instance emits Progress with isRetrying undefined (None)
+      state = progressSlice.reducer(
+        state,
+        setProgress({ ...baseProgress, percentage: 55 }),
+      )
+      expect(state[0].isRetrying).toBe(true)
+    })
+
+    it('should update isRetrying when explicitly set via setProgress', () => {
+      // CDN rotation path: Emits::set_retrying(true/false) sends Progress
+      // with isRetrying explicitly set. This must overwrite the value.
+      let state = progressSlice.reducer(
+        [],
+        setProgress({ ...baseProgress, percentage: 50 }),
+      )
+      expect(state[0].isRetrying).toBeUndefined()
+
+      // CDN rotation detected → set_retrying(true)
+      state = progressSlice.reducer(
+        state,
+        setProgress({ ...baseProgress, percentage: 50, isRetrying: true }),
+      )
+      expect(state[0].isRetrying).toBe(true)
+
+      // First chunk from new CDN → set_retrying(false)
+      state = progressSlice.reducer(
+        state,
+        setProgress({ ...baseProgress, percentage: 55, isRetrying: false }),
+      )
+      expect(state[0].isRetrying).toBe(false)
+    })
+  })
+
+  describe('setRetrying', () => {
+    it('should update isRetrying for matching downloadId', () => {
+      let state = progressSlice.reducer(
+        [],
+        setProgress({ ...baseProgress, downloadId: 'dl-1' }),
+      )
+      state = progressSlice.reducer(
+        state,
+        setProgress({ ...baseProgress, downloadId: 'dl-2' }),
+      )
+
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'dl-1',
+          isRetrying: true,
+        }),
+      )
+
+      expect(state[0].isRetrying).toBe(true)
+      expect(state[1].isRetrying).toBeUndefined()
+    })
+
+    it('should update isRetrying only for matching stage', () => {
+      let state = progressSlice.reducer(
+        [],
+        setProgress({
+          ...baseProgress,
+          stage: 'audio',
+          percentage: 50,
+        }),
+      )
+      state = progressSlice.reducer(
+        state,
+        setProgress({
+          ...baseProgress,
+          stage: 'video',
+          percentage: 50,
+        }),
+      )
+
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'test-dl-1',
+          stage: 'audio',
+          isRetrying: true,
+        }),
+      )
+
+      expect(state[0].isRetrying).toBe(true) // audio
+      expect(state[1].isRetrying).toBeUndefined() // video
+    })
+
+    it('should update all stages when stage is undefined', () => {
+      let state = progressSlice.reducer(
+        [],
+        setProgress({
+          ...baseProgress,
+          stage: 'audio',
+          percentage: 50,
+        }),
+      )
+      state = progressSlice.reducer(
+        state,
+        setProgress({
+          ...baseProgress,
+          stage: 'video',
+          percentage: 50,
+        }),
+      )
+
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'test-dl-1',
+          isRetrying: true,
+        }),
+      )
+
+      expect(state[0].isRetrying).toBe(true) // audio
+      expect(state[1].isRetrying).toBe(true) // video
+    })
+
+    it('should be a no-op when no entries match', () => {
+      let state = progressSlice.reducer(
+        [],
+        setProgress({ ...baseProgress, downloadId: 'dl-1' }),
+      )
+      const stateBefore = state
+
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'dl-other',
+          isRetrying: true,
+        }),
+      )
+
+      expect(state).toBe(stateBefore)
+    })
+
+    it('should clear isRetrying when set to false', () => {
+      let state = progressSlice.reducer(
+        [],
+        setProgress({ ...baseProgress, isRetrying: true }),
+      )
+      expect(state[0].isRetrying).toBe(true)
+
+      state = progressSlice.reducer(
+        state,
+        setRetrying({
+          downloadId: 'test-dl-1',
+          isRetrying: false,
+        }),
+      )
+      expect(state[0].isRetrying).toBe(false)
     })
   })
 })

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -15,6 +15,7 @@ import type { Progress } from '@/shared/progress'
 import {
   clearProgressByDownloadId,
   setProgress,
+  setRetrying,
 } from '@/shared/progress/progressSlice'
 import { clearQueueItem, updateQueueStatus } from '@/shared/queue/queueSlice'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
@@ -23,6 +24,22 @@ import { toast } from 'sonner'
 
 interface DownloadCancelledPayload {
   downloadId: string
+}
+
+/**
+ * Payload for the `download-retrying` event.
+ *
+ * Emitted by `retry_download` in the Rust backend when a retry attempt
+ * starts (isRetrying: true) or completes (isRetrying: false). Drives the
+ * `setRetrying` Redux action to hide transfer rate display during retries.
+ */
+interface DownloadRetryingPayload {
+  /** Unique identifier for this download operation */
+  downloadId: string
+  /** Stage identifier ("audio" or "video"). When undefined, applies to all stages */
+  stage?: string
+  /** Whether the download is currently retrying */
+  isRetrying: boolean
 }
 
 /**
@@ -77,6 +94,7 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
     let unlistenQualityResolved: UnlistenFn | undefined
     let unlistenSubtitleResolved: UnlistenFn | undefined
     let unlistenSubtitleWarning: UnlistenFn | undefined
+    let unlistenRetrying: UnlistenFn | undefined
 
     const setupListeners = async (): Promise<void> => {
       // Setup progress event listener
@@ -169,6 +187,16 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
           )
         },
       )
+
+      // Setup download retrying event listener
+      // Updates isRetrying flag on matching progress entries to hide
+      // transfer rate display during CDN rotation / full retry.
+      unlistenRetrying = await listen<DownloadRetryingPayload>(
+        'download-retrying',
+        (event) => {
+          store.dispatch(setRetrying(event.payload))
+        },
+      )
     }
 
     setupListeners()
@@ -180,6 +208,7 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
       unlistenQualityResolved?.()
       unlistenSubtitleResolved?.()
       unlistenSubtitleWarning?.()
+      unlistenRetrying?.()
     }
   }, [])
   return (

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -96,7 +96,11 @@ function StageProgress({
     <div className={`flex ${MIN_HEIGHT} items-center gap-1`}>
       <StageIcon icon={icon} label={stageLabel} fontWeight="medium" />
       <span>{progress.percentage.toFixed(0)}%</span>
-      <span>{formatTransferRate(progress.transferRate || 0)}</span>
+      <span>
+        {progress.isRetrying
+          ? '--MB/s'
+          : formatTransferRate(progress.transferRate || 0)}
+      </span>
       {progress.filesize != null && (
         <span>
           {progress.downloaded?.toFixed(1) ?? '0'}mb/

--- a/src/shared/progress/progressSlice.ts
+++ b/src/shared/progress/progressSlice.ts
@@ -69,13 +69,46 @@ export const progressSlice = createSlice({
         const downloaded = payload.isComplete
           ? payload.downloaded
           : Math.max(prev.downloaded, payload.downloaded)
+        // isRetrying is preserved when undefined (Rust sends Option<bool>).
+        // CDN rotation explicitly sets Some(true)/Some(false); retry_download
+        // leaves it None so it doesn't clobber state set via setRetrying.
+        const isRetrying = payload.isRetrying ?? prev.isRetrying
         state[idx] = {
           ...payload,
           internalId,
           parentId: payload.downloadId,
           percentage,
           downloaded,
+          isRetrying,
         }
+      }
+    },
+    /**
+     * Updates the retrying flag for progress entries matching the given
+     * download (and optionally stage).
+     *
+     * Driven by the `download-retrying` event emitted from `retry_download`
+     * in the Rust backend. Unlike `setProgress`, this only updates
+     * `isRetrying` and leaves all other fields untouched, avoiding the
+     * side effect of resetting `filesize`/`downloaded` to null when
+     * sending a partial Progress payload.
+     *
+     * @param state - Current progress array
+     * @param action - Action containing downloadId, optional stage, and isRetrying
+     */
+    setRetrying(
+      state,
+      action: PayloadAction<{
+        downloadId: string
+        stage?: string
+        isRetrying: boolean
+      }>,
+    ) {
+      const { downloadId, stage, isRetrying } = action.payload
+      for (const p of state) {
+        if (p.downloadId !== downloadId) continue
+        if (stage && p.stage !== stage) continue
+        p.isRetrying = isRetrying
       }
     },
     /**
@@ -99,8 +132,12 @@ export const progressSlice = createSlice({
   },
 })
 
-export const { setProgress, clearProgress, clearProgressByDownloadId } =
-  progressSlice.actions
+export const {
+  setProgress,
+  setRetrying,
+  clearProgress,
+  clearProgressByDownloadId,
+} = progressSlice.actions
 export default progressSlice.reducer
 
 /**

--- a/src/shared/ui/Progress/types.ts
+++ b/src/shared/ui/Progress/types.ts
@@ -20,6 +20,12 @@ export type Progress = {
   elapsedTime: number
   /** Whether this stage is complete */
   isComplete: boolean
+  /**
+   * Whether the download is currently retrying (e.g., CDN rotation or
+   * full retry). When true, the UI hides the transfer rate display to
+   * avoid flicker between pre-retry and post-retry speed values.
+   */
+  isRetrying?: boolean
   /** Download stage ('audio', 'video', 'merge', 'complete') */
   stage?: string
   /** Parent download ID for multi-part downloads */


### PR DESCRIPTION
## Summary

CDN rotation and `retry_download` previously emitted pre-retry speed values, causing the progress bar to flicker between pre-retry and post-retry speeds. This PR introduces an `isRetrying` flag that lets the frontend show `--MB/s` until the new CDN's speed stabilizes.

## Related Issue

No directly related open issue found.

## Type of Change

- [x] 🐛 Bug fix

## Implementation Details

This change uses a **hybrid design** to handle both retry paths without clobbering other Progress fields:

### CDN rotation (segment-level retry)
- Sets `isRetrying` on `Progress` payload via `Emits::set_retrying`
- Calls `Emits::reset_speed_tracking()` on rollback to clear EMA-smoothed speed from the previous CDN
- Clears `isRetrying` on first chunk from the new CDN

### retry_download (full retry)
- Emits a separate `download-retrying` event with a `DownloadRetrying` DTO
- Avoids resetting `filesize`/`downloaded` to null on the frontend
- Frontend's `setRetrying` reducer updates only `isRetrying`

### Why `Option<bool>` for `Progress.is_retrying`
- `Some(true)/Some(false)`: explicit signal from CDN rotation
- `None`: preserves frontend state — so `retry_download`'s new `Emits` instance doesn't clobber state set via the `download-retrying` event

## Test Plan

- [x] Run `npm run tauri dev`
- [x] Download a video that triggers CDN rotation (slow CDN)
- [x] Verify transfer rate shows `--MB/s` during retry
- [x] Verify transfer rate transitions to actual speed (`--` → `0` → `n`) after new CDN stabilizes
- [x] Verify progress bar no longer flickers between pre-retry and post-retry speeds
- [x] Unit tests: 17 passing (`progressSlice.test.ts`)

## Screenshots / Videos (Optional)

N/A (behavior verified during manual testing).

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A (no i18n keys added)