### PR TITLE
fix(e2e): update splash screen selector to use data-testid

### DIFF
--- a/e2e-tests/helpers/selectors.ts
+++ b/e2e-tests/helpers/selectors.ts
@@ -4,20 +4,21 @@
  * Selectors are derived from actual DOM attributes in the codebase:
  * - data-slot attributes from shadcn/ui / Radix UI primitives
  * - data-part-list / data-part-index custom attributes
+ * - data-testid attributes on custom components (e.g. SplashScreen)
  * - aria-label attributes on navigation buttons
  * - Standard HTML attributes (input[name], [role="alert"])
  */
 
-// -- Init Page --
+// -- Splash Screen --
 
-/** Full-page centered container shown during app initialization. */
-export const INIT_CONTAINER = '.flex.h-full.w-full.items-center.justify-center'
-
-/** Spinning loader indicator on the initialization page. */
-export const INIT_SPINNER = '.animate-spin.rounded-full'
-
-/** Status text label shown below the spinner during initialization. */
-export const INIT_STATUS_TEXT = '.text-muted-foreground.text-sm'
+/**
+ * Splash screen overlay container shown during app initialization.
+ *
+ * Uses `data-testid` so the selector is decoupled from CSS classes that vary
+ * across the splash screen's rendering modes (settings-loading, skip-mode,
+ * full-animation).
+ */
+export const INIT_CONTAINER = '[data-testid="splash-screen"]'
 
 // -- Sidebar --
 

--- a/e2e-tests/test/app-launch.e2e.ts
+++ b/e2e-tests/test/app-launch.e2e.ts
@@ -30,7 +30,26 @@ import * as S from '../helpers/selectors'
  */
 const TEST_VIDEO_URL = 'https://www.bilibili.com/video/BV1i3411y7xB'
 
+/**
+ * End-to-end test suite for the bilibili-downloader-gui application.
+ *
+ * Executes a sequential, phase-based happy path through the app:
+ * Phase 0 - App launch and initialization sequence
+ * Phase 1 - Home page UI verification (URL input, alerts, sidebar)
+ * Phase 2 - Settings dialog interactions (currently skipped, see notes)
+ * Phase 3 - Real video info fetch and part card rendering
+ *
+ * Tests within this suite are order-dependent; each `it` builds on state
+ * established by the previous one (e.g. video info loaded in Phase 3
+ * is reused by subsequent assertions).
+ */
 describe('bilibili-downloader-gui E2E', () => {
+  /**
+   * Suite-level setup executed once before any test runs.
+   *
+   * Ensures the screenshot output directory exists and maximizes the
+   * browser window so responsive layout assertions are stable.
+   */
   before(() => {
     ensureScreenshotDir()
     browser.maximizeWindow()
@@ -38,15 +57,9 @@ describe('bilibili-downloader-gui E2E', () => {
 
   // -- Phase 0: App Launch & Initialization --
 
-  it('should show initialization page on launch', async () => {
+  it('should show splash screen on launch', async () => {
     const container = await browser.$(S.INIT_CONTAINER)
     await container.waitForExist({ timeout: 15_000 })
-
-    const spinner = await browser.$(S.INIT_SPINNER)
-    expect(await spinner.isExisting()).to.be.true
-
-    const statusText = await browser.$(S.INIT_STATUS_TEXT)
-    expect(await statusText.isExisting()).to.be.true
 
     await saveScreenshot('launch', '00-init-page')
   })

--- a/src/features/splash/ui/SplashScreen.tsx
+++ b/src/features/splash/ui/SplashScreen.tsx
@@ -28,16 +28,28 @@ export function SplashScreen() {
 
   if (phase === 'done') return null
 
-  // Show blank splash background while settings are loading (prevents
-  // circle-indicator flash before the 3D animation starts)
+  // Rendering branch 1 of 3: settings still loading.
+  // Renders a blank splash background while settings are loading to prevent
+  // the circle-indicator flash that would otherwise appear before the 3D
+  // animation is ready to mount.
   if (skipMode === null) {
-    return <div className="fixed inset-0 z-50 bg-[#f5f7fa]" />
+    return (
+      <div
+        data-testid="splash-screen"
+        className="fixed inset-0 z-50 bg-[#f5f7fa]"
+      />
+    )
   }
 
-  // Show minimal spinner when skip mode is active
+  // Rendering branch 2 of 3: skip mode active.
+  // Renders a minimal CSS spinner instead of the full 3D animation to
+  // minimize startup time when the user has opted out of the animation.
   if (skipMode === true) {
     return (
-      <div className="bg-background fixed inset-0 z-50 flex flex-col items-center justify-center">
+      <div
+        data-testid="splash-screen"
+        className="bg-background fixed inset-0 z-50 flex flex-col items-center justify-center"
+      >
         <div className="border-foreground/20 border-t-foreground h-8 w-8 animate-spin rounded-full border-2" />
         {processingFnc && (
           <p className="text-muted-foreground mt-4 text-sm select-none">
@@ -48,11 +60,15 @@ export function SplashScreen() {
     )
   }
 
+  // Rendering branch 3 of 3: full animation mode.
+  // Renders the complete splash experience: Three.js canvas, title heading,
+  // current initialization step label, and an optional progress bar.
   const activeProgress = progress.find((p) => !p.isComplete)
   const pct = activeProgress?.percentage ?? 0
 
   return (
     <div
+      data-testid="splash-screen"
       className={cn(
         'fixed inset-0 z-50 flex flex-col items-center justify-center',
         'bg-[#f5f7fa]',
@@ -61,6 +77,9 @@ export function SplashScreen() {
       )}
       style={{ transitionDuration: `${FADE_DURATION_MS}ms` }}
       onTransitionEnd={function handleTransitionEnd(e) {
+        // Only react to the opacity transition bubbling up from the root
+        // container itself (not from child elements) to signal that the
+        // fade-out animation has completed and the splash can unmount.
         if (e.target === e.currentTarget && e.propertyName === 'opacity') {
           onFadeComplete()
         }


### PR DESCRIPTION
## Summary

- Fixes the `should show initialization page on launch` E2E test that has been failing 100% since the `SplashScreen` component replaced the old `InitPage` in PR #395
- Adds `data-testid="splash-screen"` to all three rendering branches of `SplashScreen` (settings-loading, skip-mode, full-animation)
- Updates the E2E selector to target the testid instead of CSS classes, decoupling the test from class variations across rendering modes

## Root Cause

The test selector `.flex.h-full.w-full.items-center.justify-center` matched the old `InitPage` container but not the new `SplashScreen`, whose container uses `flex flex-col items-center justify-center` without `h-full w-full`. This caused the test to time out (15s) waiting for an element that never appears, while all other tests passed.

## Changes

- `src/features/splash/ui/SplashScreen.tsx`: Add `data-testid="splash-screen"` to all three rendering branches
- `e2e-tests/helpers/selectors.ts`: Replace `INIT_CONTAINER` value with `[data-testid="splash-screen"]`; remove unused `INIT_SPINNER` and `INIT_STATUS_TEXT` (they were skip-mode-specific and the source of flakiness)
- `e2e-tests/test/app-launch.e2e.ts`: Simplify test to only verify the splash container exists; rename test to `should show splash screen on launch`

## Test plan

- [ ] E2E Tests workflow passes on CI (the previously failing test now passes)
- [ ] Other E2E tests continue to pass (no regression)
- [ ] SplashScreen still renders correctly in all three modes (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)