### PR TITLE
ci: add caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +19,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,10 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.8.0
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -39,6 +39,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,10 +48,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.8.0
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -61,6 +59,7 @@ jobs:
   frontend-build:
     name: Frontend Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,10 +68,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.8.0
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -83,6 +79,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,10 +88,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.8.0
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -111,12 +105,18 @@ jobs:
   rust-check:
     name: Rust Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)
         run: |
@@ -130,12 +130,18 @@ jobs:
   rust-clippy:
     name: Rust Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)
         run: |
@@ -149,12 +155,18 @@ jobs:
   rust-format:
     name: Rust Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)
         run: |
@@ -168,6 +180,7 @@ jobs:
   docs-format:
     name: Docs Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -176,8 +189,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: npm
-          cache-dependency-path: docs/package-lock.json
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            docs/package-lock.json
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            docs/node_modules
+            !docs/node_modules/.cache
+          key: docs-${{ runner.os }}-npm-${{ hashFiles('docs/package-lock.json') }}
+          restore-keys: |
+            docs-${{ runner.os }}-npm-
+            docs-${{ runner.os }}-
 
       - name: Install dependencies
         working-directory: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-nm-format
+        with:
+          path: node_modules
+          key: nm-format-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-nm-format.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Check formatting
@@ -48,9 +55,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-nm-lint
+        with:
+          path: node_modules
+          key: nm-lint-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-nm-lint.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run ESLint
@@ -68,9 +82,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-nm-build
+        with:
+          path: node_modules
+          key: nm-build-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-nm-build.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Type check and build
@@ -88,9 +109,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-nm-test
+        with:
+          path: node_modules
+          key: nm-test-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-nm-test.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run tests
@@ -189,23 +217,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            docs/package-lock.json
 
-      - name: Cache dependencies
+      - name: Cache docs/node_modules
         uses: actions/cache@v4
+        id: cache-nm-docs
         with:
-          path: |
-            docs/node_modules
-            !docs/node_modules/.cache
-          key: docs-${{ runner.os }}-npm-${{ hashFiles('docs/package-lock.json') }}
-          restore-keys: |
-            docs-${{ runner.os }}-npm-
-            docs-${{ runner.os }}-
+          path: docs/node_modules
+          key: nm-docs-${{ runner.os }}-${{ hashFiles('docs/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-nm-docs.outputs.cache-hit != 'true'
         working-directory: docs
         run: npm ci
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,16 @@ jobs:
         working-directory: e2e-tests
         run: npm ci
 
+      - name: Cache tauri-webdriver
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-webdriver
+          key: tauri-webdriver-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            tauri-webdriver-${{ runner.os }}-
+
       - name: Install tauri-webdriver
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install tauri-webdriver --locked
 
       - name: Build Tauri app (debug)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,15 +45,14 @@ jobs:
         run: npm ci
 
       - name: Cache tauri-webdriver
+        id: cache-tw
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/tauri-webdriver
-          key: tauri-webdriver-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            tauri-webdriver-${{ runner.os }}-
+          key: tauri-webdriver-${{ runner.os }}-v1
 
       - name: Install tauri-webdriver
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-tw.outputs.cache-hit != 'true'
         run: cargo install tauri-webdriver --locked
 
       - name: Build Tauri app (debug)


### PR DESCRIPTION
## Summary

- Add caching strategies to GitHub Actions workflows to improve CI performance
- Implement node_modules caching for Node.js jobs
- Add Rust dependencies caching with shared-key
- Cache tauri-webdriver binary for E2E tests
- Remove unnecessary npm upgrade commands
- Add job timeouts for better resource management

## Changes

### ci.yml
- Added `push: main` trigger for cache warming
- Added `actions/cache@v4` for node_modules in format, lint, frontend-build, and test jobs
- Added `Swatinem/rust-cache@v2` for Rust jobs with shared-key: rust-ci
- Added separate cache for docs/node_modules in docs-format job
- Removed `npm install -g npm@11.8.0` commands
- Added `timeout-minutes` to all jobs (10-20 minutes)

### e2e.yml
- Added `actions/cache@v4` for tauri-webdriver binary
- Implemented conditional installation based on cache hit

## Test plan

- Verify PR triggers CI on push and pull_request
- Confirm caches are properly restored and populated
- Monitor CI execution time improvements
- Ensure no functionality regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)