### PR TITLE
docs: rebuild CLAUDE.md to follow best practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,13 @@
 
 ## 必須ルール（gotcha）
 
-### shadcn/ui / animate-ui
+### shadcn/ui
 
 **IMPORTANT**: UI コンポーネントファイルを手動作成しないこと。必ず以下でインストール:
 
 ```bash
 npx shadcn@latest add <component>
 ```
-
-animate-ui コンポーネントも shadcn MCP（`@animate-ui` registry）経由で追加すること。
 
 ### i18n（多言語対応）
 
@@ -58,12 +56,13 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 
 ## 動作確認前チェック
 
-ユーザー動確前に以下を満たすこと（動確は原則ヒトが行う）:
-
-- `npm run lint` がエラーなし
-- `src-tauri/` で `cargo build` が通る（コンパイルエラー時は同ディレクトリで
-  `cargo build` を実行し詳細確認）
-- 開発サーバー起動問題時は `@hypothesi/tauri-mcp-server` でログ・DOM 要素を取得
+- `@hypothesi/tauri-mcp-server` を利用してログや HTML 要素取得を行うこと
+- 動確前は以下をチェックすること
+  - `npm run lint` でエラーがないこと
+  - `cargo build` でコンパイルが通ること
+- 動確は原則、ヒトが行う
+- `animate-ui` コンポーネントについては `shadcn` mcp を利用すること
+- Rust のコンパイルエラー → `src-tauri/` で `cargo build` を実行しエラー詳細を確認
 
 ## 参照（必要時に読む）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,200 +1,73 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+本リポジトリで Claude Code が作業する際の必須ルール。アーキテクチャ・コードスタイル・
+ブランチ/コミット規約は CONTRIBUTING.md を参照。
 
-## プロジェクト概要
+## コマンド
 
-Bilibili動画ダウンローダーのデスクトップアプリケーション。フロントエンドはReact + Vite + TypeScript、バックエンドはTauri (Rust)で構築されたクロスプラットフォームアプリ。
+| コマンド              | 用途                        |
+| --------------------- | --------------------------- |
+| `npm run tauri dev`   | Tauri アプリ起動（HMR）     |
+| `npm run dev`         | フロントのみ（Vite）        |
+| `npm run build`       | 型チェック + ビルド         |
+| `npm run typecheck`   | TypeScript 型チェック       |
+| `npm run lint`        | ESLint                      |
+| `npm run test`        | Vitest 実行                 |
+| `npm run tauri build` | 配布バイナリ作成            |
+| `cargo build` / `fmt` | Rust（`src-tauri/` で実行） |
 
-## アーキテクチャ
+## 必須ルール（gotcha）
 
-### フロントエンド構造 (src/)
+### shadcn/ui / animate-ui
 
-**Feature-based Co-location**アーキテクチャを採用。
-
-```
-src/
-├── app/                      # アプリケーション設定
-│   ├── providers/            # グローバルProvider (Theme, Listener)
-│   └── store/                # Redux store設定
-├── pages/                    # ルートレベル画面
-├── features/                 # 機能モジュール
-│   └── {feature}/
-│       ├── ui/               # プレゼンテーションコンポーネント
-│       ├── model/            # Redux slice, selectors, types
-│       ├── hooks/            # カスタムフック
-│       ├── api/              # 外部API呼び出し
-│       ├── lib/              # ユーティリティ、定数
-│       └── index.ts          # Public API
-├── shared/                   # 横断的共通リソース
-│   ├── ui/                   # shadcn/ui, 共通UI
-│   ├── hooks/                # 共通フック
-│   └── lib/                  # 共通ユーティリティ
-├── i18n/                     # 多言語対応
-└── styles/                   # グローバルスタイル
-```
-
-**設計パターン**:
-
-- **Redux Toolkit**: 状態管理にはすべて`@reduxjs/toolkit`を使用
-- **Public API**: 各featureの`index.ts`経由でインポート（深いパスは避ける）
-- **Shared modules**: `shared/`は横断的なUI/ユーティリティのみ（ドメインロジックは`features/`へ）
-- **Path alias**: `@/`で`src/`を参照
-
-**インポートルール**:
-
-- `pages` → `features`, `shared` からインポート可
-- `features` → `pages` からインポート禁止
-- `features` → 他の`features` からの直接インポートは避ける
-- `index.ts` (Public API) 経由でインポートすることを推奨
-
-### フロントエンド ↔ バックエンド通信
-
-```typescript
-// フロントエンド (TypeScript)
-import { invoke } from '@tauri-apps/api/core'
-
-const result = await invoke<Video>('fetch_video_info', {
-  videoId: 'BV1234567890',
-})
-```
-
-```rust
-// バックエンド (Rust)
-#[tauri::command]
-async fn fetch_video_info(app: AppHandle, video_id: String) -> Result<Video, String> {
-    bilibili::fetch_video_info(&app, &video_id)
-        .await
-        .map_err(|e| e.to_string())
-}
-```
-
-**重要**:
-
-- Rust側の関数名とTypeScript側の文字列は一致させる（snake_case）
-- すべてのcommandは`lib.rs`の`invoke_handler`に登録が必要
-- 複雑な型は`models/`でserialize/deserialize可能な構造体として定義
-
-## 重要なルール
-
-### shadcn/uiコンポーネント
-
-**絶対に手動でコンポーネントファイルを作成しない**。必ず以下のコマンド経由でインストール:
+**IMPORTANT**: UI コンポーネントファイルを手動作成しないこと。必ず以下でインストール:
 
 ```bash
 npx shadcn@latest add <component>
 ```
 
-### コードスタイル
+animate-ui コンポーネントも shadcn MCP（`@animate-ui` registry）経由で追加すること。
 
-- **TypeScript**: スペース2文字インデント、Prettier + ESLint
-- **Rust**: `cargo fmt`のデフォルト設定
-- **行の長さ**: 最大80文字 (可能な限り)
-- **インポート順**: Prettierの`prettier-plugin-organize-imports`で自動整理
+### i18n（多言語対応）
 
-### 多言語対応 (i18n)
+- ユーザー向けテキストは必ず `react-i18next` 経由
+- 翻訳キー命名: `{feature}.{description}`（例: `video.video_not_found`）
+- **IMPORTANT**: いずれかの言語ファイルにキーを追加・変更する場合は、
+  **全6言語（`en`/`ja`/`zh`/`ko`/`es`/`fr`）に同じ変更を適用**すること。
+  一部のみの追加は実行時エラーの原因。検証:
 
-- すべてのユーザー向けテキストは`react-i18next`経由で表示
-- 翻訳キーは`src/i18n/locales/{lang}/translation.json`に追加
-- 翻訳キー命名: `{feature}.{description}`形式（例: `video.video_not_found`）
-
-#### 翻訳ファイルの変更ルール
-
-**絶対ルール**: いずれかの言語ファイルにキーを追加・変更する場合、**すべての言語ファイル**に同じ変更を適用すること
-
-- **対象言語**: `en`, `ja`, `zh`, `ko`, `es`, `fr`
-- **検証方法**: 変更後に各言語ファイルのキー数が同一であることを確認
-- **確認コマンド**:
   ```bash
-  for f in src/i18n/locales/*.json; do
-    echo "$f: $(grep -c '":' "$f")"
-  done
+  for f in src/i18n/locales/*.json; do echo "$f: $(grep -c '":' "$f")"; done
   ```
-- **禁止事項**: 一部の言語のみにキーを追加すること（実行時エラーの原因となる）
 
-#### エラーコードマッピング
+- バックエンドの `ERR::*` エラーコードは翻訳キーへマッピング
+  （例: `ERR::VIDEO_NOT_FOUND` → `video.video_not_found`）
 
-バックエンドから返される`ERR::*`形式のエラーコードをフロントエンドで翻訳キーにマッピング:
+### Tauri command（フロント ↔ バック）
 
-```typescript
-const ERROR_MAP: Record<string, string> = {
-  'ERR::VIDEO_NOT_FOUND': 'video.video_not_found',
-  'ERR::COOKIE_MISSING': 'video.cookie_missing',
-  'ERR::API_ERROR': 'video.api_error',
-  // ...
-}
-```
+- Rust command 名と TS 側 `invoke()` の文字列は一致（snake_case）
+- 新規 command は `src-tauri/src/lib.rs` の `invoke_handler`
+  （`generate_handler!`）に登録が必須
+- 開発専用機能は `#[cfg(debug_assertions)]` で分離
 
-### Redux/Hook設計指針
-
-- **Slice**: 単純な状態のみ管理。複雑なロジックはhookに分離
-- **Selector**: 基本的なselectorは直接stateから取得、計算が必要な場合は`createSelector`を使用
-- **Hook**: 状態管理ロジックをカプセル化し、コンポーネントからは純粋なUI処理のみを行わせる
-- **禁止**: sliceファイル内での複雑なビジネスロジック、コンポーネント内での直接的なdispatch
-
-### バックエンド (Rust) 設計指針
-
-- **グローバルステート**: `app.manage()`で登録、`app.try_state::<T>()`でアクセス
-- **データ永続化**: `tauri-plugin-store`を使用（例: HistoryStore）
-- **開発モード制御**: `#[cfg(debug_assertions)]`で開発専用機能を分離
-- **DTO命名**: `#[serde(rename_all = "camelCase")]`でフロントエンドと整合
-- **エラーコード**: `ERR::*`形式で定義（例: `ERR::COOKIE_MISSING`）
-
-## テスト
-
-### フロントエンド
-
-- **フレームワーク**: Vitest + React Testing Library
-- **テスト環境**: happy-dom
-- **配置**: `src/__tests__/` および feature内の`.test.ts`ファイル
-
-### Tauri APIモックパターン
+### Tauri API モック（テスト）
 
 ```typescript
-import { vi } from 'vitest'
-
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
-}))
-
-// テスト内でモックを設定
-const mockInvoke = invoke as unknown as ReturnType<typeof vi.fn>
-mockInvoke.mockResolvedValue({ data: 'test' })
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 ```
 
-### バックエンド
+## 動作確認前チェック
 
-- **フレームワーク**: Rust標準`#[cfg(test)]` + `cargo test`
+ユーザー動確前に以下を満たすこと（動確は原則ヒトが行う）:
 
-## トラブルシューティング
+- `npm run lint` がエラーなし
+- `src-tauri/` で `cargo build` が通る（コンパイルエラー時は同ディレクトリで
+  `cargo build` を実行し詳細確認）
+- 開発サーバー起動問題時は `@hypothesi/tauri-mcp-server` でログ・DOM 要素を取得
 
-### 開発サーバーが起動しない
+## 参照（必要時に読む）
 
-- Viteのポート1420が使用中 → 他のプロセスを終了
-- Rustのコンパイルエラー → `src-tauri/`で`cargo build`を実行してエラー詳細を確認
-
-### Cookie取得が失敗する
-
-- Firefox DBファイルのロック → Firefoxを一度終了してから再試行
-- プロファイル位置: macOS `~/Library/Application Support/Firefox/Profiles/`
-
-### ffmpegが見つからない
-
-- `validate_ffmpeg` commandで確認 → `install_ffmpeg` commandで自動ダウンロード
-
-### 設定ファイルの初期化エラー
-
-- **エラーコード 6**: 設定ファイル読み込み失敗
-- **対処法**: アプリを再起動（エラーページに再起動ボタン表示）
-
-### ダウンロード関連のエラー
-
-- **低速CDN**: 初期1MBの速度が1MB/s未満の場合、自動的にCDN切り替え（最大5回）
-- **ディスク容量不足**: `ERR::DISK_FULL` - ダウンロード先に十分な空き容量を確保
-
-## 参考リンク
-
-- [Tauri公式ドキュメント](https://tauri.app/)
-- [shadcn/ui](https://ui.shadcn.com/)
-- [Redux Toolkit](https://redux-toolkit.js.org/)
-- bilibili APIを使用する際は `references/bilibili-API-collect/` を参照
+- **CONTRIBUTING.md** — アーキテクチャ・ディレクトリ構造・インポートルール・
+  コードスタイル・ブランチ/コミット規約
+- **README.md** — プロジェクト概要・機能一覧
+- **references/bilibili-API-collect/** — bilibili API 仕様

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,76 @@
 # CLAUDE.md
 
-本リポジトリで Claude Code が作業する際の必須ルール。アーキテクチャ・コードスタイル・
-ブランチ/コミット規約は CONTRIBUTING.md を参照。
+Essential rules for Claude Code when working in this repository. For
+architecture, code style, and branch/commit conventions, see
+CONTRIBUTING.md.
 
-## コマンド
+## Commands
 
-| コマンド              | 用途                        |
-| --------------------- | --------------------------- |
-| `npm run tauri dev`   | Tauri アプリ起動（HMR）     |
-| `npm run dev`         | フロントのみ（Vite）        |
-| `npm run build`       | 型チェック + ビルド         |
-| `npm run typecheck`   | TypeScript 型チェック       |
-| `npm run lint`        | ESLint                      |
-| `npm run test`        | Vitest 実行                 |
-| `npm run tauri build` | 配布バイナリ作成            |
-| `cargo build` / `fmt` | Rust（`src-tauri/` で実行） |
+| Command               | Purpose                      |
+| --------------------- | ---------------------------- |
+| `npm run tauri dev`   | Launch Tauri app (HMR)       |
+| `npm run dev`         | Frontend only (Vite)         |
+| `npm run build`       | Type-check + build           |
+| `npm run typecheck`   | TypeScript type check        |
+| `npm run lint`        | ESLint                       |
+| `npm run test`        | Run Vitest                   |
+| `npm run tauri build` | Build distributable binaries |
+| `cargo build` / `fmt` | Rust (run in `src-tauri/`)   |
 
-## 必須ルール
+## Required Rules
 
 ### shadcn/ui
 
-**IMPORTANT**: UI コンポーネントファイルを手動作成しないこと。必ず以下でインストール:
+**IMPORTANT**: Never create component files by hand. Always install via:
 
 ```bash
 npx shadcn@latest add <component>
 ```
 
-### i18n（多言語対応）
+### i18n (Internationalization)
 
-- ユーザー向けテキストは必ず `react-i18next` 経由
-- 翻訳キー命名: `{feature}.{description}`（例: `video.video_not_found`）
-- **IMPORTANT**: いずれかの言語ファイルにキーを追加・変更する場合は、
-  **全6言語（`en`/`ja`/`zh`/`ko`/`es`/`fr`）に同じ変更を適用**すること。
-  一部のみの追加は実行時エラーの原因。検証:
+- All user-facing text must go through `react-i18next`
+- Translation key naming: `{feature}.{description}` (e.g.,
+  `video.video_not_found`)
+- **IMPORTANT**: When adding or changing a key in any language file,
+  apply the same change to **all 6 languages
+  (`en`/`ja`/`zh`/`ko`/`es`/`fr`)**. Adding to only some languages causes
+  runtime errors. Verify:
 
   ```bash
   for f in src/i18n/locales/*.json; do echo "$f: $(grep -c '":' "$f")"; done
   ```
 
-- バックエンドの `ERR::*` エラーコードは翻訳キーへマッピング
-  （例: `ERR::VIDEO_NOT_FOUND` → `video.video_not_found`）
+- Map backend `ERR::*` error codes to translation keys (e.g.,
+  `ERR::VIDEO_NOT_FOUND` → `video.video_not_found`)
 
-### Tauri command（フロント ↔ バック）
+### Tauri Commands (Frontend ↔ Backend)
 
-- Rust command 名と TS 側 `invoke()` の文字列は一致（snake_case）
-- 新規 command は `src-tauri/src/lib.rs` の `invoke_handler`
-  （`generate_handler!`）に登録が必須
-- 開発専用機能は `#[cfg(debug_assertions)]` で分離
+- The Rust command name must match the string passed to `invoke()` on
+  the TS side (snake_case)
+- New commands must be registered in the `invoke_handler`
+  (`generate_handler!`) in `src-tauri/src/lib.rs`
+- Gate dev-only features behind `#[cfg(debug_assertions)]`
 
-### Tauri API モック（テスト）
+### Tauri API Mock (tests)
 
 ```typescript
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 ```
 
-## 動作確認前チェック
+## Pre-verification Checklist
 
-- `@hypothesi/tauri-mcp-server` を利用してログや HTML 要素取得を行うこと
-- 動確前は以下をチェックすること
-  - `npm run lint` でエラーがないこと
-  - `cargo build` でコンパイルが通ること
-- 動確は原則、ヒトが行う
-- `animate-ui` コンポーネントについては `shadcn` mcp を利用すること
-- Rust のコンパイルエラー → `src-tauri/` で `cargo build` を実行しエラー詳細を確認
+- Use `@hypothesi/tauri-mcp-server` to retrieve logs and HTML elements
+- Before user verification, check the following:
+  - `npm run lint` has no errors
+  - `cargo build` compiles successfully
+- Verification is performed by a human, as a rule
+- For `animate-ui` components, use the `shadcn` MCP
+- For Rust compile errors → run `cargo build` in `src-tauri/` for details
 
-## 参照（必要時に読む）
+## References (read on demand)
 
-- **CONTRIBUTING.md** — アーキテクチャ・ディレクトリ構造・インポートルール・
-  コードスタイル・ブランチ/コミット規約
-- **README.md** — プロジェクト概要・機能一覧
-- **references/bilibili-API-collect/** — bilibili API 仕様
+- **CONTRIBUTING.md** — architecture, directory structure, import rules,
+  code style, branch/commit conventions
+- **README.md** — project overview, feature list
+- **references/bilibili-API-collect/** — bilibili API reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 | `npm run tauri build` | 配布バイナリ作成            |
 | `cargo build` / `fmt` | Rust（`src-tauri/` で実行） |
 
-## 必須ルール（gotcha）
+## 必須ルール
 
 ### shadcn/ui
 


### PR DESCRIPTION
## Summary

Rebuilt `CLAUDE.md` from scratch following [Anthropic's official best practices](https://code.claude.com/docs/en/best-practices), reducing it from **200 → 73 lines**.

The guiding question: _"Would removing this cause Claude to make mistakes?"_

## Changes

- **Removed** content Claude can infer from code — directory tree, design patterns, import rules, communication code examples, Redux/Hook & backend design guidelines
- **Moved** architecture, code style, and branch/commit rules to `CONTRIBUTING.md` (already comprehensive and more accurate) via **link reference** instead of duplicating
- **Kept** only non-obvious gotchas Claude cannot infer:
  - shadcn/ui manual creation ban
  - i18n 6-language sync rule (causes runtime error if missed)
  - `ERR::*` error code → translation key mapping
  - Tauri command registration (snake_case match, `invoke_handler`, debug-only)
- **Folded in** prior uncommitted edits: animate-ui via shadcn MCP, "verification done by human"

## Design decision

Chose **link reference** over `@import` for `CONTRIBUTING.md` (325 lines) so the per-session context load stays minimal — aligns with the ~100-line body goal. Commands are written inline (non-guessable Bash); architecture details are read on demand.

## Verification

- [x] `npm run format:check` passes (all files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)