### PR TITLE
feat(appbar): add separator between GitHub stars and language switcher

### DIFF
--- a/src/shared/ui/AppBar/AppBar.tsx
+++ b/src/shared/ui/AppBar/AppBar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/shared/animate-ui/radix/tooltip'
 import { Button } from '@/shared/ui/button'
 import { GitHubStars } from '@/shared/ui/GitHubStars'
+import { Separator } from '@/shared/ui/separator'
 import { QrCode, UserRound } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -96,7 +97,18 @@ function AppBar({ user, theme, setTheme }: Props) {
         </div>
         <div className="flex items-center gap-3">
           {showGithubStars && (
-            <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />
+            <>
+              <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />
+              {/*
+               * Constraint: keep the `data-[orientation=vertical]:` variant. A plain `h-4`
+               * loses CSS specificity to shadcn's default `data-[orientation=vertical]:h-full`
+               * and collapses to height:0 (invisible). See src/shared/ui/separator.tsx.
+               */}
+              <Separator
+                orientation="vertical"
+                className="data-[orientation=vertical]:h-4"
+              />
+            </>
           )}
           <LanguageSwitcher />
           <ToggleThemeButton theme={theme} setTheme={setTheme} />


### PR DESCRIPTION
## Summary

Add a vertical separator between the GitHub stars count and the language switcher in the AppBar to visually group the controls. Uses the existing shadcn `Separator` (`@/shared/ui/separator`).

Implementation note: the height is set via `data-[orientation=vertical]:h-4` rather than a plain `h-4`. shadcn's `Separator` ships `data-[orientation=vertical]:h-full`, which has higher CSS specificity than `h-4`; a plain `h-4` loses to it and collapses to `height:0` (invisible) because the parent flex row has no explicit height. Matching the same variant is the only way to override it.

`animate-ui` was originally considered for this, but its registry has no separator/divider component (verified across all 580 items), so the existing shadcn Separator is used instead.

## Related Issue

None.

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] Run `npm run tauri dev`
- [x] Verify a vertical separator renders between GitHub stars and the language switcher
- [x] Toggle "show GitHub stars" off in settings and confirm the separator also disappears

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (minor UI addition)
- [x] i18n files synced — N/A (no user-facing text added)