### PR TITLE
refactor: unify sub-page UI frame with PageTemplate

### DIFF
--- a/src/features/favorite/ui/FavoriteList.tsx
+++ b/src/features/favorite/ui/FavoriteList.tsx
@@ -107,7 +107,8 @@ function FavoriteList({
         }
       }}
       itemContent={(_index, video) => (
-        <div className="py-1">
+        // Why: pr-3 reserves space so the Virtuoso scrollbar gutter does not overlap the right-aligned download button on each FavoriteItem.
+        <div className="py-1 pr-3">
           <FavoriteItem
             video={video}
             onDownload={onDownload}

--- a/src/features/history/ui/HistoryList.tsx
+++ b/src/features/history/ui/HistoryList.tsx
@@ -82,7 +82,8 @@ function HistoryList({
       style={{ height: '100%' }}
       data={entries}
       itemContent={(_index, entry) => (
-        <div key={entry.id} className="py-1">
+        // Why: pr-3 reserves space so the Virtuoso scrollbar gutter does not overlap the right-aligned action buttons on each HistoryItem.
+        <div key={entry.id} className="py-1 pr-3">
           <HistoryItem
             entry={entry}
             onDelete={() => onDelete(entry.id)}

--- a/src/features/watch-history/ui/WatchHistoryList.tsx
+++ b/src/features/watch-history/ui/WatchHistoryList.tsx
@@ -74,7 +74,8 @@ export function WatchHistoryList({
       style={{ height: '100%' }}
       data={entries}
       itemContent={(_index, entry) => (
-        <div className="py-1">
+        // Why: pr-3 reserves space so the Virtuoso scrollbar gutter does not overlap the right-aligned download button on each WatchHistoryItem.
+        <div className="py-1 pr-3">
           <WatchHistoryItem
             entry={entry}
             onDownload={onDownload}

--- a/src/pages/concat/index.tsx
+++ b/src/pages/concat/index.tsx
@@ -1,4 +1,5 @@
 import { ConcatForm } from '@/features/concat'
+import { PageTemplate } from '@/shared/layout'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -16,17 +17,14 @@ export function ConcatContent() {
   }, [t])
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="border-border shrink-0 border-b p-3">
-        <h1 className="text-xl font-semibold">{t('concat.title')}</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          {t('concat.description')}
-        </p>
-      </div>
-      <div className="min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto px-4 pt-2 pb-4 sm:px-6 sm:pt-3 sm:pb-6">
+    <PageTemplate
+      title={t('concat.title')}
+      description={t('concat.description')}
+    >
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
         <ConcatForm />
       </div>
-    </div>
+    </PageTemplate>
   )
 }
 

--- a/src/pages/favorite/index.tsx
+++ b/src/pages/favorite/index.tsx
@@ -4,6 +4,7 @@ import type { FavoriteVideo } from '@/features/favorite/types'
 import FavoriteList from '@/features/favorite/ui/FavoriteList'
 import FolderSelector from '@/features/favorite/ui/FolderSelector'
 import { usePendingDownload } from '@/shared/hooks/usePendingDownload'
+import { PageTemplate } from '@/shared/layout'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import { Button } from '@/shared/ui/button'
 import { RefreshCw } from 'lucide-react'
@@ -85,10 +86,10 @@ export function FavoriteContent() {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="border-border shrink-0 border-b p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-xl font-semibold">{t('favorite.title')}</h1>
+    <PageTemplate
+      title={t('favorite.title')}
+      actions={
+        <>
           <div className="flex flex-1 items-center gap-2">
             <FolderSelector
               folders={folders}
@@ -97,7 +98,6 @@ export function FavoriteContent() {
               loading={foldersLoading}
             />
           </div>
-
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -109,9 +109,9 @@ export function FavoriteContent() {
               <span className="hidden md:inline">{t('favorite.refresh')}</span>
             </Button>
           </div>
-        </div>
-      </div>
-
+        </>
+      }
+    >
       <div className="min-h-0 flex-1">
         <FavoriteList
           videos={videos}
@@ -123,7 +123,7 @@ export function FavoriteContent() {
           disabled={hasActiveDownloads}
         />
       </div>
-    </div>
+    </PageTemplate>
   )
 }
 

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -6,6 +6,7 @@ import HistoryFilters from '@/features/history/ui/HistoryFilters'
 import HistoryList from '@/features/history/ui/HistoryList'
 import HistorySearch from '@/features/history/ui/HistorySearch'
 import { usePendingDownload } from '@/shared/hooks/usePendingDownload'
+import { PageTemplate } from '@/shared/layout'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import { Button } from '@/shared/ui/button'
 import { confirm, save } from '@tauri-apps/plugin-dialog'
@@ -122,10 +123,10 @@ export function HistoryContent() {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="border-border shrink-0 border-b p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-xl font-semibold">{t('nav.downloadHistory')}</h1>
+    <PageTemplate
+      title={t('nav.downloadHistory')}
+      actions={
+        <>
           <div className="flex flex-1 items-center gap-2">
             <HistorySearch value={searchQuery} onChange={setSearch} />
             <HistoryFilters
@@ -133,7 +134,6 @@ export function HistoryContent() {
               onChange={(status) => updateFilters({ status })}
             />
           </div>
-
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -155,9 +155,9 @@ export function HistoryContent() {
               <span className="hidden md:inline">{t('history.clearAll')}</span>
             </Button>
           </div>
-        </div>
-      </div>
-
+        </>
+      }
+    >
       <div className="min-h-0 flex-1">
         <HistoryList
           entries={entries}
@@ -173,7 +173,7 @@ export function HistoryContent() {
         onOpenChange={setExportDialogOpen}
         onExport={handleExport}
       />
-    </div>
+    </PageTemplate>
   )
 }
 

--- a/src/pages/trim/index.tsx
+++ b/src/pages/trim/index.tsx
@@ -1,4 +1,5 @@
 import { TrimForm } from '@/features/trim'
+import { PageTemplate } from '@/shared/layout'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -16,17 +17,11 @@ export function TrimContent() {
   }, [t])
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="border-border shrink-0 border-b p-3">
-        <h1 className="text-xl font-semibold">{t('trim.title')}</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          {t('trim.description')}
-        </p>
-      </div>
-      <div className="min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto px-4 pt-2 pb-4 sm:px-6 sm:pt-3 sm:pb-6">
+    <PageTemplate title={t('trim.title')} description={t('trim.description')}>
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
         <TrimForm />
       </div>
-    </div>
+    </PageTemplate>
   )
 }
 

--- a/src/pages/watch-history/index.tsx
+++ b/src/pages/watch-history/index.tsx
@@ -7,6 +7,7 @@ import {
   WatchHistorySearch,
 } from '@/features/watch-history'
 import { usePendingDownload } from '@/shared/hooks/usePendingDownload'
+import { PageTemplate } from '@/shared/layout'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import { Alert, AlertDescription } from '@/shared/ui/alert'
 import { Button } from '@/shared/ui/button'
@@ -97,10 +98,10 @@ export function WatchHistoryContent() {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="border-border shrink-0 border-b p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-xl font-semibold">{t('watchHistory.title')}</h1>
+    <PageTemplate
+      title={t('watchHistory.title')}
+      actions={
+        <>
           <div className="flex flex-1 items-center gap-2">
             <WatchHistorySearch value={searchQuery} onChange={setSearch} />
             <WatchHistoryFilters value={dateFilter} onChange={setDate} />
@@ -118,12 +119,13 @@ export function WatchHistoryContent() {
               </span>
             </Button>
           </div>
-        </div>
-      </div>
-
+        </>
+      }
+    >
       {/* Error */}
+      {/* Why: render OUTSIDE the virtualized list's flex-1 wrapper so the Alert is a sibling, not a list item. shrink-0 keeps it from being squeezed by the min-h-0 flex-1 list below (commit 1c6b98f, watch-history refresh feature). */}
       {error && (
-        <Alert variant="destructive" className="m-3">
+        <Alert variant="destructive" className="my-3 shrink-0">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{error}</AlertDescription>
         </Alert>
@@ -141,7 +143,7 @@ export function WatchHistoryContent() {
           disabled={hasActiveDownloads}
         />
       </div>
-    </div>
+    </PageTemplate>
   )
 }
 

--- a/src/shared/layout/PageLayout.tsx
+++ b/src/shared/layout/PageLayout.tsx
@@ -24,23 +24,10 @@ import { cn } from '@/shared/lib/utils'
 import AppBar from '@/shared/ui/AppBar/AppBar'
 import { Button } from '@/shared/ui/button'
 import { NavigationSidebarHeader } from '@/shared/ui/NavigationSidebar'
-import { ScrollArea, ScrollBar } from '@/shared/ui/scroll-area'
 import { Archive, PanelLeft, PanelLeftClose } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
-
-/**
- * Props for PageLayout component.
- */
-export interface PageLayoutProps {
-  /** Page content to render */
-  children: ReactNode
-  /** Whether to wrap content in ScrollArea */
-  withScrollArea?: boolean
-  /** Additional className for the inner content wrapper */
-  innerClassName?: string
-}
 
 /**
  * Props for PageLayoutShell component.
@@ -152,71 +139,5 @@ export function PageLayoutShell({ children }: PageLayoutShellProps) {
       <DownloadStatusDialog />
       <SettingsDialog />
     </>
-  )
-}
-
-/**
- * Standardized page layout component with sidebar navigation.
- *
- * Provides consistent layout structure across all pages including:
- * - Collapsible sidebar with navigation
- * - App bar with user info and theme toggle
- * - Optional scrollable content area
- * - Centered content with max-width constraint
- *
- * This is a convenience wrapper around PageLayoutShell that provides
- * common content styling. For more control, use PageLayoutShell directly.
- *
- * @example
- * ```tsx
- * // With scroll area (default)
- * <PageLayout>
- *   <YourPageContent />
- * </PageLayout>
- *
- * // Without scroll area
- * <PageLayout withScrollArea={false}>
- *   <YourPageContent />
- * </PageLayout>
- *
- * // With custom classes
- * <PageLayout
- *   withScrollArea={false}
- *   innerClassName="gap-6"
- * >
- *   <YourPageContent />
- * </PageLayout>
- * ```
- */
-export function PageLayout({
-  children,
-  withScrollArea = true,
-  innerClassName,
-}: PageLayoutProps) {
-  const content = (
-    <div
-      className={cn(
-        'mx-auto flex w-full max-w-5xl flex-col gap-3 p-3 sm:px-6',
-        innerClassName,
-      )}
-    >
-      {children}
-    </div>
-  )
-
-  return (
-    <PageLayoutShell>
-      {withScrollArea ? (
-        <ScrollArea
-          style={{ height: 'calc(100dvh - 2.3rem)' }}
-          className="flex w-full"
-        >
-          {content}
-          <ScrollBar />
-        </ScrollArea>
-      ) : (
-        content
-      )}
-    </PageLayoutShell>
   )
 }

--- a/src/shared/layout/PageTemplate.tsx
+++ b/src/shared/layout/PageTemplate.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Props for PageTemplate component.
+ */
+export interface PageTemplateProps {
+  /** Page title rendered in the header <h1>. */
+  title: ReactNode
+  /** Optional description shown below the title (simple layout only). */
+  description?: ReactNode
+  /** Optional header actions slot. Enables the toolbar header layout. */
+  actions?: ReactNode
+  /** Page content rendered after the header (typically the body wrapper). */
+  children: ReactNode
+}
+
+/**
+ * Standardized per-page content frame for sub-pages.
+ *
+ * Unifies the layout skeleton shared by sub-pages: a centered
+ * (max-w-5xl) flex column with a header strip. Chrome (Sidebar / AppBar)
+ * is provided separately by PageLayoutShell; this template owns only the
+ * per-page frame rendered as the content inside it.
+ *
+ * Layout rules:
+ * - Header renders a simple title (+ optional description) when no `actions`,
+ *   or a responsive toolbar row (title / actions) when `actions` is provided.
+ * - `children` are rendered inside a body wrapper that shares the header's
+ *   horizontal padding (`px-4 sm:px-6`), so titles and content align. Each
+ *   page controls its body height/scroll via children (scrollable form,
+ *   virtualized list, or extra elements such as error banners).
+ *
+ * The root is `h-full` to stay compatible with PersistentPageLayout's
+ * `display:none` persistence strategy (keeps the template mounted but hidden).
+ *
+ * @example
+ * ```tsx
+ * // Simple form page (trim / concat)
+ * <PageTemplate title={t('trim.title')} description={t('trim.description')}>
+ *   <div className="min-h-0 flex-1 overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+ *     <TrimForm />
+ *   </div>
+ * </PageTemplate>
+ *
+ * // List page with toolbar actions (favorite / history / watch-history)
+ * <PageTemplate title={t('favorite.title')} actions={<ToolbarActions />}>
+ *   <div className="min-h-0 flex-1">
+ *     <FavoriteList />
+ *   </div>
+ * </PageTemplate>
+ * ```
+ */
+export function PageTemplate({
+  title,
+  description,
+  actions,
+  children,
+}: PageTemplateProps) {
+  const hasActions = actions !== undefined
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden">
+      <div className="border-border shrink-0 border-b px-4 py-3 sm:px-6">
+        {hasActions ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 className="text-xl font-semibold">{title}</h1>
+            {actions}
+          </div>
+        ) : (
+          <div>
+            <h1 className="text-xl font-semibold">{title}</h1>
+            {description !== undefined && (
+              <p className="text-muted-foreground mt-1 text-sm">
+                {description}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col px-4 sm:px-6">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/shared/layout/PersistentPageLayout.tsx
+++ b/src/shared/layout/PersistentPageLayout.tsx
@@ -1,5 +1,4 @@
 import { PageLayoutShell } from '@/shared/layout/PageLayout'
-import { ScrollArea, ScrollBar } from '@/shared/ui/scroll-area'
 import type { FC, ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router'
@@ -14,25 +13,15 @@ import { WatchHistoryContent } from '@/pages/watch-history'
 interface PageConfig {
   readonly path: string
   readonly Component: FC
-  readonly withScrollArea?: boolean
-  readonly maxWidth?: boolean
 }
 
 const PAGES: readonly PageConfig[] = [
   { path: '/home', Component: HomeContent },
-  { path: '/history', Component: HistoryContent, maxWidth: true },
-  { path: '/favorite', Component: FavoriteContent, maxWidth: true },
-  { path: '/watch-history', Component: WatchHistoryContent, maxWidth: true },
-  {
-    path: '/trim',
-    Component: TrimContent,
-    maxWidth: true,
-  },
-  {
-    path: '/concat',
-    Component: ConcatContent,
-    maxWidth: true,
-  },
+  { path: '/history', Component: HistoryContent },
+  { path: '/favorite', Component: FavoriteContent },
+  { path: '/watch-history', Component: WatchHistoryContent },
+  { path: '/trim', Component: TrimContent },
+  { path: '/concat', Component: ConcatContent },
 ] as const
 
 const VALID_PATHS: readonly string[] = PAGES.map((p) => p.path)
@@ -49,6 +38,10 @@ function isValidPath(pathname: string): boolean {
  * 2. Page content is lazy-mounted on first visit and kept in DOM
  * 3. Inactive pages are hidden with display:none to preserve state
  * 4. Active pages are shown with their normal display
+ *
+ * Per-page content frames (max-width centering, header, body scroll mode)
+ * are owned by each page via PageTemplate, so this layout only handles
+ * mounting and the shared chrome.
  *
  * Benefits:
  * - Scroll position is preserved when navigating back to a page
@@ -79,30 +72,16 @@ export function PersistentPageLayout(): ReactElement {
 
   return (
     <PageLayoutShell>
-      {PAGES.map(({ path, Component, withScrollArea, maxWidth }) =>
+      {PAGES.map(({ path, Component }) =>
         mountedPages.has(path) ? (
           <div
             key={path}
             style={{ display: pathname === path ? undefined : 'none' }}
             className="min-h-0 w-full flex-1"
           >
-            {withScrollArea ? (
-              <ScrollArea
-                style={{ height: 'calc(100dvh - 2.3rem)' }}
-                className="flex w-full"
-              >
-                <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 p-3 sm:px-6">
-                  <Component />
-                </div>
-                <ScrollBar />
-              </ScrollArea>
-            ) : (
-              <div
-                className={`h-full w-full overflow-hidden ${maxWidth ? 'mx-auto max-w-5xl' : ''}`}
-              >
-                <Component />
-              </div>
-            )}
+            <div className="h-full w-full overflow-hidden">
+              <Component />
+            </div>
           </div>
         ) : null,
       )}

--- a/src/shared/layout/index.ts
+++ b/src/shared/layout/index.ts
@@ -1,3 +1,5 @@
-export { PageLayout, PageLayoutShell } from './PageLayout'
-export type { PageLayoutProps, PageLayoutShellProps } from './PageLayout'
+export { PageLayoutShell } from './PageLayout'
+export type { PageLayoutShellProps } from './PageLayout'
+export { PageTemplate } from './PageTemplate'
+export type { PageTemplateProps } from './PageTemplate'
 export { PersistentPageLayout } from './PersistentPageLayout'

--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -9,6 +9,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-bg': 'var(--popover)',
           '--normal-text': 'var(--popover-foreground)',
           '--normal-border': 'var(--border)',
+          // Ensure toasts render above dialogs (z-50) and other overlays.
+          zIndex: 9999,
         } as React.CSSProperties
       }
       {...props}


### PR DESCRIPTION
## Summary

- **PageTemplate extraction**: Extract a shared `PageTemplate` (root + header + body wrapper) to unify the per-page content frame across sub-pages (trim, concat, favorite, history, watch-history). Header and body now share `px-4 sm:px-6` padding so titles and content align — previously the trim/concat body padding was hardcoded per-page and misaligned with the header.
- **Dead code cleanup**: Remove the unused `PageLayout` wrapper and simplify `PersistentPageLayout` (drop unused `maxWidth`/`withScrollArea` flags). Home is unaffected (it never used `maxWidth`).
- **Toast z-index**: Set Toaster `zIndex: 9999` so toasts render above dialogs (`z-50`) instead of behind them.
- **Scrollbar spacing**: Add `pr-3` to the `itemContent` wrapper of the three virtualized lists so the Virtuoso scrollbar no longer overlaps right-aligned action buttons.

Closes #396

## Notes

- Per-page differences are kept intentionally (description on trim/concat only, history's `nav.downloadHistory` title key, per-page login gates, `/history` sidebar placement, `/login` orphan page) — the template unifies only the frame skeleton.
- Body height/scroll stays page-controlled (scrollable form vs. virtualized list) so watch-history's error Alert can stay outside the list's `flex-1` wrapper.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ (124 passed)
- `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)