### PR TITLE
fix(window): disable maximize button during splash screen

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -35,6 +35,7 @@ pub fn create_main_window(
         .title(WINDOW_TITLE)
         .theme(theme.or(Some(Theme::Light)))
         .resizable(false)
+        .maximizable(false)
         .min_inner_size(MIN_WIDTH, MIN_HEIGHT);
 
     builder = match geometry {
@@ -49,11 +50,19 @@ pub fn create_main_window(
     Ok(())
 }
 
-/// Enables window resizing after the splash screen completes.
+/// Re-enables window resizing and maximizing after the splash screen completes.
+///
+/// The window is created with `resizable(false)` and `maximizable(false)` to
+/// lock its geometry during the splash screen. This restores both so the user
+/// can resize and maximize the main window once initialization is done.
 #[tauri::command]
 pub fn enable_window_resize(app: AppHandle) -> Result<(), String> {
     let window = app.get_webview_window("main").ok_or("Window not found")?;
+    // Constraint: set_resizable MUST run before set_maximizable. When the window
+    // is still non-resizable, Tauri/tao silently ignores set_maximizable on
+    // Windows, so reversing the order would leave the maximize button disabled.
     window.set_resizable(true).map_err(|e| format!("{e}"))?;
+    window.set_maximizable(true).map_err(|e| format!("{e}"))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Disable the window's native maximize button while the splash screen is visible. On Windows the button stayed active even though `resizable(false)` was set at window creation, letting users maximize during the splash and distort the window geometry.

Tauri documents that `resizable=false` should auto-disable the maximize button, but the Windows/tao backend does not honor this, so `maximizable` is now managed explicitly:

- `create_main_window`: the window is created with `.maximizable(false)`
- `enable_window_resize`: `set_maximizable(true)` runs after `set_resizable(true)` once the splash completes

The call order matters: `set_maximizable` is silently ignored while the window is still non-resizable.

## Related Issue

N/A (reported directly)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Run `npm run tauri dev` on Windows
- [ ] While the splash screen is visible, confirm the maximize button is disabled (grayed out)
- [ ] After the splash completes, confirm the maximize button is enabled and maximizing works
- [ ] Confirm window edge-drag resize still works after the splash

## Screenshots / Videos

N/A (Windows title-bar behavior; verified on-device)

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (window control behavior, verified manually)
- [x] i18n files synced — N/A (no user-facing text changed)