### PR TITLE
fix(splash): apply native theme at fade start to remove title bar lag

### DIFF
--- a/src/features/splash/hooks/useSplashLifecycle.ts
+++ b/src/features/splash/hooks/useSplashLifecycle.ts
@@ -31,12 +31,15 @@ interface SplashLifecycle {
  * Manages the full lifecycle of the splash screen.
  *
  * Orchestrates three phases:
- * 1. **active**  -- splash is visible; waits for both backend initialization
- *    and a minimum display duration before advancing (unless skip mode).
- * 2. **fading**  -- CSS opacity transition is running; the caller is expected
- *    to call `onFadeComplete` when the transition ends.
- * 3. **done**    -- splash is removed from the DOM; the native window theme is
- *    restored and resizing is enabled.
+ * 1. **active**  -- splash is visible; the native title bar is locked to the
+ *    light theme to match the splash background; waits for both backend
+ *    initialization and a minimum display duration before advancing (unless
+ *    skip mode).
+ * 2. **fading**  -- CSS opacity transition is running; the saved theme is
+ *    applied just before the fade so the title bar switches in step with the
+ *    fade-out (no post-splash theme lag). The caller is expected to call
+ *    `onFadeComplete` when the transition ends.
+ * 3. **done**    -- splash is removed from the DOM and resizing is enabled.
  *
  * When `skipSplashAnimation` is enabled in settings, the minimum display time
  * and fade animation are skipped for fastest possible startup.
@@ -48,7 +51,8 @@ export function useSplashLifecycle(): SplashLifecycle {
   const [skipMode, setSkipMode] = useState<boolean | null>(null)
   const disposedRef = useRef(false)
 
-  // Force light theme during splash
+  // Lock the native title bar to the light theme while the splash is visible
+  // so it matches the light splash background.
   useEffect(() => {
     getCurrentWindow()
       .setTheme('light')
@@ -80,6 +84,21 @@ export function useSplashLifecycle(): SplashLifecycle {
       }
 
       if (disposedRef.current) return
+
+      // Apply the saved theme as the splash begins to fade (or, in skip mode,
+      // just before removal). Running this here rather than after the fade
+      // lets the title bar switch in step with the fade-out, so there is no
+      // visible theme lag once the splash is gone.
+      const theme = store.getState().settings.theme ?? 'light'
+      getCurrentWindow()
+        .setTheme(theme)
+        .catch(() => {})
+      // Caution: This arms useThemeEffect (useThemeEffect.ts), which gates its own
+      // setTheme behind the tauriThemeReady flag to avoid overriding the light lock
+      // while the splash is visible. Must stay after the splash-visible phase or the
+      // user's saved theme will clobber the intentional light lock prematurely.
+      markTauriThemeReady()
+
       notifySplashFading()
       setPhase(skip ? 'done' : 'fading')
     }
@@ -91,17 +110,11 @@ export function useSplashLifecycle(): SplashLifecycle {
     }
   }, [])
 
-  // Restore theme and enable resize after splash
+  // Enable resize after the splash is fully gone
   useEffect(() => {
     if (phase !== 'done') return
     notifySplashDone()
     invoke('enable_window_resize').catch(() => {})
-
-    const theme = store.getState().settings.theme ?? 'light'
-    getCurrentWindow()
-      .setTheme(theme)
-      .catch(() => {})
-    markTauriThemeReady()
   }, [phase])
 
   const onFadeComplete = useCallback(() => {


### PR DESCRIPTION
## Summary

The native window title bar stayed light during the splash screen and only switched to the saved theme after the splash's fade-out completed (`phase === 'done'`), causing a visible theme lag (≈ `MIN_DISPLAY_MS` + 500ms padding + 700ms fade) once the splash was gone. This was most noticeable for dark-theme users, who saw the title bar flip from light to dark noticeably after the splash disappeared.

**Root cause:** the forced-light theme lock during splash (Effect A, which intentionally matches the light splash background `#f5f7fa`) was correct, but the theme *restoration* (`setTheme(theme)` + `markTauriThemeReady()`) only ran in the `phase === 'done'` effect — i.e. *after* the 700ms fade finished.

**Fix:** keep the forced-light lock during splash, but move `setTheme(theme)` + `markTauriThemeReady()` to just before the fade begins (end of the `run()` task). The title bar now switches to the saved theme in step with the fade-out, so there is no visible lag once the splash is removed. Both normal (fade) and skip modes apply the theme correctly.

## Related Issue

Closes #425

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Set theme to **dark**, launch the app (`npm run tauri dev`)
- [ ] Title bar is **light** while the splash is visible (matches the light splash background)
- [ ] Title bar switches to **dark** as the splash fades out
- [ ] **No theme lag** after the splash is fully gone
- [ ] Repeat with **light** theme (title bar stays light, no lag)
- [ ] Toggle theme in Settings → title bar reflects immediately
- [ ] Enable `skipSplashAnimation` → skip mode applies the correct theme without lag

## Screenshots / Videos (Optional)

N/A — theme-timing change; best verified via a screen recording of app launch in dark mode.

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (logic-timing change, verified manually)
- [x] i18n files synced — N/A (no user-facing text changed)