### PR TITLE
fix(download): correct cancel behavior (per-part strikethrough, cancel-all fires, merge-stage guard)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 
 **Proactively add tooltips where the user may be confused (disabled
 buttons, state-dependent restrictions, non-obvious behavior). Explain
-*why*, not just *what*.**
+_why_, not just _what_.**
 
 - Use `@/shared/animate-ui/radix/tooltip` (`Tooltip` / `TooltipTrigger` /
   `TooltipContent`). `TooltipProvider` may be omitted when an ancestor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,31 @@ npx shadcn@latest add <component>
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 ```
 
+### Tooltips for Ambiguous / Disabled Controls
+
+**Proactively add tooltips where the user may be confused (disabled
+buttons, state-dependent restrictions, non-obvious behavior). Explain
+*why*, not just *what*.**
+
+- Use `@/shared/animate-ui/radix/tooltip` (`Tooltip` / `TooltipTrigger` /
+  `TooltipContent`). `TooltipProvider` may be omitted when an ancestor
+  already provides it (e.g. `DownloadStatusDialog`)
+- **Disabled buttons**: native `title` won't fire because
+  `pointer-events: none` blocks hover. Wrap with
+  `<TooltipTrigger asChild><span><Button disabled>…</Button></span></TooltipTrigger>`
+  so the wrapper receives the hover
+- Tooltip text must be **i18n**-ized across all 6 languages; key naming
+  follows `{feature}.{description}`
+- Render `TooltipContent` only when the reason applies (conditional), not
+  always-on
+
+### Code Comments
+
+**Write all code comments in English.** This includes inline `//`
+comments, JSDoc/docstring descriptions, and WHY/CAUTION/CONSTRAINT tags.
+Existing Japanese comments may remain, but never add new Japanese
+comments.
+
 ## Pre-verification Checklist
 
 - Use `@hypothesi/tauri-mcp-server` to retrieve logs and HTML elements

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,7 +252,10 @@ pub fn run() {
                 .max_file_size(10_000_000) // 10MB
                 .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
                 .targets([
-                    // tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    // Mirror logs to stderr so the dev terminal shows them
+                    // live (stderr is unbuffered, so panics/crashes don't
+                    // lose log lines). Stdout is left disabled.
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stderr),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
                         path: log_dir,
                         file_name: Some("app".into()),
@@ -576,6 +579,15 @@ async fn cancel_download(app: AppHandle, download_id: String) -> Result<bool, St
             "download_cancelled",
             serde_json::json!({ "downloadId": download_id }),
         );
+    } else {
+        // No token: either a pre-enqueued pending child (download_video not
+        // started yet) or a finished download whose token was already
+        // removed. Mark it pre-cancelled so download_video rejects it on
+        // start, mirroring cancel_all_downloads. We deliberately do NOT emit
+        // download_cancelled here: that event triggers clearQueueItem on the
+        // frontend, which would drop the row. A cancelled pending part must
+        // stay visible (greyed dot + strikethrough) instead of vanishing.
+        DOWNLOAD_CANCEL_REGISTRY.mark_cancelled(&download_id).await;
     }
 
     Ok(was_found)

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -17,7 +17,7 @@ import {
   setProgress,
   setRetrying,
 } from '@/shared/progress/progressSlice'
-import { clearQueueItem, updateQueueStatus } from '@/shared/queue/queueSlice'
+import { updateQueueStatus } from '@/shared/queue/queueSlice'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { createContext, useEffect, type FC, type ReactNode } from 'react'
 import { toast } from 'sonner'
@@ -149,8 +149,11 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
           if (item && (item.status === 'done' || item.status === 'error')) {
             return
           }
-          // Remove queue item to restore pre-download state
-          store.dispatch(clearQueueItem(downloadId))
+          // @why: Keep the row as 'cancelled' instead of removing it. Silently
+          //   deleting the item hides which part the user cancelled, leaving the
+          //   status dialog and part card unclear about what was cancelled. The
+          //   cancelled row stays visible with a strikethrough.
+          store.dispatch(updateQueueStatus({ downloadId, status: 'cancelled' }))
           // Clear progress entries for this download
           store.dispatch(clearProgressByDownloadId(downloadId))
           // Show toast notification

--- a/src/features/download-status/model/selectors.ts
+++ b/src/features/download-status/model/selectors.ts
@@ -145,11 +145,17 @@ export const selectPartStatusRows = createSelector(
         const rep = pickStageData(progressEntries)
         // partInputs is 0-based; partIndex is 1-based
         const title = partInputs[partIndex - 1]?.title ?? `Part ${partIndex}`
+        // @why: When cancel-all lands right after a merge finishes, child.status
+        //   becomes 'cancelled' even though the file is actually complete. Override
+        //   to 'done' when isComplete so the display matches the real artifact —
+        //   this keeps the PartStatusRow dot/strikethrough and OverallSummary
+        //   completedCount free of a contradictory "cancelled but complete" state.
+        const status = rep.isComplete ? 'done' : (child.status ?? 'pending')
         return {
           downloadId: child.downloadId,
           partIndex,
           title,
-          status: child.status ?? 'pending',
+          status,
           errorMessage: child.errorMessage,
           percentage: rep.percentage,
           audio: rep.audio,
@@ -170,32 +176,43 @@ export const selectPartStatusRows = createSelector(
 export const selectOverallSummary = createSelector(
   [selectPartStatusRows],
   (rows): OverallSummary => {
-    const totalParts = rows.length
-    const completedCount = rows.filter((r) => r.status === 'done').length
-    const errorCount = rows.filter((r) => r.status === 'error').length
-    const cancelledCount = rows.filter((r) => r.status === 'cancelled').length
-    const activeCount = rows.filter(
+    // Exclude cancelled parts from totals/progress: they won't download, so
+    // counting them in the denominator reads as "still pending" (e.g. 7/10
+    // with 3 cancelled looks like 3 are left). cancelledCount is still
+    // reported separately for display.
+    const active = rows.filter((r) => r.status !== 'cancelled')
+    const totalParts = active.length
+    const completedCount = active.filter((r) => r.status === 'done').length
+    const errorCount = active.filter((r) => r.status === 'error').length
+    const cancelledCount = rows.length - active.length
+    const activeCount = active.filter(
       (r) => r.status === 'running' || r.status === 'pending',
     ).length
-    // Average of per-part progress ratios (done=1, cancelled=0, otherwise
-    // percentage/100). Cancelled parts freeze at 0 so a still-running backend
-    // download doesn't move the overall bar.
+    // Average progress ratio over non-cancelled parts (done=1, otherwise
+    // percentage/100).
     const overallRatio =
       totalParts > 0
-        ? rows.reduce((sum, r) => {
-            let ratio: number
-            if (r.status === 'done') ratio = 1
-            else if (r.status === 'cancelled') ratio = 0
-            else ratio = r.percentage / 100
-            return sum + ratio
-          }, 0) / totalParts
+        ? active.reduce(
+            (sum, r) => sum + (r.status === 'done' ? 1 : r.percentage / 100),
+            0,
+          ) / totalParts
         : 0
-    // Sum elapsed times across all non-cancelled parts. Serial downloads
-    // run one after another, so total wall-clock time = sum of each part's
-    // elapsed time.
-    const elapsedSeconds = rows.reduce(
-      (sum, r) => (r.status === 'cancelled' ? sum : sum + r.elapsedTime),
-      0,
+    // Sum elapsed times across non-cancelled parts. Serial downloads run one
+    // after another, so total wall-clock time = sum of each part's elapsed time.
+    const elapsedSeconds = active.reduce((sum, r) => sum + r.elapsedTime, 0)
+    // Any part in the merge stage blocks cancel-all: ffmpeg is a CLI
+    // process that's unsafe to interrupt mid-merge.
+    // @why: The merge stage runs an ffmpeg CLI child process. Cancelling kills
+    //   the child, but if the cancel arrives in the brief window right after
+    //   ffmpeg reaches `progress=end`, it exits successfully and the output file
+    //   is already complete (see src-tauri/src/handlers/ffmpeg.rs merge_avs
+    //   "don't discard a finished file", commit d9202270). This actually caused
+    //   a contradictory "cancelled yet complete progress emitted" display.
+    // @constraint: Fully closing that race window in the backend is hard, so the
+    //   safest and simplest fix is to refuse cancel-all while any part is
+    //   merging (disable the button).
+    const isMerging = rows.some(
+      (r) => r.status === 'running' && r.stage === 'merge',
     )
     return {
       totalParts,
@@ -204,6 +221,7 @@ export const selectOverallSummary = createSelector(
       cancelledCount,
       activeCount,
       hasActive: activeCount > 0,
+      isMerging,
       overallRatio,
       elapsedSeconds,
     }

--- a/src/features/download-status/model/types.ts
+++ b/src/features/download-status/model/types.ts
@@ -66,6 +66,22 @@ export type OverallSummary = {
   activeCount: number
   /** 何らかのDLが進行中か */
   hasActive: boolean
+  /**
+   * True when any part is currently merging (ffmpeg CLI running). Blocks cancel-all.
+   *
+   * @why The merge stage spawns an ffmpeg CLI child process to combine video
+   *   and audio. Cancelling must kill that child, but if the cancel arrives in
+   *   the brief window right after ffmpeg reaches `progress=end` (done), the
+   *   process exits successfully and the output file is already complete. This
+   *   follows the "don't discard a finished file" intent in
+   *   `src-tauri/src/handlers/ffmpeg.rs` `merge_avs` (commit d9202270). It
+   *   actually caused a contradictory "cancelled yet complete progress emitted"
+   *   UI state.
+   * @constraint Fully closing that race window in the backend is hard, so the
+   *   safest and simplest workaround is to refuse cancel-all while any part is
+   *   merging (disable the button).
+   */
+  isMerging: boolean
   /** 全体進捗 0..1（完了=1、進行中=percentage/100 の平均） */
   overallRatio: number
   /** 経過時間 秒（全子の max(elapsedTime)） */

--- a/src/features/download-status/ui/DownloadStatusDialog.tsx
+++ b/src/features/download-status/ui/DownloadStatusDialog.tsx
@@ -1,4 +1,5 @@
-import { useSelector } from '@/app/store'
+import { useAppDispatch, useSelector } from '@/app/store'
+import { updatePartSelected } from '@/features/video/model/inputSlice'
 import {
   Dialog,
   DialogContent,
@@ -8,6 +9,7 @@ import {
 } from '@/shared/animate-ui/radix/dialog'
 import { TooltipProvider } from '@/shared/animate-ui/radix/tooltip'
 import { cn } from '@/shared/lib/utils'
+import { cancelDownload } from '@/shared/queue'
 import { useTranslation } from 'react-i18next'
 
 import { useDownloadStatusDialog } from '../hooks/useDownloadStatusDialog'
@@ -33,6 +35,7 @@ import { PartStatusRow } from './PartStatusRow'
  */
 export function DownloadStatusDialog() {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   const { close } = useDownloadStatusDialog()
   const isOpen = useSelector(selectDownloadStatusDialogOpen)
   const rows = useSelector(selectPartStatusRows)
@@ -64,7 +67,23 @@ export function DownloadStatusDialog() {
             ) : (
               <div className="space-y-1 py-2">
                 {rows.map((row) => (
-                  <PartStatusRow key={row.downloadId} part={row} />
+                  <PartStatusRow
+                    key={row.downloadId}
+                    part={row}
+                    onCancel={() => {
+                      dispatch(cancelDownload(row.downloadId))
+                      // @why: Mirror the home (VideoPartCard.handleCancel) behavior and
+                      //   also clear the selection on cancel. Without this, a re-download
+                      //   would re-fetch this part, contradicting the user's "I don't want
+                      //   it" intent. partIndex is 1-based, so -1 converts to 0-based.
+                      dispatch(
+                        updatePartSelected({
+                          index: row.partIndex - 1,
+                          selected: false,
+                        }),
+                      )
+                    }}
+                  />
                 ))}
               </div>
             )}

--- a/src/features/download-status/ui/OverallProgressBar.tsx
+++ b/src/features/download-status/ui/OverallProgressBar.tsx
@@ -1,4 +1,9 @@
 import { useAppDispatch, useSelector } from '@/app/store'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/animate-ui/radix/tooltip'
 import { cancelAllDownloads } from '@/shared/queue'
 import { Button } from '@/shared/ui/button'
 import { useTranslation } from 'react-i18next'
@@ -37,14 +42,43 @@ export function OverallProgressBar() {
       <span className="text-muted-foreground text-sm whitespace-nowrap tabular-nums">
         {t('downloadStatus.elapsed')} {formatElapsed(summary.elapsedSeconds)}
       </span>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={handleCancelAll}
-        disabled={!summary.hasActive}
-      >
-        {t('downloadStatus.cancel_all')}
-      </Button>
+      {/*
+        @why: Disabling on isMerging is because the merge stage spawns an ffmpeg
+          CLI child process. Cancelling kills the child, but if the cancel hits
+          the brief window right after ffmpeg reaches `progress=end`, it exits
+          successfully and the output is already complete
+          (src-tauri/src/handlers/ffmpeg.rs merge_avs "don't discard a finished
+          file", commit d9202270). This actually caused a contradictory
+          "cancelled yet complete progress emitted" display.
+        @caution: Removing this disable lets the cancel slip through the race
+          window and the UI shows a contradictory "complete" + "cancelled" state.
+        @constraint: Fully closing the race window in the backend is hard, so
+          refusing cancel-all while merging is the safest and simplest approach.
+      */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/*
+            A span wrapper is required: a disabled button gets pointer-events:
+            none and hover never reaches it. The wrapper receives the hover and
+            shows the tooltip.
+          */}
+          <span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCancelAll}
+              disabled={!summary.hasActive || summary.isMerging}
+            >
+              {t('downloadStatus.cancel_all')}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {summary.isMerging && (
+          <TooltipContent side="top">
+            {t('downloadStatus.cancel_all_disabled_merging')}
+          </TooltipContent>
+        )}
+      </Tooltip>
     </div>
   )
 }

--- a/src/features/download-status/ui/PartStatusRow.tsx
+++ b/src/features/download-status/ui/PartStatusRow.tsx
@@ -1,3 +1,5 @@
+import { IconButton } from '@/components/animate-ui/components/buttons/icon'
+import { CircleX } from '@/components/animate-ui/icons/circle-x'
 import {
   Tooltip,
   TooltipContent,
@@ -68,10 +70,23 @@ function StageMini({
  * 左から: ステータスドット / P番号 / パート名 / [DL中] audio bar+%+speed +
  * video bar+%+speed / [マージ中] merge bar+% / ステータスラベル。
  */
-export function PartStatusRow({ part }: { part: PartStatusRowModel }) {
+export function PartStatusRow({
+  part,
+  onCancel,
+}: {
+  part: PartStatusRowModel
+  onCancel?: () => void
+}) {
   const { t } = useTranslation()
   const isDownloading = part.status === 'running'
   const dotClass = STATUS_DOT_CLASS[part.status] ?? STATUS_DOT_CLASS.pending
+  // Only pending/running parts are cancellable. Merge stage (stage=merge) and
+  // completed (isComplete) are excluded — cancelling mid-merge races with the
+  // ffmpeg kill and produces a contradictory display.
+  const canCancel =
+    (part.status === 'pending' || part.status === 'running') &&
+    part.stage !== 'merge' &&
+    !part.isComplete
   const rawName =
     part.status === 'error' && part.errorMessage
       ? part.errorMessage
@@ -105,7 +120,15 @@ export function PartStatusRow({ part }: { part: PartStatusRowModel }) {
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="min-w-0 flex-1 cursor-default truncate">
+          <span
+            className={cn(
+              'min-w-0 flex-1 cursor-default truncate',
+              // Cancelled parts: greyed text (matches the waiting dot) +
+              // strikethrough so they never read as a successful download.
+              part.status === 'cancelled' &&
+                'text-muted-foreground line-through',
+            )}
+          >
             {rawName}
           </span>
         </TooltipTrigger>
@@ -155,6 +178,23 @@ export function PartStatusRow({ part }: { part: PartStatusRowModel }) {
             {mergePct}%
           </span>
         </div>
+      )}
+      {canCancel && onCancel && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconButton
+              variant="ghost"
+              size="sm"
+              onClick={onCancel}
+              className="text-muted-foreground hover:text-destructive size-5 shrink-0 p-0"
+            >
+              <CircleX animateOnHover className="size-3.5" />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent side="top" arrow>
+            {t('video.cancel_download')}
+          </TooltipContent>
+        </Tooltip>
       )}
     </div>
   )

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -23,12 +23,8 @@ import { selectDuplicateIndices } from '@/features/video/model/selectors'
 import { setVideo } from '@/features/video/model/videoSlice'
 import { setError } from '@/shared/downloadStatus/downloadStatusSlice'
 import { logger } from '@/shared/lib/logger'
-import {
-  clearQueue,
-  clearQueueItem,
-  enqueue,
-  findCompletedItemForPart,
-} from '@/shared/queue/queueSlice'
+import { clearProgressByDownloadId } from '@/shared/progress/progressSlice'
+import { clearQueue, clearQueueItem, enqueue } from '@/shared/queue/queueSlice'
 import {
   createContext,
   useCallback,
@@ -445,11 +441,26 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
     // Clear previous resolved quality/subtitle info before starting new download
     store.dispatch(clearResolvedInfo())
 
-    // Clear previously completed items for the selected parts to allow re-download
+    // Clear previously finished items (done/cancelled/error) for the selected
+    // parts so a re-download starts clean. selectDownloadIdByPartIndex
+    // resolves by part suffix only, so stale items from a prior session would
+    // otherwise shadow the new download and show wrong state in the part card.
     for (const { idx } of selectedParts) {
-      const completedItem = findCompletedItemForPart(store.getState(), idx + 1)
-      if (completedItem)
-        store.dispatch(clearQueueItem(completedItem.downloadId))
+      const partNumber = idx + 1
+      const staleItems = store.getState().queue.filter((item) => {
+        const match = item.downloadId.match(/-p(\d+)$/)
+        return (
+          match &&
+          parseInt(match[1], 10) === partNumber &&
+          (item.status === 'done' ||
+            item.status === 'cancelled' ||
+            item.status === 'error')
+        )
+      })
+      for (const item of staleItems) {
+        store.dispatch(clearQueueItem(item.downloadId))
+        store.dispatch(clearProgressByDownloadId(item.downloadId))
+      }
     }
 
     // Each download session gets a unique parentId so the dialog shows a
@@ -519,19 +530,22 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
       } catch (e) {
         const raw = String(e)
 
-        // User-initiated cancel stops the entire playlist to avoid
-        // the next part auto-starting (which looks like a restart).
-        // Judge by the parent's status (not just the error string) so
-        // error-message format changes don't let the next part start.
         const parent = store
           .getState()
           .queue.find((q) => q.downloadId === parentId)
-        if (
-          parent?.status === 'cancelling' ||
-          parent?.status === 'cancelled' ||
-          raw.includes('ERR::CANCELLED')
-        ) {
+        // Whole-playlist cancel (cancelAllDownloads) stops the loop. Judge by
+        // the parent's status so error-message format changes can't let the
+        // next part start.
+        if (parent?.status === 'cancelling' || parent?.status === 'cancelled') {
           break
+        }
+
+        // Per-part cancel (cancelDownload) only rejects this part with
+        // ERR::CANCELLED while leaving the parent running/pending — skip this
+        // part silently and continue to the next. Don't toast: the user
+        // intentionally cancelled.
+        if (raw.includes('ERR::CANCELLED')) {
+          continue
         }
 
         const description = getErrorMessage(raw, t)
@@ -557,14 +571,15 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
 
     const parent = store.getState().queue.find((q) => q.downloadId === parentId)
     if (parent?.status === 'cancelled' || parent?.status === 'cancelling') {
-      // On cancel, remove only aborted/not-started children. Keep completed
-      // (done/error) children so their queue state (used by re-download
-      // checks) is preserved.
+      // Keep cancelled children visible (strikethrough) so the user can see
+      // which parts they skipped. Only remove orphaned pending children
+      // (left behind when the loop was interrupted before they could start).
+      // Done/error children are always kept for their re-download queue state.
       const children = store
         .getState()
         .queue.filter((q) => q.parentId === parentId)
       for (const child of children) {
-        if (child.status !== 'done' && child.status !== 'error') {
+        if (child.status === 'pending') {
           store.dispatch(clearQueueItem(child.downloadId))
         }
       }

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -386,7 +386,11 @@ export function PartDownloadProgress({
         </div>
       )}
 
-      {isCancelled && (
+      {/* @why: Prefer isComplete. When cancel-all lands right after a merge
+          finishes, status becomes 'cancelled' but the file is actually
+          complete, so the "complete" view is accurate. Showing both is
+          contradictory. */}
+      {isCancelled && !isComplete && (
         <div
           className={`text-muted-foreground ${MIN_HEIGHT} flex items-center text-sm`}
         >

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -569,6 +569,7 @@
     "no_downloads": "No downloads",
     "elapsed": "Elapsed",
     "cancel_all": "Cancel All",
+    "cancel_all_disabled_merging": "Merging in progress — cancel unavailable",
     "open": "Downloads",
     "status_completed": "Completed",
     "status_downloading": "Downloading",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -569,6 +569,7 @@
     "no_downloads": "Sin descargas",
     "elapsed": "Transcurrido",
     "cancel_all": "Cancelar todo",
+    "cancel_all_disabled_merging": "Combinación en curso: no se puede cancelar",
     "open": "Descargas",
     "status_completed": "Completado",
     "status_downloading": "Descargando",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -569,6 +569,7 @@
     "no_downloads": "Aucun téléchargement",
     "elapsed": "Temps écoulé",
     "cancel_all": "Tout annuler",
+    "cancel_all_disabled_merging": "Fusion en cours — annulation indisponible",
     "open": "Téléchargements",
     "status_completed": "Terminé",
     "status_downloading": "Téléchargement",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -569,6 +569,7 @@
     "no_downloads": "ダウンロードなし",
     "elapsed": "経過",
     "cancel_all": "すべてキャンセル",
+    "cancel_all_disabled_merging": "マージ中のためキャンセルできません",
     "open": "DL状況",
     "status_completed": "完了",
     "status_downloading": "DL中",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -569,6 +569,7 @@
     "no_downloads": "다운로드 없음",
     "elapsed": "경과",
     "cancel_all": "모두 취소",
+    "cancel_all_disabled_merging": "병합 중이라 취소할 수 없습니다",
     "open": "다운로드",
     "status_completed": "완료",
     "status_downloading": "다운로드 중",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -569,6 +569,7 @@
     "no_downloads": "无下载",
     "elapsed": "已用时间",
     "cancel_all": "全部取消",
+    "cancel_all_disabled_merging": "正在合并，无法取消",
     "open": "下载",
     "status_completed": "完成",
     "status_downloading": "下载中",

--- a/src/shared/queue/queueSlice.ts
+++ b/src/shared/queue/queueSlice.ts
@@ -53,13 +53,20 @@ function aggregateParentStatuses(state: QueueItem[]): void {
 
     const statuses = children.map((c) => c.status)
 
-    // Priority: error > cancelling > running > done > cancelled > pending
+    // Priority: error > cancelling > running > pending > done > cancelled.
+    // A pending child means the playlist hasn't finished yet, so a cancelled
+    // sibling (from a per-part cancel) must NOT flip the parent to
+    // 'cancelled' — that would abort the remaining parts in the serial
+    // download loop. Only once every remaining part is done/cancelled does
+    // the parent settle to 'cancelled' (or 'done' if nothing was skipped).
     if (statuses.includes('error')) {
       parent.status = 'error'
     } else if (statuses.includes('cancelling')) {
       parent.status = 'cancelling'
     } else if (statuses.includes('running')) {
       parent.status = 'running'
+    } else if (statuses.includes('pending')) {
+      parent.status = 'pending'
     } else if (statuses.every((s) => s === 'done')) {
       parent.status = 'done'
     } else if (statuses.includes('cancelled')) {
@@ -111,24 +118,37 @@ const initialState: QueueItem[] = []
  *
  * @param downloadId - Unique identifier of the download to cancel
  */
-export const cancelDownload = createAsyncThunk(
+export const cancelDownload = createAsyncThunk<
+  { downloadId: string; wasCancelled: boolean },
+  string,
+  { state: RootState; pendingMeta: { wasPending: boolean } }
+>(
   'queue/cancelDownload',
-  async (downloadId: string, { getState }) => {
-    const state = getState() as RootState
-    const item = state.queue.find((i) => i.downloadId === downloadId)
-    if (!item) {
-      throw new Error(`Download not found: ${downloadId}`)
-    }
-
-    const cancellableStatuses = ['pending', 'running', 'cancelling']
-    if (!cancellableStatuses.includes(item.status || '')) {
-      throw new Error(
-        `Download is not cancellable: ${downloadId} (status: ${item.status})`,
-      )
-    }
-
+  async (downloadId) => {
+    // Note: cancellability is enforced in `condition` (runs before the
+    // pending reducer), not here. By the time this runs, the pending
+    // reducer may have already finalized a pending child to 'cancelled', so
+    // a status check here would wrongly abort the backend call that sets
+    // mark_cancelled — and the part would later be re-downloaded.
     const wasCancelled = await callCancelDownload(downloadId)
     return { downloadId, wasCancelled }
+  },
+  {
+    // Run before the pending reducer flips the status. Reject done/error
+    // items here: returning false aborts before pending fires, leaving the
+    // status unchanged.
+    condition: (downloadId, { getState }) => {
+      const item = getState().queue.find((i) => i.downloadId === downloadId)
+      if (!item) return false
+      return ['pending', 'running', 'cancelling'].includes(item.status || '')
+    },
+    // Capture the pre-cancel status BEFORE the pending reducer flips it to
+    // 'cancelling'. The pending reducer uses it to finalize a pre-enqueued
+    // pending child (no backend token) immediately as 'cancelled'.
+    getPendingMeta: ({ arg }, { getState }) => {
+      const item = getState().queue.find((i) => i.downloadId === arg)
+      return { wasPending: item?.status === 'pending' }
+    },
   },
 )
 
@@ -141,8 +161,16 @@ export const cancelAllDownloads = createAsyncThunk(
   'queue/cancelAllDownloads',
   async (_, { getState }) => {
     const state = getState() as RootState
+    // Include 'cancelling': this thunk's own pending action has already
+    // flipped pending/running items to 'cancelling' before this body runs,
+    // so filtering only pending/running would drop them and short-circuit
+    // without ever calling the backend (the backend cancel never fires,
+    // while the frontend still settles to 'cancelled' — the exact bug we
+    // saw where P0 "cancelled" but kept downloading).
     const cancellableIds = state.queue
-      .filter((i) => i.status === 'pending' || i.status === 'running')
+      .filter((i) =>
+        ['pending', 'running', 'cancelling'].includes(i.status || ''),
+      )
       .map((i) => i.downloadId)
 
     if (cancellableIds.length === 0) {
@@ -258,13 +286,20 @@ export const queueSlice = createSlice({
     builder.addCase(cancelDownload.pending, (state, action) => {
       const item = state.find((i) => i.downloadId === action.meta.arg)
       if (item) {
-        item.status = 'cancelling'
+        // wasPending is captured pre-cancel in pendingMeta (before this
+        // reducer runs). A pre-enqueued pending child has no backend token,
+        // so cancel can only pre-mark it (mark_cancelled). Finalize to
+        // 'cancelled' immediately instead of routing through 'cancelling',
+        // which the fulfilled case relies on to detect a running→done race.
+        item.status = action.meta.wasPending ? 'cancelled' : 'cancelling'
       }
       aggregateParentStatuses(state)
     })
 
-    // Finalize cancel status regardless of backend result so the UI never
-    // sticks in "cancelling". wasCancelled=false means it already finished.
+    // Finalize the cancel status of a running download. Only running
+    // downloads reach here with status 'cancelling' (pending children were
+    // finalized in the pending case). wasCancelled=false means it raced to
+    // completion just before the cancel signal arrived, so treat as done.
     builder.addCase(cancelDownload.fulfilled, (state, action) => {
       const { wasCancelled } = action.payload
       const item = state.find((i) => i.downloadId === action.meta.arg)
@@ -356,10 +391,18 @@ export const selectDownloadIdByPartIndex = (
   state: { queue: QueueItem[] },
   partIndex: number,
 ): string | undefined => {
-  return state.queue.find((item) => {
-    const match = item.downloadId.match(/-p(\d+)$/)
-    return match && parseInt(match[1], 10) === partIndex + 1
-  })?.downloadId
+  // Search from the end: the most recently enqueued part for this index
+  // wins. During a re-download, stale items from a prior session (e.g.
+  // cancelled children kept for visibility) coexist with the new ones, and
+  // resolving to an old downloadId would make the part card show the prior
+  // session's state.
+  for (let i = state.queue.length - 1; i >= 0; i--) {
+    const match = state.queue[i].downloadId.match(/-p(\d+)$/)
+    if (match && parseInt(match[1], 10) === partIndex + 1) {
+      return state.queue[i].downloadId
+    }
+  }
+  return undefined
 }
 
 /** Memoized selector factory for queue item by download ID. */


### PR DESCRIPTION
## Summary

Fixes multiple issues with download cancellation in the status dialog and home part cards.

- **cancel-all now actually fires**: `cancelAllDownloads` thunk was reading state *after* its own `pending` reducer flipped items to `cancelling`, so the `pending || running` filter dropped them and short-circuited to an empty list — the backend cancel never ran. Now includes `cancelling`.
- **Per-part cancel shows strikethrough+grey** instead of green (done). Pre-enqueued pending children cancel correctly via `mark_cancelled` + `getPendingMeta`.
- **Cancel-all disabled while merging** (ffmpeg kill race) with an explanatory tooltip.
- **Per-part cancel button added to the dialog** (mirrors home; also clears selection so it is not re-downloaded).
- **Cancelled rows stay visible** (strikethrough) instead of disappearing; excluded from progress totals (7/7 not 7/10).
- **isComplete priority**: a part that finished merging shows "complete" even if cancel-all landed in the race window (the file exists).
- **Re-download cleanup**: clears stale done/cancelled/error items so the new download is selected.
- **Per-part cancel no longer aborts the whole playlist**; only cancel-all does.
- Mirror logs to stderr (unbuffered) for reliable dev terminal output.
- CLAUDE.md: rules for tooltips on ambiguous/disabled controls and English-only code comments.
- i18n: `downloadStatus.cancel_all_disabled_merging` in all 6 languages.

## Related Issue

Follow-up to #409 (download status dialog). No open issue.

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Start a multi-part download, cancel one part mid-download → it shows strikethrough, others continue
- [ ] Cancel-all mid-download (not merging) → all parts stop and show strikethrough (backend cancel fires)
- [ ] Cancel-all while a part is merging → button disabled with tooltip
- [ ] Re-download after cancel → no stale state, clean start
- [ ] \`npm run lint\` / \`cargo build\` pass

## Checklist

- [x] \`/review-all\` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)