### PR TITLE
fix(ui): align collapsed sidebar nav icons to center

### DIFF
--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -197,7 +197,7 @@ export function NavigationSidebarHeader({
     <TooltipProvider>
       <nav
         aria-label={t('nav.aria.mainNavigation')}
-        className={cn('flex flex-col px-2', className)}
+        className={cn('flex flex-col', className)}
       >
         {groups.map((group, index) => (
           <Fragment key={group.id}>


### PR DESCRIPTION
## Summary

Fixes icon button overflow / right-shift in the collapsed (icon-only) sidebar. The `<nav>` wrapper's `px-2` doubled up with the inner `SidebarGroup`'s `p-2`, shifting the main nav icons 7px right of center. Removing the redundant `px-2` lets `SidebarGroup`'s `p-2` provide symmetric padding, matching the footer icons and the standard shadcn sidebar.

## Related Issue

Closes #426

## Root Cause (verified by DOM measurement via tauri-mcp)

In collapsed mode (`data-collapsible=icon`), the sidebar container is **42px** (`--sidebar-width-icon`; root font is 14px so `size-8`=28px, `p-2`=7px). With `SidebarGroup`'s `p-2` alone, a `SidebarMenuButton` (28px) fits exactly: `7 + 28 + 7 = 42`.

But `NavigationSidebarHeader` wrapped the groups in `<nav className="flex flex-col px-2">`, adding **another 7px** on each side → only ~16px remained for the 28px button.

| Buttons | `left` | center vs container center (21px) |
| --- | --- | --- |
| Main nav (Home / Favorite / Watch history / Trim / Concat) | **14px** | **+7px right** ❌ |
| Footer (Download history / Settings) | **7px** | centered ✅ |

The shifted button position also made the hover background and focus ring appear off-center ("style broken on focus"). One root cause, one fix.

## Fix

Remove the redundant `px-2` from `NavigationSidebarHeader`'s `<nav>` (one-line change). `SidebarGroup`'s `p-2` now provides symmetric padding, aligning main nav with footer.

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `npm run lint` / `npm run typecheck` pass
- [x] Pre-fix DOM measurement: main nav `left=14px`, footer `left=7px` (7px gap)
- [x] Code review (review-all): no issues
- [ ] Human verification: collapse the sidebar and confirm all nav icons align with the footer icons (and hover/focus rings are centered)

## Checklist

- [x] `/review-all` executed (format → code-reviewer; simplifier/doc skipped — one-line class change)
- [x] Conventional Commits format followed
- [x] i18n: N/A (no user-facing text changed)
