### PR TITLE
fix(ci): add workspaces to rust-cache to fix Clippy timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: src-tauri
           shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)
@@ -169,6 +170,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: src-tauri
           shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)
@@ -194,6 +196,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: src-tauri
           shared-key: rust-ci
 
       - name: Install dependencies (Ubuntu only)


### PR DESCRIPTION
## Problem

The Rust Clippy job in CI timed out (15m) on [run #459](https://github.com/j4rviscmd/bilibili-downloader-gui/actions/runs/27768045974), while Rust Check and Rust Format completed normally.

## Root Cause

The `Swatinem/rust-cache@v2` action was missing the `workspaces` parameter. Without it, the action runs `cargo metadata` from the repository root, where **no `Cargo.toml` exists** (it lives in `src-tauri/`):

```
command: 'cargo metadata --all-features --format-version 1 --no-deps',
stderr: 'error: could not find `Cargo.toml` in `/home/runner/work/bilibili-downloader-gui/bilibili-downloader-gui` or any parent directory'
```

As a result, the action could not identify the workspace target directory, producing a **0-byte cache** that "hit" every run while doing nothing:

```
Cache hit for: v0-rust-rust-ci-Linux-x64-4107bf91-da39a3ee
Cache Size: ~0 MB (569 B)
```

This forced **every Rust job into a full rebuild**. Rust Clippy (`cargo clippy -- -D warnings`) is the heaviest (full build + lint analysis), so it exceeded the 15m timeout. Rust Check / Rust Format only passed because they are lighter.

## Fix

Add `workspaces: src-tauri` to all three Rust cache steps, matching the existing configuration already present in `e2e.yml`:

```yaml
- name: Cache Rust
  uses: Swatinem/rust-cache@v2
  with:
    workspaces: src-tauri
    shared-key: rust-ci
```

Now `cargo metadata` resolves `src-tauri/Cargo.toml`, the build artifacts in `src-tauri/target/` are correctly cached, and Clippy should complete in a few minutes instead of timing out.

## Note

The original concern was that concurrent PRs were causing the timeout, but the real cause was the broken cache within a single PR. Concurrency settings did not need to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)