### PR TITLE
chore(ci): bump Rust Check/Clippy timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   rust-check:
     name: Rust Check
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
   rust-clippy:
     name: Rust Clippy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #431.

## Context

On the first cold-cache run, Rust Clippy took **11m11s** — close to the 15m limit. While the cache now works correctly and subsequent runs will be much faster, full rebuilds can still occur (e.g. after `Cargo.lock` updates) and could push Clippy past 15m on a slow runner.

## Change

Bump the timeout for the two build-bearing Rust jobs from 15m → **30m**:

| Job | Before | After |
|---|---|---|
| Rust Check | 15m | 30m |
| Rust Clippy | 15m | 30m |
| Rust Format | 10m | 10m (unchanged) |

Rust Format is left unchanged — it runs `cargo fmt --check` (no compilation) and completes in ~2m, so 10m is already plenty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)