### PR TITLE
fix(log): restrict stderr mirror to WARN-and-above

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,10 +252,14 @@ pub fn run() {
                 .max_file_size(10_000_000) // 10MB
                 .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
                 .targets([
-                    // Mirror logs to stderr so the dev terminal shows them
-                    // live (stderr is unbuffered, so panics/crashes don't
-                    // lose log lines). Stdout is left disabled.
-                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stderr),
+                    // Mirror only WARN-and-above logs to stderr so the dev
+                    // terminal surfaces warnings/errors without flooding it
+                    // with INFO noise (stderr is unbuffered, so
+                    // panics/crashes don't lose log lines). The global level
+                    // stays Info, so the Folder target below still captures
+                    // INFO. Stdout is left disabled.
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stderr)
+                        .filter(|metadata| metadata.level() <= log::Level::Warn),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
                         path: log_dir,
                         file_name: Some("app".into()),


### PR DESCRIPTION
## Summary

The Stderr log target (enabled in #429) inherited the global `Info` level, flooding the dev terminal with INFO logs. Add a per-target filter so only WARN/ERROR reach stderr, while the Folder target keeps capturing INFO+ via the unchanged global level.

## Changes

- `src-tauri/src/lib.rs`: Add `.filter(|metadata| metadata.level() <= log::Level::Warn)` to the Stderr target of `tauri-plugin-log` (v2.6.0).

## Behavior

| Target | Before | After |
|--------|--------|-------|
| Stderr (terminal) | INFO+ | WARN+ only |
| Folder (log file) | INFO+ | INFO+ (unchanged) |

- The global `.level(Info)` is unchanged, so the Folder target still captures INFO.
- `log::Level` ordering (`Error < Warn < Info < Debug < Trace`) makes `<= Warn` mean "WARN and above".
- `eprintln!` / `panic!` bypass the `log` crate and still reach stderr regardless of this filter.

## Verification

- `cargo fmt` / `cargo build` pass
- Manual: terminal shows WARN/ERROR only; `app.log` still records INFO/WARN/ERROR