### PR TITLE
fix: prevent merge TOCTOU race on post-download cancel

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -730,6 +730,13 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             }),
         )?;
 
+        // Check for cancellation after download completes but before merge starts.
+        // This TOCTOU fix prevents wasted ffmpeg launches when the user cancels
+        // immediately after download finishes.
+        if cancel_token.is_cancelled() {
+            return Err("ERR::CANCELLED".to_string());
+        }
+
         // Subtitle processing
         let (subtitle_mode, subtitle_language_labels, subtitle_failed_labels) =
             prepare_subtitle_mode(
@@ -781,6 +788,14 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             }
             _ => vec![],
         };
+
+        // Check cancellation before starting merge. A cancel that arrived
+        // during the final chunk write can slip past download_url's check
+        // (the chunk was already written), so without this guard we'd spawn
+        // ffmpeg only to abort it on the first progress line (ERR::CANCELLED).
+        if cancel_token.is_cancelled() {
+            return Err("ERR::CANCELLED".to_string());
+        }
 
         // Execute merge
         log::info!(


### PR DESCRIPTION
## Summary

Adds cancellation checks between download completion and the ffmpeg merge step to close a TOCTOU race that intermittently surfaced as "merge failed" (`ERR::CANCELLED`).

## Problem

When a cancel arrived immediately after the parallel audio/video download finished, it could slip past `download_url`'s final cancel check (the last chunk was already written). The flow then proceeded to `merge_avs`, where the cancel was only detected inside the ffmpeg progress loop, returning `ERR::CANCELLED`. This:

- Spawned ffmpeg unnecessarily (wasted CPU)
- Logged an `ERROR`-level "ffmpeg merge failed" message
- Surfaced to the user as a merge failure rather than a clean cancel

## Fix

Add two `cancel_token.is_cancelled()` checks in `download_video`:

1. After `tokio::try_join!` (download complete), before subtitle processing — avoids wasted subtitle downloads
2. Immediately before `merge_avs` — the final guard before spawning ffmpeg

On cancel, both return `ERR::CANCELLED` early, so the existing `result.is_err()` cleanup removes temp files and the frontend (`downloadVideo.ts`) already maps `ERR::CANCELLED` to a clean cancelled state.

The two checks guard different windows (subtitle processing involves network I/O between them), so both are kept.

## Verification

- `cargo build` succeeds (no new warnings)
- Manual: cancel a download around the completion boundary — it settles as cancelled instead of "merge failed"

## Scope

Backend-only (`src-tauri/src/handlers/bilibili.rs`). Frontend cancellation handling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)