### PR TITLE
fix(toast): keep toasts interactive above modal dialogs

### DIFF
--- a/src/shared/animate-ui/radix/dialog.tsx
+++ b/src/shared/animate-ui/radix/dialog.tsx
@@ -137,6 +137,18 @@ function DialogContent({
             onInteractOutside={(e) => {
               if (disableOutsideClick) {
                 e.preventDefault()
+                return
+              }
+              // @why: Sonner toasts live in their own portal outside the dialog.
+              //   Without this guard, interacting with a toast (close button /
+              //   swipe) is detected as an outside interaction and dismisses the
+              //   dialog beneath it.
+              if (
+                (e.target as HTMLElement | null)?.closest(
+                  '[data-sonner-toaster]',
+                )
+              ) {
+                e.preventDefault()
               }
             }}
             forceMount

--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -11,6 +11,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-border': 'var(--border)',
           // Ensure toasts render above dialogs (z-50) and other overlays.
           zIndex: 9999,
+          // @why: Radix Dialog (modal) sets pointer-events: none on body
+          //   siblings while open, disabling Sonner's portal. Force auto so
+          //   swipe-to-dismiss and the close button stay clickable above
+          //   open dialogs (e.g. DownloadStatusDialog).
+          pointerEvents: 'auto',
         } as React.CSSProperties
       }
       {...props}


### PR DESCRIPTION
## Summary

Sonner toasts were unclickable (swipe-to-dismiss, close button) whenever a Radix modal Dialog was open. Radix Dialog (`modal`) sets `pointer-events: none` on body siblings while open, which disabled Sonner's portal even though the toast was visually on top (`z-index: 9999`).

## Changes

- **`src/shared/ui/sonner.tsx`**: add `pointerEvents: 'auto'` to the Toaster style so the toast reclaims input above open dialogs.
- **`src/shared/animate-ui/radix/dialog.tsx`**: guard `onInteractOutside` to ignore interactions originating from the Sonner toaster (`[data-sonner-toaster]`), so touching a toast no longer dismisses the dialog beneath. Normal outside-click-to-close is preserved.

## Verification

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Manual: opened DownloadStatusDialog, triggered an error toast, confirmed swipe-to-dismiss and close button work and the dialog stays open
