### PR TITLE
🚀 Release v1.39.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

This release bumps the version from `v1.38.0` to `v1.39.0` (minor) in `src-tauri/tauri.conf.json`.

### ✨ Added
- Download status dialog with per-part progress tracking
- Separator between GitHub stars and language switcher in app bar

### 🐛 Fixed
- Prevent merge TOCTOU race on post-download cancel
- Keep toasts interactive above modal dialogs
- Download cancel behavior (per-part strikethrough, cancel-all, merge-stage guard)
- Hide transfer rate display during CDN rotation and retry
- Preserve current page when returning home during active download
- Reserve scrollbar space in virtualized lists
- Raise toast z-index above dialogs
- Apply native theme at splash fade start; disable maximize button during splash
- Align collapsed sidebar nav icons to center
- Restrict stderr mirror to WARN-and-above
- Resolve CI failures (prettier format + clippy too_many_arguments)
- Update splash screen E2E selector to use data-testid

### 🔧 Changed
- Extract PageTemplate for unified sub-page UI frame
- Upgrade radix-ui to ^1.5.0
- Add caching and bump timeouts in GitHub Actions workflows
- Rebuild CLAUDE.md to follow best practices and translate to English

## Related Issue

N/A (release)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [ ] Verify `src-tauri/tauri.conf.json` version is `1.39.0`
- [ ] Confirm CI pipeline passes
- [ ] After merge, CI/CD pipeline will create the GitHub Release and tag automatically

## Breaking Changes

None.

## Checklist

- [ ] `/review-all` executed (N/A — version bump only)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A for release bump)
- [x] i18n files synced (N/A for release bump)

---

⚠️ GitHub Release creation and tag push will be handled by the CI/CD pipeline after merge.