### PR TITLE
ci(e2e): cache node_modules and document E2E as non-blocking

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,10 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            e2e-tests/package-lock.json
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -36,11 +32,23 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          shared-key: rust-ci
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-nm
+        with:
+          path: |
+            node_modules
+            e2e-tests/node_modules
+          key: nm-e2e-${{ runner.os }}-${{ hashFiles('package-lock.json', 'e2e-tests/package-lock.json') }}
 
       - name: Install frontend dependencies
+        if: steps.cache-nm.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Install E2E test dependencies
+        if: steps.cache-nm.outputs.cache-hit != 'true'
         working-directory: e2e-tests
         run: npm ci
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,17 @@ comments, JSDoc/docstring descriptions, and WHY/CAUTION/CONSTRAINT tags.
 Existing Japanese comments may remain, but never add new Japanese
 comments.
 
+## CI & E2E Workflows
+
+- **CI** (`.github/workflows/ci.yml`) runs 9 jobs on Ubuntu and is
+  aggregated into the **required** `ci-status` status check.
+- **E2E Tests** (`.github/workflows/e2e.yml`) runs separately on macOS
+  and is **NOT a required** status check.
+- When monitoring CI (e.g. during `worktree-finish`), do **not** wait
+  for the E2E workflow to finish — `ci-status` passing is sufficient to
+  treat CI as green. Treat E2E as informational (screenshots are still
+  useful for visual review).
+
 ## Pre-verification Checklist
 
 - Use `@hypothesi/tauri-mcp-server` to retrieve logs and HTML elements


### PR DESCRIPTION
## Summary

- Speed up the `E2E Tests` workflow with dependency caching
- Document that E2E is a **non-blocking** CI check

## Changes

### `.github/workflows/e2e.yml`
- Add `actions/cache` for `node_modules` (frontend + `e2e-tests`), keyed on both lockfiles. Both `npm ci` steps are skipped on cache hit.
- Add `shared-key: rust-ci` to `Swatinem/rust-cache`, aligning the key scheme with `ci.yml` (OS is still isolated internally, so no cross-OS cache contamination).
- Drop `setup-node`'s `cache: npm` / `cache-dependency-path`, now redundant given the `node_modules` cache.

### `CLAUDE.md`
- New **CI & E2E Workflows** section: `ci-status` is the required check; `E2E Tests` is **NOT** required. CI monitoring (e.g. `worktree-finish`) should not wait for E2E completion.

## Notes

- `workspaces: src-tauri` was already present in `e2e.yml` (the earlier `ci.yml` bug did not affect it).
- E2E currently takes ~5 min; the `npm ci` skip (on cache hit) is the main expected win.

## Verification

- [x] YAML syntax validated
- [x] Prettier `format:check` passes (both files unchanged by the formatter)
- [ ] CI run on this PR (cache effectiveness confirmed by run time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)