### PR TITLE
feat(audio): add audio extraction feature

### DIFF
--- a/src-tauri/src/handlers/audio.rs
+++ b/src-tauri/src/handlers/audio.rs
@@ -1,0 +1,287 @@
+//! Audio Extraction
+//!
+//! Extracts the audio track from a local MP4 file into MP3 (`.mp3`) or AAC
+//! (`.m4a`) using ffmpeg. Independent of the Bilibili download pipeline: it
+//! operates only on local files specified by absolute paths.
+
+use crate::models::settings::AudioFormat;
+use crate::utils::ffmpeg_probe::probe_duration_sec;
+use crate::utils::ffmpeg_progress::parse_out_time;
+use crate::utils::paths::get_ffmpeg_path;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Stdio;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command as AsyncCommand;
+
+/// Event name for audio extraction progress updates emitted to the frontend.
+const AUDIO_PROGRESS_EVENT: &str = "audio://progress";
+
+/// Per-format ffmpeg arguments for the audio codec.
+///
+/// MP3 uses `libmp3lame`; M4a uses the native `aac` encoder inside an MP4
+/// container. Both target a constant bitrate (`-b:a`) in kbps.
+fn codec_args(format: AudioFormat, bitrate_kbps: u32) -> Vec<String> {
+    let codec = match format {
+        AudioFormat::Mp3 => "libmp3lame",
+        AudioFormat::M4a => "aac",
+    };
+    vec![
+        "-c:a".to_string(),
+        codec.to_string(),
+        "-b:a".to_string(),
+        format!("{}k", bitrate_kbps),
+    ]
+}
+
+/// Options for an audio extraction operation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioOptions {
+    /// Absolute path to the input `.mp4` file.
+    pub input_path: String,
+    /// Absolute path for the output file. Extension must match `format`.
+    pub output_path: String,
+    /// Target audio format.
+    pub format: AudioFormat,
+    /// Target bitrate in kbps (e.g. 128, 192, 256, 320).
+    pub bitrate_kbps: u32,
+}
+
+/// Result of a successful audio extraction.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioResult {
+    /// Absolute path of the written output file.
+    pub output_path: String,
+}
+
+/// Progress payload emitted via {@link AUDIO_PROGRESS_EVENT} while ffmpeg runs.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioProgressPayload {
+    pub progress: f64,
+    pub current_time_sec: f64,
+    pub total_duration_sec: f64,
+}
+
+/// Builds the ffmpeg argument list for an audio extraction.
+///
+/// `-vn` discards the video stream so only audio is decoded and re-encoded.
+/// `-progress pipe:2` emits structured `key=value` lines to stderr at 1-second
+/// cadence so we can drive the progress bar from `out_time=`.
+pub fn build_ffmpeg_args(options: &AudioOptions) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "-nostats".to_string(),
+        "-stats_period".to_string(),
+        "1".to_string(),
+        "-progress".to_string(),
+        "pipe:2".to_string(),
+        "-i".to_string(),
+        options.input_path.clone(),
+        // Discard video; extract and re-encode the audio track only.
+        "-vn".to_string(),
+    ];
+    args.extend(codec_args(options.format, options.bitrate_kbps));
+    args.push("-y".to_string());
+    args.push(options.output_path.clone());
+    args
+}
+
+fn is_mp4(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("mp4"))
+        .unwrap_or(false)
+}
+
+fn has_extension(path: &Path, ext: &str) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case(ext))
+        .unwrap_or(false)
+}
+
+/// Checks whether two paths refer to the same file on disk.
+///
+/// Mirrors the trim handler's logic: canonicalizes both paths to catch
+/// symlinks, relative paths, and case differences. The output may not yet
+/// exist, so its parent is canonicalized and the file name rejoined.
+fn is_same_file(input: &Path, output: &Path) -> bool {
+    let canon_input = std::fs::canonicalize(input).ok();
+    let canon_output = std::fs::canonicalize(output).ok().or_else(|| {
+        output
+            .parent()
+            .and_then(|p| std::fs::canonicalize(p).ok())
+            .and_then(|p| output.file_name().map(|n| p.join(n)))
+    });
+    match (canon_input, canon_output) {
+        (Some(a), Some(b)) => a == b,
+        _ => input == output,
+    }
+}
+
+/// Validates inputs and runs ffmpeg to produce the extracted audio file.
+///
+/// # Errors
+///
+/// Returns strings beginning with `ERR::AUDIO_*`:
+/// - `ERR::AUDIO_INPUT_NOT_FOUND`
+/// - `ERR::AUDIO_UNSUPPORTED_FORMAT` (input not `.mp4`)
+/// - `ERR::AUDIO_UNSUPPORTED_OUTPUT_FORMAT` (extension does not match `format`)
+/// - `ERR::AUDIO_SAME_PATH`
+/// - `ERR::AUDIO_INVALID_BITRATE`
+/// - `ERR::AUDIO_FFMPEG_FAILED`
+pub async fn extract_audio(app: &AppHandle, options: &AudioOptions) -> Result<AudioResult, String> {
+    let input_path = Path::new(&options.input_path);
+    let output_path = Path::new(&options.output_path);
+
+    if !input_path.exists() {
+        return Err("ERR::AUDIO_INPUT_NOT_FOUND".to_string());
+    }
+    if !is_mp4(input_path) {
+        return Err("ERR::AUDIO_UNSUPPORTED_FORMAT".to_string());
+    }
+    let expected_ext = match options.format {
+        AudioFormat::Mp3 => "mp3",
+        AudioFormat::M4a => "m4a",
+    };
+    if !has_extension(output_path, expected_ext) {
+        return Err("ERR::AUDIO_UNSUPPORTED_OUTPUT_FORMAT".to_string());
+    }
+    if is_same_file(input_path, output_path) {
+        return Err("ERR::AUDIO_SAME_PATH".to_string());
+    }
+    if options.bitrate_kbps == 0 {
+        return Err("ERR::AUDIO_INVALID_BITRATE".to_string());
+    }
+
+    let ffmpeg_path = get_ffmpeg_path(app);
+    let args = build_ffmpeg_args(options);
+
+    let total_duration_sec = probe_duration_sec(&ffmpeg_path, &options.input_path).await;
+
+    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    cmd.args(&args);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("ERR::AUDIO_FFMPEG_FAILED: spawn {e}"))?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "ERR::AUDIO_FFMPEG_FAILED: no stderr".to_string())?;
+
+    let mut stderr_reader = BufReader::new(stderr);
+    let app_for_progress = app.clone();
+    let stderr_task = tokio::spawn(async move {
+        let mut stderr_lines = String::new();
+        let mut line = String::new();
+        while stderr_reader.read_line(&mut line).await.unwrap_or(0) > 0 {
+            stderr_lines.push_str(&line);
+
+            if let Some(total) = total_duration_sec {
+                if total > 0.0 {
+                    if let Some(current) = parse_out_time(&line) {
+                        let progress = (current / total * 100.0).clamp(0.0, 100.0);
+                        let _ = app_for_progress.emit(
+                            AUDIO_PROGRESS_EVENT,
+                            AudioProgressPayload {
+                                progress,
+                                current_time_sec: current,
+                                total_duration_sec: total,
+                            },
+                        );
+                    }
+                }
+            }
+
+            line.clear();
+        }
+        stderr_lines
+    });
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("ERR::AUDIO_FFMPEG_FAILED: wait {e}"))?;
+
+    let stderr_output = stderr_task.await.unwrap_or_default();
+
+    if !status.success() {
+        return Err(format!(
+            "ERR::AUDIO_FFMPEG_FAILED\nExit code: {:?}\nstderr: {}",
+            status.code(),
+            stderr_output
+        ));
+    }
+
+    Ok(AudioResult {
+        output_path: options.output_path.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_args_mp3_uses_libmp3lame_and_bitrate() {
+        let options = AudioOptions {
+            input_path: "input.mp4".to_string(),
+            output_path: "out.mp3".to_string(),
+            format: AudioFormat::Mp3,
+            bitrate_kbps: 192,
+        };
+        let args = build_ffmpeg_args(&options);
+        assert!(args.contains(&"-vn".to_string()));
+        assert!(args.contains(&"-c:a".to_string()));
+        assert!(args.contains(&"libmp3lame".to_string()));
+        assert!(args.contains(&"192k".to_string()));
+        assert!(args.last().is_some_and(|a| a == "out.mp3"));
+    }
+
+    #[test]
+    fn build_args_m4a_uses_aac() {
+        let options = AudioOptions {
+            input_path: "input.mp4".to_string(),
+            output_path: "out.m4a".to_string(),
+            format: AudioFormat::M4a,
+            bitrate_kbps: 256,
+        };
+        let args = build_ffmpeg_args(&options);
+        assert!(args.contains(&"aac".to_string()));
+        assert!(args.contains(&"256k".to_string()));
+    }
+
+    #[test]
+    fn build_args_includes_progress_flags() {
+        let options = AudioOptions {
+            input_path: "input.mp4".to_string(),
+            output_path: "out.mp3".to_string(),
+            format: AudioFormat::Mp3,
+            bitrate_kbps: 128,
+        };
+        let args = build_ffmpeg_args(&options);
+        assert!(args.contains(&"-nostats".to_string()));
+        assert!(args.contains(&"-progress".to_string()));
+        assert!(args.contains(&"pipe:2".to_string()));
+    }
+
+    #[test]
+    fn is_mp4_checks_extension_case_insensitively() {
+        assert!(is_mp4(Path::new("video.mp4")));
+        assert!(is_mp4(Path::new("VIDEO.MP4")));
+        assert!(!is_mp4(Path::new("video.mkv")));
+    }
+}

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -13,6 +13,7 @@
 //! - **trim**: Local MP4 file trimming via ffmpeg stream copy
 //! - **updater**: GitHub release notes fetching
 
+pub mod audio;
 pub mod bilibili;
 pub mod cleanup;
 pub mod concat;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use tauri::AppHandle;
 use tauri::Manager;
 
+use crate::handlers::audio;
 use crate::handlers::bilibili;
 use crate::handlers::cleanup;
 use crate::handlers::concat;
@@ -186,6 +187,8 @@ pub fn run() {
             cleanup_temp_files,
             trim_video,
             concat_videos,
+            extract_audio,
+            probe_audio_bitrate,
             generate_qr_code,
             poll_qr_status,
             qr_logout,
@@ -1222,6 +1225,28 @@ async fn concat_videos(
     options: concat::ConcatOptions,
 ) -> Result<concat::ConcatResult, String> {
     concat::concat_videos(&app, &options).await
+}
+
+/// Extracts the audio track from a local MP4 file into MP3 or M4a.
+///
+/// Returns the absolute path of the written output file.
+#[tauri::command]
+async fn extract_audio(
+    app: AppHandle,
+    options: audio::AudioOptions,
+) -> Result<audio::AudioResult, String> {
+    audio::extract_audio(&app, &options).await
+}
+
+/// Probes the audio stream bitrate (kbps) of a local media file.
+///
+/// Returns `null` when ffmpeg reports no concrete bitrate (e.g. VBR). Used
+/// by the frontend to disable lossy up-conversion presets and to auto-select
+/// the best-effort bitrate.
+#[tauri::command]
+async fn probe_audio_bitrate(app: AppHandle, input_path: String) -> Result<Option<u32>, String> {
+    let ffmpeg_path = crate::utils::paths::get_ffmpeg_path(&app);
+    Ok(crate::utils::ffmpeg_probe::probe_audio_bitrate_kbps(&ffmpeg_path, &input_path).await)
 }
 
 /// Sets the simulate logout flag for development mode.

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -144,6 +144,14 @@ pub struct Settings {
     /// Defaults to "copy" (stream copy) if not specified.
     #[serde(rename = "trimMode", default, skip_serializing_if = "Option::is_none")]
     pub trim_mode: Option<TrimMode>,
+    /// Default output format for the audio extraction feature.
+    /// Defaults to "mp3" if not specified.
+    #[serde(
+        rename = "audioFormat",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub audio_format: Option<AudioFormat>,
     /// UI theme preference. Defaults to system preference if not set.
     #[serde(rename = "theme", default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<UiTheme>,
@@ -158,6 +166,17 @@ pub enum TrimMode {
     Copy,
     /// Re-encode (libx264), slow but frame-accurate.
     Reencode,
+}
+
+/// Output format for the audio extraction feature.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AudioFormat {
+    /// MP3 (libmp3lame), `.mp3`.
+    #[default]
+    Mp3,
+    /// AAC in MP4 container, `.m4a`.
+    M4a,
 }
 
 /// UI theme preference for light/dark mode.

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -31,3 +31,46 @@ pub async fn probe_duration_sec(ffmpeg_path: &Path, input_path: &str) -> Option<
     }
     None
 }
+
+/// Probes the audio stream bitrate of `input_path` in kbps by running
+/// `ffmpeg -i` and parsing the trailing `<n> kb/s` on the `Audio:` line.
+///
+/// Returns `None` when no concrete bitrate is reported (e.g. VBR streams
+/// where ffmpeg prints no value or `N/A`).
+pub async fn probe_audio_bitrate_kbps(ffmpeg_path: &Path, input_path: &str) -> Option<u32> {
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
+    cmd.arg("-i").arg(input_path);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let output = cmd.output().await.ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stderr.lines() {
+        // Match the audio stream line, e.g.:
+        //   Stream #0:1[0x2](und): Audio: aac (LC), 44100 Hz, stereo, fltp, 192 kb/s
+        if line.contains("Audio:") {
+            if let Some(kbps) = parse_trailing_kbps(line) {
+                return Some(kbps);
+            }
+        }
+    }
+    None
+}
+
+/// Extracts the trailing `<n> kb/s` value from an ffmpeg stream line.
+///
+/// Finds the last `kb/s` occurrence and parses the number immediately
+/// preceding it. Returns `None` if no numeric value is present.
+fn parse_trailing_kbps(line: &str) -> Option<u32> {
+    let kb_index = line.rfind("kb/s")?;
+    let before = &line[..kb_index];
+    // The bitrate is the last numeric token before "kb/s".
+    let token = before
+        .rsplit([',', ' '])
+        .find(|t| !t.is_empty() && t.chars().all(|c| c.is_ascii_digit()))?;
+    token.parse::<u32>().ok()
+}

--- a/src/features/audio/api/audioApi.ts
+++ b/src/features/audio/api/audioApi.ts
@@ -1,0 +1,38 @@
+/**
+ * Audio feature API layer.
+ *
+ * Thin wrappers around `invoke('extract_audio', ...)` and
+ * `invoke('probe_audio_bitrate', ...)` to keep Tauri coupling in a single
+ * module — the rest of the feature depends on these functions, not on
+ * `invoke` directly.
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+
+import type { AudioOptions, AudioResult } from '../types'
+
+/**
+ * Invokes the backend `extract_audio` command.
+ *
+ * @param options - Extraction parameters; see {@link AudioOptions}
+ * @returns The output file path on success
+ * @throws Error with a message beginning with `ERR::AUDIO_*` on failure
+ */
+export async function extractAudio(
+  options: AudioOptions,
+): Promise<AudioResult> {
+  return invoke<AudioResult>('extract_audio', { options })
+}
+
+/**
+ * Invokes the backend `probe_audio_bitrate` command.
+ *
+ * @param inputPath - Absolute path of the media file to probe
+ * @returns The audio stream bitrate in kbps, or `null` when ffmpeg reports
+ *   no concrete bitrate (e.g. VBR)
+ */
+export async function probeAudioBitrate(
+  inputPath: string,
+): Promise<number | null> {
+  return invoke<number | null>('probe_audio_bitrate', { inputPath })
+}

--- a/src/features/audio/hooks/useAudio.ts
+++ b/src/features/audio/hooks/useAudio.ts
@@ -1,0 +1,294 @@
+/**
+ * Audio feature hook.
+ *
+ * Encapsulates all state and orchestration for the audio extraction page:
+ * file dialogs, format/bitrate selection, best-effort bitrate auto-select
+ * on input load, and invocation of `extract_audio`. The output format is
+ * persisted to settings (like trim's mode); the bitrate is recomputed per
+ * input because it depends on the source audio bitrate.
+ */
+
+import { store, useSelector } from '@/app/store'
+import { callSetSettings } from '@/features/settings/api/settingApi'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { error as logError } from '@tauri-apps/plugin-log'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { extractAudio, probeAudioBitrate } from '../api/audioApi'
+import {
+  getEnabledPresets,
+  selectBestEffortBitrate,
+  type BitratePreset,
+} from '../lib/bitrate'
+import type { AudioFormat, AudioProgress } from '../types'
+
+export type AudioStatus =
+  | 'idle'
+  | 'probing'
+  | 'extracting'
+  | 'success'
+  | 'error'
+
+/**
+ * Result returned by {@link useAudio}.
+ */
+export type UseAudioResult = {
+  inputPath: string | null
+  outputPath: string | null
+  format: AudioFormat
+  bitrateKbps: number
+  /** Presets selectable for the current input (gated by source bitrate). */
+  enabledBitrates: readonly BitratePreset[]
+  /** Probed source audio bitrate in kbps, or `null` when unknown (VBR). */
+  inputBitrate: number | null
+  status: AudioStatus
+  /**
+   * Latest progress payload from `audio://progress`, or `null` when no
+   * extraction is in flight. Drives the progress bar.
+   */
+  progress: AudioProgress | null
+  /** Wall-clock seconds since the current extraction started. `0` when idle. */
+  elapsedSec: number
+  /**
+   * Estimated seconds remaining based on current progress rate. `null` when
+   * progress is too small to estimate or no extraction is running.
+   */
+  remainingSec: number | null
+  setFormat: (value: AudioFormat) => void
+  setBitrateKbps: (value: number) => void
+  handleBrowse: () => Promise<void>
+  handleChooseOutput: () => Promise<void>
+  handleExtract: () => Promise<void>
+  handleReveal: () => Promise<void>
+  reset: () => void
+}
+
+export function useAudio(): UseAudioResult {
+  const { t } = useTranslation()
+  const settings = useSelector((state) => state.settings)
+  const [inputPath, setInputPath] = useState<string | null>(null)
+  const [outputPath, setOutputPath] = useState<string | null>(null)
+  const [format, setFormatLocal] = useState<AudioFormat>(
+    settings.audioFormat ?? 'mp3',
+  )
+  const [bitrateKbps, setBitrateKbps] = useState<number>(192)
+  const [inputBitrate, setInputBitrate] = useState<number | null>(null)
+  const [status, setStatus] = useState<AudioStatus>('idle')
+  const [progress, setProgress] = useState<AudioProgress | null>(null)
+  const [startedAtMs, setStartedAtMs] = useState<number | null>(null)
+  const [finalElapsedSec, setFinalElapsedSec] = useState<number | null>(null)
+
+  // Subscribe to ffmpeg progress events emitted by the Rust side. The
+  // listener stays mounted for the hook's lifetime; events are ignored
+  // unless an extraction is in flight.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined
+    void listen<AudioProgress>('audio://progress', (event) => {
+      setProgress(event.payload)
+    }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
+  }, [])
+
+  // Sync local format when settings change from outside (e.g. settings dialog)
+  useEffect(() => {
+    if (settings.audioFormat && settings.audioFormat !== format) {
+      setFormatLocal(settings.audioFormat)
+    }
+  }, [settings.audioFormat, format])
+
+  const enabledBitrates = getEnabledPresets(inputBitrate)
+
+  const setFormat = useCallback(
+    (value: AudioFormat) => {
+      setFormatLocal(value)
+      setStatus('idle')
+      // CAUTION: reset output path so its extension matches the new format
+      // on re-select (the save dialog filters by the chosen extension).
+      setOutputPath(null)
+      const updated = { ...settings, audioFormat: value } as Settings
+      store.dispatch(setSettings(updated))
+      callSetSettings(updated).catch((e) => {
+        logError(`Failed to save audio format: ${e}`)
+      })
+    },
+    [settings],
+  )
+
+  // Wrapper that resets status to 'idle' so the completed progress bar
+  // disappears and the Extract button re-enables the moment the user tweaks
+  // any condition after a successful extraction.
+  const setBitrateKbpsWrapper = useCallback((value: number) => {
+    setBitrateKbps(value)
+    setStatus('idle')
+  }, [])
+
+  const handleBrowse = useCallback(async () => {
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: 'MP4 Video', extensions: ['mp4'] }],
+    })
+    if (typeof selected === 'string') {
+      setInputPath(selected)
+      setOutputPath(null)
+      setStatus('probing')
+      setInputBitrate(null)
+      // Probe source audio bitrate to drive preset enablement + auto-select.
+      const bitrate = await probeAudioBitrate(selected).catch((e) => {
+        logError(`Failed to probe audio bitrate: ${e}`)
+        return null
+      })
+      setInputBitrate(bitrate)
+      setBitrateKbps(selectBestEffortBitrate(bitrate))
+      setStatus('idle')
+    }
+  }, [])
+
+  const handleChooseOutput = useCallback(async () => {
+    if (!inputPath) return
+    const defaultName = makeDefaultOutputName(inputPath, format)
+    const selected = await save({
+      filters: [
+        {
+          name: format === 'mp3' ? 'MP3 Audio' : 'AAC Audio (M4A)',
+          extensions: [format],
+        },
+      ],
+      defaultPath: defaultName,
+    })
+    if (typeof selected === 'string') {
+      setOutputPath(selected)
+      setStatus('idle')
+    }
+  }, [inputPath, format])
+
+  const handleReveal = useCallback(async () => {
+    if (!outputPath) return
+    await invoke('reveal_in_folder', { path: outputPath }).catch((e) => {
+      logError(`Failed to reveal in folder: ${e}`)
+    })
+  }, [outputPath])
+
+  const handleExtract = useCallback(async () => {
+    if (!inputPath || !outputPath) return
+    setProgress(null)
+    setFinalElapsedSec(null)
+    const startedAt = Date.now()
+    setStartedAtMs(startedAt)
+    setStatus('extracting')
+    try {
+      await extractAudio({
+        inputPath,
+        outputPath,
+        format,
+        bitrateKbps,
+      })
+      setStatus('success')
+      setFinalElapsedSec((Date.now() - startedAt) / 1000)
+      setProgress((prev) => ({
+        progress: 100,
+        currentTimeSec: prev?.currentTimeSec ?? 0,
+        totalDurationSec: prev?.totalDurationSec ?? 0,
+      }))
+      toast.success(t('audio.success'), {
+        action: {
+          label: t('audio.openFolder'),
+          onClick: () => {
+            void handleReveal()
+          },
+        },
+      })
+    } catch (e) {
+      setStatus('error')
+      setProgress(null)
+      setFinalElapsedSec(null)
+      const raw = e instanceof Error ? e.message : String(e)
+      const description = mapAudioError(raw, t)
+      toast.error(t('audio.failed'), { description })
+    } finally {
+      setStartedAtMs(null)
+    }
+  }, [inputPath, outputPath, format, bitrateKbps, t, handleReveal])
+
+  const reset = useCallback(() => {
+    setInputPath(null)
+    setOutputPath(null)
+    setFormatLocal('mp3')
+    setBitrateKbps(192)
+    setInputBitrate(null)
+    setStatus('idle')
+    setProgress(null)
+    setStartedAtMs(null)
+    setFinalElapsedSec(null)
+  }, [])
+
+  // Derive elapsed/remaining on each render (same approach as useTrim).
+  const elapsedSec =
+    startedAtMs !== null
+      ? Math.max(0, (Date.now() - startedAtMs) / 1000)
+      : (finalElapsedSec ?? 0)
+  const remainingSec =
+    progress && progress.progress > 1
+      ? (elapsedSec * (100 - progress.progress)) / progress.progress
+      : null
+
+  return {
+    inputPath,
+    outputPath,
+    format,
+    bitrateKbps,
+    enabledBitrates,
+    inputBitrate,
+    status,
+    progress,
+    elapsedSec,
+    remainingSec,
+    setFormat,
+    setBitrateKbps: setBitrateKbpsWrapper,
+    handleBrowse,
+    handleChooseOutput,
+    handleExtract,
+    handleReveal,
+    reset,
+  }
+}
+
+/**
+ * Builds a sensible default output filename from an input path and format.
+ *
+ * Inserts `_audio` before the extension and switches to the target format:
+ * `movie.mp4` → `movie_audio.mp3`. Cross-platform path separator detection
+ * via both `/` and `\`.
+ */
+function makeDefaultOutputName(inputPath: string, format: AudioFormat): string {
+  const filename = inputPath.split(/[\\/]/).pop() ?? `output.${format}`
+  const dot = filename.lastIndexOf('.')
+  const base = dot > 0 ? filename.slice(0, dot) : filename
+  return `${base}_audio.${format}`
+}
+
+const AUDIO_ERROR_MAP: Record<string, string> = {
+  'ERR::AUDIO_INPUT_NOT_FOUND': 'audio.error.input_not_found',
+  'ERR::AUDIO_UNSUPPORTED_FORMAT': 'audio.error.unsupported_format',
+  'ERR::AUDIO_UNSUPPORTED_OUTPUT_FORMAT':
+    'audio.error.unsupported_output_format',
+  'ERR::AUDIO_SAME_PATH': 'audio.error.same_path',
+  'ERR::AUDIO_INVALID_BITRATE': 'audio.error.invalid_bitrate',
+  'ERR::AUDIO_FFMPEG_FAILED': 'audio.error.ffmpeg_failed',
+}
+
+function mapAudioError(raw: string, t: (key: string) => string): string {
+  for (const [code, key] of Object.entries(AUDIO_ERROR_MAP)) {
+    if (raw.includes(code)) return t(key)
+  }
+  return raw
+}

--- a/src/features/audio/index.ts
+++ b/src/features/audio/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Audio feature module.
+ *
+ * Provides extraction of the audio track from local MP4 files into MP3
+ * (`.mp3`) or AAC (`.m4a`) via ffmpeg, with bitrate presets gated by the
+ * source audio bitrate.
+ *
+ * @module audio
+ */
+
+// Public API: Components
+export { default as AudioForm } from './ui/AudioForm'
+
+// Public API: Hooks
+export {
+  useAudio,
+  type AudioStatus,
+  type UseAudioResult,
+} from './hooks/useAudio'
+
+// Public API: Types
+export type {
+  AudioFormat,
+  AudioOptions,
+  AudioProgress,
+  AudioResult,
+} from './types'

--- a/src/features/audio/lib/bitrate.test.ts
+++ b/src/features/audio/lib/bitrate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BITRATE_PRESETS,
+  DEFAULT_BITRATE_KBPS,
+  MIN_BITRATE_KBPS,
+  getEnabledPresets,
+  selectBestEffortBitrate,
+} from './bitrate'
+
+describe('getEnabledPresets', () => {
+  it('returns all presets when input bitrate is unknown', () => {
+    expect(getEnabledPresets(null)).toEqual(BITRATE_PRESETS)
+  })
+
+  it('excludes presets that exceed the input bitrate', () => {
+    expect(getEnabledPresets(160)).toEqual([128])
+  })
+
+  it('keeps the floor preset even when input is below it', () => {
+    expect(getEnabledPresets(96)).toEqual([128])
+  })
+
+  it('includes all presets up to the input bitrate', () => {
+    expect(getEnabledPresets(256)).toEqual([128, 192, 256])
+  })
+
+  it('includes every preset when input is very high', () => {
+    expect(getEnabledPresets(500)).toEqual(BITRATE_PRESETS)
+  })
+})
+
+describe('selectBestEffortBitrate', () => {
+  it('returns the default when input bitrate is unknown', () => {
+    expect(selectBestEffortBitrate(null)).toBe(DEFAULT_BITRATE_KBPS)
+  })
+
+  it('picks the largest preset not exceeding the input', () => {
+    expect(selectBestEffortBitrate(160)).toBe(128)
+    expect(selectBestEffortBitrate(200)).toBe(192)
+    expect(selectBestEffortBitrate(300)).toBe(256)
+  })
+
+  it('falls back to the floor when input is below every preset', () => {
+    expect(selectBestEffortBitrate(96)).toBe(MIN_BITRATE_KBPS)
+  })
+
+  it('selects the highest preset when input is very high', () => {
+    expect(selectBestEffortBitrate(500)).toBe(320)
+  })
+})

--- a/src/features/audio/lib/bitrate.ts
+++ b/src/features/audio/lib/bitrate.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure-function helpers for audio bitrate preset selection.
+ *
+ * Kept free of React/i18n so they can be unit-tested in isolation. The UI
+ * layer calls {@link getEnabledPresets} to decide which presets are
+ * selectable and {@link selectBestEffortBitrate} to auto-pick a default.
+ */
+
+/**
+ * Selectable bitrate presets in ascending order.
+ */
+export const BITRATE_PRESETS = [128, 192, 256, 320] as const
+
+export type BitratePreset = (typeof BITRATE_PRESETS)[number]
+
+/**
+ * Default bitrate used when the input audio bitrate cannot be determined
+ * (e.g. VBR streams). Matches the issue's default of 192 kbps.
+ */
+export const DEFAULT_BITRATE_KBPS: BitratePreset = 192
+
+/**
+ * The lowest preset, always kept selectable as a floor even when the input
+ * bitrate is below it — so the UI never ends up with every option disabled.
+ */
+export const MIN_BITRATE_KBPS: BitratePreset = BITRATE_PRESETS[0]
+
+/**
+ * Returns the bitrate presets that should be selectable for a given input
+ * audio bitrate.
+ *
+ * Presets that exceed the input bitrate are excluded because lossy
+ * up-conversion only wastes space (the output can never sound better than
+ * the source). The smallest preset is always included as a floor so
+ * extraction is never blocked entirely. Pass `null` when the input bitrate
+ * is unknown (VBR): all presets become selectable.
+ *
+ * @param inputBitrate - Source audio bitrate in kbps, or `null` if unknown
+ * @returns Presets the user is allowed to pick
+ */
+export function getEnabledPresets(
+  inputBitrate: number | null,
+): readonly BitratePreset[] {
+  if (inputBitrate === null) return BITRATE_PRESETS
+  return BITRATE_PRESETS.filter(
+    (preset) => preset === MIN_BITRATE_KBPS || preset <= inputBitrate,
+  )
+}
+
+/**
+ * Picks the best-effort default bitrate for a given input audio bitrate.
+ *
+ * Selects the largest preset that does not exceed the input bitrate, so the
+ * output stays as close to the source quality as possible without wasting
+ * bits. Falls back to the floor preset when the input is below every preset.
+ * Returns the configured default when the input bitrate is unknown.
+ *
+ * @param inputBitrate - Source audio bitrate in kbps, or `null` if unknown
+ * @returns The recommended preset to pre-select
+ */
+export function selectBestEffortBitrate(
+  inputBitrate: number | null,
+): BitratePreset {
+  if (inputBitrate === null) return DEFAULT_BITRATE_KBPS
+  for (const preset of [...BITRATE_PRESETS].reverse()) {
+    if (preset <= inputBitrate) return preset
+  }
+  return MIN_BITRATE_KBPS
+}

--- a/src/features/audio/lib/format.ts
+++ b/src/features/audio/lib/format.ts
@@ -1,0 +1,26 @@
+/**
+ * Time formatting helper for the audio extraction progress UI.
+ *
+ * Formats a duration in seconds to `M:SS` (or `H:MM:SS` for durations of an
+ * hour or longer). Clamps negative input to zero so a transient bad value
+ * never renders as `-1:30`.
+ *
+ * @example
+ * ```typescript
+ * formatDuration(12.5)   // '0:12'
+ * formatDuration(125)    // '2:05'
+ * formatDuration(3661)   // '1:01:01'
+ * ```
+ */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  if (h > 0) return `${h}:${pad(m)}:${pad(s)}`
+  return `${m}:${pad(s)}`
+}
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0')
+}

--- a/src/features/audio/types.ts
+++ b/src/features/audio/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Audio feature type definitions.
+ *
+ * Mirrors the Rust DTOs in `src-tauri/src/handlers/audio.rs`. Field names
+ * are camelCase to align with `#[serde(rename_all = "camelCase")]` on the
+ * backend.
+ */
+
+/**
+ * Output audio format. `mp3` uses the libmp3lame encoder; `m4a` uses AAC
+ * inside an MP4 container.
+ */
+export type AudioFormat = 'mp3' | 'm4a'
+
+/**
+ * Request payload for the `extract_audio` Tauri command.
+ */
+export type AudioOptions = {
+  /** Absolute path of the input `.mp4` file. */
+  inputPath: string
+  /** Absolute path for the output file. Extension must match `format`. */
+  outputPath: string
+  /** Target audio format. */
+  format: AudioFormat
+  /** Target bitrate in kbps (128 / 192 / 256 / 320). */
+  bitrateKbps: number
+}
+
+/**
+ * Successful response from the `extract_audio` Tauri command.
+ */
+export type AudioResult = {
+  /** Absolute path of the written output file. */
+  outputPath: string
+}
+
+/**
+ * Payload for the `audio://progress` Tauri event emitted by ffmpeg while
+ * extracting. `progress` is 0–100. The frontend derives elapsed/remaining
+ * from `currentTimeSec`, `totalDurationSec`, and a wall-clock start time.
+ */
+export type AudioProgress = {
+  progress: number
+  currentTimeSec: number
+  totalDurationSec: number
+}

--- a/src/features/audio/ui/AudioForm.tsx
+++ b/src/features/audio/ui/AudioForm.tsx
@@ -1,0 +1,292 @@
+/**
+ * Audio extraction form UI.
+ *
+ * Layout follows the trim page pattern: input file section, format section,
+ * bitrate section (with presets disabled above the source bitrate), output
+ * file section, actions. State and behavior come from {@link useAudio};
+ * this component is responsible only for presentation.
+ */
+
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@/shared/animate-ui/radix/radio-group'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/animate-ui/radix/tooltip'
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/ui/button'
+import type { TFunction } from 'i18next'
+import { FileUp, FolderOpen, Loader2, Music, RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useAudio } from '../hooks/useAudio'
+import { BITRATE_PRESETS, type BitratePreset } from '../lib/bitrate'
+import { formatDuration } from '../lib/format'
+import type { AudioFormat } from '../types'
+
+export function AudioForm() {
+  const { t } = useTranslation()
+  const {
+    inputPath,
+    outputPath,
+    format,
+    bitrateKbps,
+    enabledBitrates,
+    inputBitrate,
+    status,
+    progress,
+    elapsedSec,
+    remainingSec,
+    setFormat,
+    setBitrateKbps,
+    handleBrowse,
+    handleChooseOutput,
+    handleExtract,
+    handleReveal,
+    reset,
+  } = useAudio()
+
+  const isBusy = status === 'probing' || status === 'extracting'
+  const isSuccess = status === 'success'
+  const canExtract =
+    Boolean(inputPath) && Boolean(outputPath) && !isBusy && !isSuccess
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">{t('audio.inputFile')}</h2>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBrowse}
+            disabled={isBusy}
+          >
+            <FileUp className="size-4" />
+            {t('audio.browse')}
+          </Button>
+          {inputPath ? (
+            <p
+              className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+              title={inputPath}
+            >
+              {inputPath}
+            </p>
+          ) : (
+            <span className="text-muted-foreground text-sm">
+              {t('audio.noFileSelected')}
+            </span>
+          )}
+          {status === 'probing' && (
+            <Loader2 className="text-muted-foreground size-4 animate-spin" />
+          )}
+        </div>
+        {inputBitrate !== null && (
+          <p className="text-muted-foreground mt-2 text-xs">
+            {t('audio.sourceBitrate', { value: inputBitrate })}
+          </p>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">{t('audio.format.label')}</h2>
+        <RadioGroup
+          value={format}
+          onValueChange={(v) => setFormat(v as AudioFormat)}
+          className="grid grid-cols-2 gap-3"
+          disabled={isBusy}
+        >
+          <label
+            htmlFor="audio-format-mp3"
+            className="flex cursor-pointer items-center gap-3"
+          >
+            <RadioGroupItem id="audio-format-mp3" value="mp3" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">
+                {t('audio.format.mp3')}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {t('audio.format.mp3Hint')}
+              </span>
+            </div>
+          </label>
+          <label
+            htmlFor="audio-format-m4a"
+            className="flex cursor-pointer items-center gap-3"
+          >
+            <RadioGroupItem id="audio-format-m4a" value="m4a" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">
+                {t('audio.format.m4a')}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {t('audio.format.m4aHint')}
+              </span>
+            </div>
+          </label>
+        </RadioGroup>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">{t('audio.bitrate.label')}</h2>
+        <TooltipProvider>
+          <RadioGroup
+            value={String(bitrateKbps)}
+            onValueChange={(v) => setBitrateKbps(Number(v))}
+            className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+            disabled={isBusy}
+          >
+            {BITRATE_PRESETS.map((preset) => (
+              <BitrateOption
+                key={preset}
+                preset={preset}
+                isEnabled={enabledBitrates.includes(preset)}
+                inputBitrate={inputBitrate}
+                t={t}
+              />
+            ))}
+          </RadioGroup>
+        </TooltipProvider>
+        <p className="text-muted-foreground mt-2 text-xs">
+          {t('audio.bitrate.hint')}
+        </p>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">{t('audio.outputFile')}</h2>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleChooseOutput}
+            disabled={!inputPath || isBusy}
+          >
+            <FolderOpen className="size-4" />
+            {t('audio.chooseOutput')}
+          </Button>
+          {outputPath ? (
+            <p
+              className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+              title={outputPath}
+            >
+              {outputPath}
+            </p>
+          ) : (
+            <span className="text-muted-foreground text-sm">
+              {t('audio.noOutputSelected')}
+            </span>
+          )}
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3">
+        {(isBusy || isSuccess) && progress && (
+          <>
+            <div className="bg-primary/20 relative h-2 flex-1 overflow-hidden rounded-full">
+              <div
+                className="bg-primary h-full transition-[width] duration-1000 ease-linear"
+                style={{ width: `${progress.progress}%` }}
+              />
+            </div>
+            <span className="text-sm font-medium whitespace-nowrap tabular-nums">
+              {Math.round(progress.progress)}%
+            </span>
+            <span className="text-muted-foreground text-sm whitespace-nowrap tabular-nums">
+              {t('audio.elapsed')} {formatDuration(elapsedSec)}
+              {remainingSec !== null && (
+                <>
+                  {' / '}
+                  {t('audio.remaining')} {formatDuration(remainingSec)}
+                </>
+              )}
+            </span>
+          </>
+        )}
+        <div className="ml-auto flex gap-3">
+          <Button
+            variant="outline"
+            onClick={handleReveal}
+            disabled={!isSuccess || !outputPath}
+            className={isSuccess && outputPath ? '' : 'invisible'}
+          >
+            <FolderOpen className="size-4" />
+            {t('audio.openFolder')}
+          </Button>
+          <Button variant="ghost" onClick={reset} disabled={isBusy}>
+            <RotateCcw className="size-4" />
+            {t('audio.clear')}
+          </Button>
+          <Button onClick={handleExtract} disabled={!canExtract}>
+            {status === 'extracting' ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Music className="size-4" />
+            )}
+            {status === 'extracting'
+              ? t('audio.extracting')
+              : t('audio.extract')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * A single bitrate preset radio option.
+ *
+ * When disabled (preset exceeds the source bitrate), wraps the label in a
+ * tooltip so the user understands _why_ the option is unavailable. The
+ * wrapper `<span>` receives the hover because the disabled control itself
+ * has `pointer-events: none`.
+ */
+function BitrateOption({
+  preset,
+  isEnabled,
+  inputBitrate,
+  t,
+}: {
+  preset: BitratePreset
+  isEnabled: boolean
+  inputBitrate: number | null
+  t: TFunction
+}) {
+  const label = (
+    <label
+      htmlFor={`audio-bitrate-${preset}`}
+      className={cn(
+        'flex items-center gap-2',
+        isEnabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
+      )}
+    >
+      <RadioGroupItem
+        id={`audio-bitrate-${preset}`}
+        value={String(preset)}
+        disabled={!isEnabled}
+      />
+      <span className="text-sm font-medium">{preset} kbps</span>
+    </label>
+  )
+
+  // No tooltip when enabled, or when the source bitrate is unknown.
+  if (isEnabled || inputBitrate === null) return label
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="max-w-xs">
+          {t('audio.bitrate.exceedsSource', { value: inputBitrate })}
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default AudioForm

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -645,6 +645,38 @@ function SettingsForm() {
         </div>
         <Separator />
         <div className="space-y-2">
+          <div className="space-y-0.5">
+            <Label>{t('settings.audio_format_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.audio_format_description')}
+            </p>
+          </div>
+          <RadioGroup
+            value={settings.audioFormat ?? 'mp3'}
+            onValueChange={(value) => {
+              saveByForm({
+                ...settings,
+                audioFormat: value as 'mp3' | 'm4a',
+              })
+            }}
+            className="grid grid-cols-2 gap-4"
+          >
+            <div className="flex items-center space-x-3">
+              <RadioGroupItem value="mp3" id="audio-mp3" />
+              <Label htmlFor="audio-mp3">
+                {t('settings.audio_format_mp3')}
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <RadioGroupItem value="m4a" id="audio-m4a" />
+              <Label htmlFor="audio-m4a">
+                {t('settings.audio_format_m4a')}
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+        <Separator />
+        <div className="space-y-2">
           <Label>{t('settings.app_section_label')}</Label>
           <div className="flex w-full items-end gap-2">
             <UpdateCheckButton />

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -18,6 +18,7 @@ const initialState: SettingsState = {
   showGithubStars: true,
   fontSize: 16,
   trimMode: 'copy',
+  audioFormat: 'mp3',
   theme: 'light',
 }
 

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -85,6 +85,11 @@ export interface Settings {
    */
   trimMode?: TrimMode
   /**
+   * Default output format for the audio extraction feature.
+   * Defaults to 'mp3' if not specified.
+   */
+  audioFormat?: AudioFormat
+  /**
    * UI theme: 'light' or 'dark'.
    * Persisted to settings.json via Tauri backend.
    * Defaults to 'light' if not set.
@@ -111,6 +116,13 @@ export type Theme = 'light' | 'dark'
  * - reencode: Re-encode, slow but frame-accurate
  */
 export type TrimMode = 'copy' | 'reencode'
+
+/**
+ * Output format for audio extraction.
+ * - mp3: MP3 (libmp3lame)
+ * - m4a: AAC in MP4 container
+ */
+export type AudioFormat = 'mp3' | 'm4a'
 
 /**
  * Supported language codes for the application.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,8 +28,10 @@
       "concat": "Navigate to concat page",
       "toggleSidebar": "Toggle Sidebar",
       "openSidebar": "Open sidebar",
-      "closeSidebar": "Close sidebar"
-    }
+      "closeSidebar": "Close sidebar",
+      "audio": "Navigate to audio page"
+    },
+    "audio": "Audio"
   },
   "trim": {
     "title": "Trim Video",
@@ -377,7 +379,11 @@
       "confirm_delete": "Delete this rule?",
       "from_label": "From",
       "to_label": "To"
-    }
+    },
+    "audio_format_label": "Audio Output Format",
+    "audio_format_description": "Default output format used when extracting audio",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "Audio",
     "stage_video": "Video",
     "stage_merge": "Merge"
+  },
+  "audio": {
+    "title": "Audio Extraction",
+    "description": "Extract the audio track from a local MP4 file into MP3 or M4A.",
+    "inputFile": "Input File",
+    "browse": "Browse",
+    "noFileSelected": "No file selected",
+    "sourceBitrate": "Source audio bitrate: {{value}} kbps",
+    "format": {
+      "label": "Format",
+      "mp3": "MP3",
+      "mp3Hint": "Smaller file, widely compatible",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "Better quality at the same bitrate"
+    },
+    "bitrate": {
+      "label": "Bitrate",
+      "hint": "Presets above the source bitrate are disabled to avoid wasteful up-conversion.",
+      "exceedsSource": "Exceeds the source bitrate ({{value}} kbps); up-conversion would not improve quality."
+    },
+    "outputFile": "Output File",
+    "chooseOutput": "Choose Output",
+    "noOutputSelected": "No output selected",
+    "extract": "Extract Audio",
+    "extracting": "Extracting...",
+    "clear": "Clear",
+    "success": "Audio extracted successfully",
+    "failed": "Audio extraction failed",
+    "openFolder": "Open Folder",
+    "elapsed": "elapsed",
+    "remaining": "remaining",
+    "error": {
+      "input_not_found": "Input file not found",
+      "unsupported_format": "Input must be an MP4 file",
+      "unsupported_output_format": "Output extension does not match the selected format",
+      "same_path": "Output path must differ from the input",
+      "invalid_bitrate": "Invalid bitrate",
+      "ffmpeg_failed": "ffmpeg failed to extract audio"
+    }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -28,8 +28,10 @@
       "concat": "Ir a la página de concatenación",
       "toggleSidebar": "Alternar barra lateral",
       "openSidebar": "Abrir barra lateral",
-      "closeSidebar": "Cerrar barra lateral"
-    }
+      "closeSidebar": "Cerrar barra lateral",
+      "audio": "Ir a la página de audio"
+    },
+    "audio": "Audio"
   },
   "trim": {
     "title": "Recortar vídeo",
@@ -377,7 +379,11 @@
       "confirm_delete": "¿Eliminar esta regla?",
       "from_label": "De",
       "to_label": "A"
-    }
+    },
+    "audio_format_label": "Formato de salida de audio",
+    "audio_format_description": "Formato de salida predeterminado al extraer audio",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "Audio",
     "stage_video": "Video",
     "stage_merge": "Combinar"
+  },
+  "audio": {
+    "title": "Extracción de audio",
+    "description": "Extrae la pista de audio de un archivo MP4 local a MP3 o M4A.",
+    "inputFile": "Archivo de entrada",
+    "browse": "Examinar",
+    "noFileSelected": "Ningún archivo seleccionado",
+    "sourceBitrate": "Tasa de bits de audio de origen: {{value}} kbps",
+    "format": {
+      "label": "Formato",
+      "mp3": "MP3",
+      "mp3Hint": "Archivo más pequeño, gran compatibilidad",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "Mejor calidad con la misma tasa de bits"
+    },
+    "bitrate": {
+      "label": "Tasa de bits",
+      "hint": "Las tasas superiores a la de origen se desactivan para evitar una conversión ascendente innecesaria.",
+      "exceedsSource": "Supera la tasa de bits de origen ({{value}} kbps); la conversión ascendente no mejoraría la calidad."
+    },
+    "outputFile": "Archivo de salida",
+    "chooseOutput": "Elegir salida",
+    "noOutputSelected": "Ninguna salida seleccionada",
+    "extract": "Extraer audio",
+    "extracting": "Extrayendo...",
+    "clear": "Limpiar",
+    "success": "Audio extraído correctamente",
+    "failed": "Error en la extracción de audio",
+    "openFolder": "Abrir carpeta",
+    "elapsed": "transcurrido",
+    "remaining": "restante",
+    "error": {
+      "input_not_found": "No se encontró el archivo de entrada",
+      "unsupported_format": "La entrada debe ser un archivo MP4",
+      "unsupported_output_format": "La extensión de salida no coincide con el formato seleccionado",
+      "same_path": "La ruta de salida debe ser distinta de la entrada",
+      "invalid_bitrate": "Tasa de bits no válida",
+      "ffmpeg_failed": "ffmpeg no pudo extraer el audio"
+    }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -28,8 +28,10 @@
       "concat": "Accéder à la page de concaténation",
       "toggleSidebar": "Basculer la barre latérale",
       "openSidebar": "Ouvrir la barre latérale",
-      "closeSidebar": "Fermer la barre latérale"
-    }
+      "closeSidebar": "Fermer la barre latérale",
+      "audio": "Aller à la page audio"
+    },
+    "audio": "Audio"
   },
   "trim": {
     "title": "Découper la vidéo",
@@ -377,7 +379,11 @@
       "confirm_delete": "Supprimer cette règle ?",
       "from_label": "De",
       "to_label": "Vers"
-    }
+    },
+    "audio_format_label": "Format de sortie audio",
+    "audio_format_description": "Format de sortie par défaut lors de l'extraction audio",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "Audio",
     "stage_video": "Vidéo",
     "stage_merge": "Fusion"
+  },
+  "audio": {
+    "title": "Extraction audio",
+    "description": "Extrait la piste audio d'un fichier MP4 local au format MP3 ou M4A.",
+    "inputFile": "Fichier d'entrée",
+    "browse": "Parcourir",
+    "noFileSelected": "Aucun fichier sélectionné",
+    "sourceBitrate": "Débit audio source : {{value}} kbps",
+    "format": {
+      "label": "Format",
+      "mp3": "MP3",
+      "mp3Hint": "Fichier plus petit, large compatibilité",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "Meilleure qualité à débit égal"
+    },
+    "bitrate": {
+      "label": "Débit binaire",
+      "hint": "Les débits supérieurs à celui de la source sont désactivés pour éviter une conversion ascendante inutile.",
+      "exceedsSource": "Dépasse le débit source ({{value}} kbps) ; la conversion ascendante n'améliorerait pas la qualité."
+    },
+    "outputFile": "Fichier de sortie",
+    "chooseOutput": "Choisir la sortie",
+    "noOutputSelected": "Aucune sortie sélectionnée",
+    "extract": "Extraire l'audio",
+    "extracting": "Extraction...",
+    "clear": "Effacer",
+    "success": "Audio extrait avec succès",
+    "failed": "Échec de l'extraction audio",
+    "openFolder": "Ouvrir le dossier",
+    "elapsed": "écoulé",
+    "remaining": "restant",
+    "error": {
+      "input_not_found": "Fichier d'entrée introuvable",
+      "unsupported_format": "L'entrée doit être un fichier MP4",
+      "unsupported_output_format": "L'extension de sortie ne correspond pas au format sélectionné",
+      "same_path": "Le chemin de sortie doit être différent de l'entrée",
+      "invalid_bitrate": "Débit binaire invalide",
+      "ffmpeg_failed": "ffmpeg n'a pas pu extraire l'audio"
+    }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -28,8 +28,10 @@
       "concat": "結合画面へ移動",
       "toggleSidebar": "サイドバーを切り替え",
       "openSidebar": "サイドバーを開く",
-      "closeSidebar": "サイドバーを閉じる"
-    }
+      "closeSidebar": "サイドバーを閉じる",
+      "audio": "音声抽出ページへ移動"
+    },
+    "audio": "音声抽出"
   },
   "trim": {
     "title": "動画トリム",
@@ -377,7 +379,11 @@
       "confirm_delete": "このルールを削除しますか？",
       "from_label": "置換前",
       "to_label": "置換後"
-    }
+    },
+    "audio_format_label": "音声出力フォーマット",
+    "audio_format_description": "音声抽出時のデフォルト出力フォーマット",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "音声",
     "stage_video": "動画",
     "stage_merge": "マージ"
+  },
+  "audio": {
+    "title": "音声抽出",
+    "description": "ローカルのMP4ファイルから音声をMP3またはM4Aとして抽出します。",
+    "inputFile": "入力ファイル",
+    "browse": "参照",
+    "noFileSelected": "ファイルが選択されていません",
+    "sourceBitrate": "ソース音声ビットレート: {{value}} kbps",
+    "format": {
+      "label": "フォーマット",
+      "mp3": "MP3",
+      "mp3Hint": "ファイルサイズ小、互換性高い",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "同じビットレートでより高音質"
+    },
+    "bitrate": {
+      "label": "ビットレート",
+      "hint": "ソースビットレートを超えるプリセットは、無駄なアップコンバートを避けるため無効化されます。",
+      "exceedsSource": "ソースビットレート（{{value}} kbps）を超えています。アップコンバートしても音質は向上しません。"
+    },
+    "outputFile": "出力ファイル",
+    "chooseOutput": "出力先を選択",
+    "noOutputSelected": "出力先が選択されていません",
+    "extract": "音声を抽出",
+    "extracting": "抽出中...",
+    "clear": "クリア",
+    "success": "音声を抽出しました",
+    "failed": "音声の抽出に失敗しました",
+    "openFolder": "フォルダを開く",
+    "elapsed": "経過",
+    "remaining": "残り",
+    "error": {
+      "input_not_found": "入力ファイルが見つかりません",
+      "unsupported_format": "入力はMP4ファイルである必要があります",
+      "unsupported_output_format": "出力の拡張子が選択したフォーマットと一致しません",
+      "same_path": "出力パスは入力と異なる必要があります",
+      "invalid_bitrate": "無効なビットレートです",
+      "ffmpeg_failed": "ffmpegでの音声抽出に失敗しました"
+    }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -28,8 +28,10 @@
       "concat": "병합 페이지로 이동",
       "toggleSidebar": "사이드바 토글",
       "openSidebar": "사이드바 열기",
-      "closeSidebar": "사이드바 닫기"
-    }
+      "closeSidebar": "사이드바 닫기",
+      "audio": "오디오 추출 페이지로 이동"
+    },
+    "audio": "오디오 추출"
   },
   "trim": {
     "title": "영상 트림",
@@ -377,7 +379,11 @@
       "confirm_delete": "이 규칙을 삭제하시겠습니까?",
       "from_label": "원본",
       "to_label": "치환"
-    }
+    },
+    "audio_format_label": "오디오 출력 형식",
+    "audio_format_description": "오디오 추출 시 기본 출력 형식",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "오디오",
     "stage_video": "비디오",
     "stage_merge": "병합"
+  },
+  "audio": {
+    "title": "오디오 추출",
+    "description": "로컬 MP4 파일에서 오디오를 MP3 또는 M4A로 추출합니다.",
+    "inputFile": "입력 파일",
+    "browse": "찾아보기",
+    "noFileSelected": "선택된 파일이 없습니다",
+    "sourceBitrate": "원본 오디오 비트레이트: {{value}} kbps",
+    "format": {
+      "label": "형식",
+      "mp3": "MP3",
+      "mp3Hint": "파일 크기가 작고 호환성이 높음",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "동일 비트레이트에서 더 좋은 음질"
+    },
+    "bitrate": {
+      "label": "비트레이트",
+      "hint": "원본 비트레이트를 초과하는 프리셋은 불필요한 업컨버팅을 방지하기 위해 비활성화됩니다.",
+      "exceedsSource": "원본 비트레이트({{value}} kbps)를 초과합니다. 업컨버팅해도 음질이 향상되지 않습니다."
+    },
+    "outputFile": "출력 파일",
+    "chooseOutput": "출력 선택",
+    "noOutputSelected": "출력이 선택되지 않았습니다",
+    "extract": "오디오 추출",
+    "extracting": "추출 중...",
+    "clear": "지우기",
+    "success": "오디오 추출 성공",
+    "failed": "오디오 추출 실패",
+    "openFolder": "폴더 열기",
+    "elapsed": "경과",
+    "remaining": "남은 시간",
+    "error": {
+      "input_not_found": "입력 파일을 찾을 수 없습니다",
+      "unsupported_format": "입력은 MP4 파일이어야 합니다",
+      "unsupported_output_format": "출력 확장자가 선택한 형식과 일치하지 않습니다",
+      "same_path": "출력 경로는 입력과 달라야 합니다",
+      "invalid_bitrate": "잘못된 비트레이트",
+      "ffmpeg_failed": "ffmpeg 오디오 추출 실패"
+    }
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -28,8 +28,10 @@
       "concat": "前往合并页面",
       "toggleSidebar": "切换侧边栏",
       "openSidebar": "打开侧边栏",
-      "closeSidebar": "关闭侧边栏"
-    }
+      "closeSidebar": "关闭侧边栏",
+      "audio": "前往音频提取页面"
+    },
+    "audio": "音频提取"
   },
   "trim": {
     "title": "裁剪视频",
@@ -377,7 +379,11 @@
       "confirm_delete": "确定删除此规则？",
       "from_label": "原字符",
       "to_label": "替换为"
-    }
+    },
+    "audio_format_label": "音频输出格式",
+    "audio_format_description": "提取音频时的默认输出格式",
+    "audio_format_mp3": "MP3",
+    "audio_format_m4a": "M4A (AAC)"
   },
   "validation": {
     "path": {
@@ -581,5 +587,44 @@
     "stage_audio": "音频",
     "stage_video": "视频",
     "stage_merge": "合并"
+  },
+  "audio": {
+    "title": "音频提取",
+    "description": "从本地 MP4 文件中提取音频为 MP3 或 M4A。",
+    "inputFile": "输入文件",
+    "browse": "浏览",
+    "noFileSelected": "未选择文件",
+    "sourceBitrate": "源音频比特率：{{value}} kbps",
+    "format": {
+      "label": "格式",
+      "mp3": "MP3",
+      "mp3Hint": "文件更小，兼容性广",
+      "m4a": "M4A (AAC)",
+      "m4aHint": "相同比特率下音质更好"
+    },
+    "bitrate": {
+      "label": "比特率",
+      "hint": "高于源比特率的预设已禁用，以避免无意义的升码转换。",
+      "exceedsSource": "超过源比特率（{{value}} kbps）；升码转换不会提升音质。"
+    },
+    "outputFile": "输出文件",
+    "chooseOutput": "选择输出",
+    "noOutputSelected": "未选择输出",
+    "extract": "提取音频",
+    "extracting": "提取中...",
+    "clear": "清除",
+    "success": "音频提取成功",
+    "failed": "音频提取失败",
+    "openFolder": "打开文件夹",
+    "elapsed": "已用",
+    "remaining": "剩余",
+    "error": {
+      "input_not_found": "找不到输入文件",
+      "unsupported_format": "输入必须是 MP4 文件",
+      "unsupported_output_format": "输出扩展名与所选格式不匹配",
+      "same_path": "输出路径必须与输入不同",
+      "invalid_bitrate": "无效的比特率",
+      "ffmpeg_failed": "ffmpeg 提取音频失败"
+    }
   }
 }

--- a/src/pages/audio/index.tsx
+++ b/src/pages/audio/index.tsx
@@ -1,0 +1,28 @@
+import { AudioForm } from '@/features/audio'
+import { PageTemplate } from '@/shared/layout'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Audio extraction page content.
+ *
+ * Mounted by `PersistentPageLayout` at `/audio`. Header explains the feature;
+ * the rest is delegated to {@link AudioForm}.
+ */
+export function AudioContent() {
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    document.title = `${t('audio.title')} - ${t('app.title')}`
+  }, [t])
+
+  return (
+    <PageTemplate title={t('audio.title')} description={t('audio.description')}>
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+        <AudioForm />
+      </div>
+    </PageTemplate>
+  )
+}
+
+export default AudioContent

--- a/src/shared/layout/PersistentPageLayout.tsx
+++ b/src/shared/layout/PersistentPageLayout.tsx
@@ -3,6 +3,7 @@ import type { FC, ReactElement } from 'react'
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router'
 
+import { AudioContent } from '@/pages/audio'
 import { ConcatContent } from '@/pages/concat'
 import { FavoriteContent } from '@/pages/favorite'
 import { HistoryContent } from '@/pages/history'
@@ -22,6 +23,7 @@ const PAGES: readonly PageConfig[] = [
   { path: '/watch-history', Component: WatchHistoryContent },
   { path: '/trim', Component: TrimContent },
   { path: '/concat', Component: ConcatContent },
+  { path: '/audio', Component: AudioContent },
 ] as const
 
 const VALID_PATHS: readonly string[] = PAGES.map((p) => p.path)

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -19,7 +19,7 @@ import {
 import { cn } from '@/shared/lib/utils'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import type { LucideIcon } from 'lucide-react'
-import { Combine, Eye, Home, Scissors, Star } from 'lucide-react'
+import { Combine, Eye, Home, Music, Scissors, Star } from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
@@ -120,6 +120,13 @@ export function NavigationSidebarHeader({
           icon: Combine,
           label: t('nav.concat'),
           ariaLabel: t('nav.aria.concat'),
+          requiresAuth: false,
+        },
+        {
+          path: '/audio',
+          icon: Music,
+          label: t('nav.audio'),
+          ariaLabel: t('nav.aria.audio'),
           requiresAuth: false,
         },
       ],


### PR DESCRIPTION
## Summary

Adds a new **Audio Extraction** page that extracts the audio track from a local MP4 file into MP3 or M4A using ffmpeg. The architecture mirrors the existing trim feature.

## Changes

### Backend (Rust)
- `handlers/audio.rs` (new): `extract_audio` (`-vn` + `libmp3lame`/`aac`) with `audio://progress` events and `ERR::AUDIO_*` error codes
- `utils/ffmpeg_probe.rs`: `probe_audio_bitrate_kbps` — parses the `Audio:` line from `ffmpeg -i` (no ffprobe binary dependency)
- `lib.rs`: `extract_audio` / `probe_audio_bitrate` commands registered
- `models/settings.rs`: `AudioFormat` enum + `audio_format` field

### Frontend (React/TS)
- `features/audio` (new): types / api / bitrate presets / hook / form
- Bitrate presets above the probed source bitrate are **disabled** (lossy up-conversion only wastes space); the default is auto-selected as the largest preset not exceeding the source, with a 128 kbps floor and 192 kbps fallback when the bitrate is unknown (VBR)
- `pages/audio`: page content
- `PersistentPageLayout` / `NavigationSidebarHeader`: new `/audio` route and "Audio" entry under the Tools sidebar group
- `SettingsForm` / `settingsSlice` / `type.ts`: `audioFormat` persisted to `settings.json`, configurable from both the settings dialog and the audio page (symmetrical with `trimMode`)

### i18n
- `audio.*` and `settings.audio_format_*` added across all 6 languages (en/ja/zh/ko/es/fr)

Closes #391