### PR TITLE
chore: force issue templates for non-maintainers

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Non-maintainers are forced to pick a template. Users with Write access or
+# above still see the "Maintainers only" blank-issue option.
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary

Add `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` so that non-maintainers must pick an issue template. Per GitHub's behavior, users with Write access or above (Write / Maintain / Admin) still see the blank-issue option labeled **Maintainers only**.

## Related Issue

N/A

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [ ] After merge, open `/issues/new/choose` as a non-collaborator → only template options are shown (no blank issue)
- [ ] As a collaborator (Write+), confirm the "Open a blank issue" link appears with the **Maintainers only** label

## Checklist

- [x] Conventional Commits format followed
- [x] Tests: N/A (config-only change, no TS/Rust code)
- [x] i18n: N/A (no user-facing strings)
