### PR TITLE
feat(ffmpeg): validate binary functionality and add retry on install failure

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -39,3 +39,11 @@ pub const MIN_DATA_FOR_SPEED_CHECK: u64 = 100 * 1024; // 100 KiB
 /// Limits the number of times CDN nodes are rotated when slow speeds
 /// are detected. Max is (number of CDN URLs) × MAX_CDN_LOOPS.
 pub const MAX_CDN_LOOPS: u8 = 3;
+
+/// Timeout in seconds for the ffmpeg functional validation probe.
+///
+/// The validation runs a tiny AAC encode to confirm the binary is not
+/// partially corrupted. A generous timeout covers low-spec machines
+/// where process spawn + codec init is slower; a hung ffmpeg (a symptom
+/// of corruption) is treated as validation failure.
+pub const FFMPEG_VALIDATION_TIMEOUT_SECS: u64 = 60;

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -4,11 +4,13 @@
 //! It downloads platform-specific ffmpeg binaries and provides functionality
 //! to merge separate video and audio streams into a single MP4 file.
 
+use crate::constants::FFMPEG_VALIDATION_TIMEOUT_SECS;
 use crate::emits::Emits;
 use crate::utils::downloads::download_url;
 use crate::utils::paths::{get_ffmpeg_path, get_ffmpeg_root_path};
 use anyhow::Result;
 use std::fs::File;
+use std::time::Duration;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -17,6 +19,7 @@ use std::{
 use tauri::AppHandle;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 /// Options for embedding subtitles during video merging.
@@ -69,7 +72,7 @@ pub enum MergeMode {
 /// # Returns
 ///
 /// Returns `true` if ffmpeg is valid and executable, `false` otherwise.
-pub fn validate_ffmpeg(app: &AppHandle) -> bool {
+pub async fn validate_ffmpeg(app: &AppHandle) -> bool {
     log::info!("[BE] validate_ffmpeg: checking ffmpeg installation");
     let ffmpeg_root = get_ffmpeg_root_path(app);
     let ffmpeg_path = get_ffmpeg_path(app);
@@ -83,7 +86,7 @@ pub fn validate_ffmpeg(app: &AppHandle) -> bool {
         return false;
     }
 
-    if !validate_command(&ffmpeg_path) {
+    if !validate_command(&ffmpeg_path).await {
         log::warn!("[BE] validate_ffmpeg: ffmpeg binary validation failed, cleaning up");
         cleanup_ffmpeg_dir(&ffmpeg_root);
         return false;
@@ -201,6 +204,19 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         }
     }
 
+    // Functional validation: confirm the freshly installed binary can
+    // actually encode audio. A download/extract that produced a
+    // partially corrupted binary would otherwise be accepted and only
+    // surface later as broken merges (issue #440). On failure, remove
+    // the corrupt tree so the next launch re-downloads from scratch.
+    let ffmpeg_bin = get_ffmpeg_path(app);
+    if !validate_command(&ffmpeg_bin).await {
+        log::warn!("[BE] install_ffmpeg: post-install validation failed, removing ffmpeg");
+        let _ = fs::remove_dir_all(&ffmpeg_root);
+        return Ok(false);
+    }
+
+    log::info!("[BE] install_ffmpeg: installed and validated successfully");
     Ok(true)
 }
 
@@ -303,33 +319,87 @@ fn build_ffmpeg_bin_path(base_path: &Path) -> PathBuf {
     path
 }
 
-/// Validates that a binary can be executed by running it with --help.
+/// Validates that the ffmpeg binary is functionally intact.
+///
+/// Runs a tiny AAC encode driven by a built-in `lavfi` source
+/// (`anullsrc`) so no external test file is needed. This is stronger
+/// than a `--help` probe, which only confirms the binary can start: a
+/// partially corrupted build whose codec pipeline is broken can still
+/// answer `--help` but silently produce truncated/broken merges (see
+/// issue #440). A successful encode exit proves the AAC codec works.
 ///
 /// On Windows, this function prevents console window creation during validation.
 ///
+/// The probe is bounded by [`FFMPEG_VALIDATION_TIMEOUT_SECS`]; a hung
+/// ffmpeg (another corruption symptom) is treated as failure.
+///
 /// # Arguments
 ///
-/// * `path` - Path to the binary to validate
+/// * `path` - Path to the ffmpeg binary to validate
 ///
 /// # Returns
 ///
-/// Returns `true` if the binary exists and can be executed successfully.
-fn validate_command(path: &Path) -> bool {
+/// Returns `true` if the binary exists and the test encode succeeds
+/// within the timeout.
+async fn validate_command(path: &Path) -> bool {
     if !path.exists() {
         return false;
     }
 
-    let mut cmd_builder = Command::new(path);
-    cmd_builder.arg("--help");
+    log::info!("[BE] validate_command: running functional AAC encode probe");
+
+    let mut cmd = AsyncCommand::new(path);
+    // Ensure the probe child is reaped on timeout. Without this, a hung
+    // (corrupted) ffmpeg would be orphaned when the timeout future drops,
+    // which on Windows can also block the subsequent remove_dir_all.
+    cmd.kill_on_drop(true);
+    cmd.args([
+        "-hide_banner",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=r=44100:cl=stereo",
+        "-t",
+        "0.05",
+        "-c:a",
+        "aac",
+        "-f",
+        "null",
+        "-",
+    ]);
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
 
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd_builder.creation_flags(CREATE_NO_WINDOW);
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
-    cmd_builder.output().is_ok()
+    match timeout(
+        Duration::from_secs(FFMPEG_VALIDATION_TIMEOUT_SECS),
+        cmd.status(),
+    )
+    .await
+    {
+        Ok(Ok(status)) if status.success() => true,
+        Ok(Ok(status)) => {
+            log::warn!("[BE] validate_command: probe failed, exit={:?}", status);
+            false
+        }
+        Ok(Err(e)) => {
+            log::warn!("[BE] validate_command: probe spawn error: {}", e);
+            false
+        }
+        Err(_) => {
+            log::warn!(
+                "[BE] validate_command: probe timed out after {}s",
+                FFMPEG_VALIDATION_TIMEOUT_SECS
+            );
+            false
+        }
+    }
 }
 
 /// Moves ffmpeg from one location to another with validation.
@@ -359,7 +429,7 @@ fn validate_command(path: &Path) -> bool {
 /// - Directory creation fails
 /// - Copy operation fails
 /// - Validation fails (new path is cleaned up)
-pub fn move_ffmpeg(from_path: PathBuf, to_path: PathBuf) -> Result<(), String> {
+pub async fn move_ffmpeg(from_path: PathBuf, to_path: PathBuf) -> Result<(), String> {
     // Validate source ffmpeg
     if !from_path.exists() {
         return Err(format!(
@@ -374,7 +444,7 @@ pub fn move_ffmpeg(from_path: PathBuf, to_path: PathBuf) -> Result<(), String> {
         return Err(format!("Source ffmpeg binary not found: {:?}", ffmpeg_bin));
     }
 
-    if !validate_command(&ffmpeg_bin) {
+    if !validate_command(&ffmpeg_bin).await {
         return Err(format!(
             "Source ffmpeg binary is not valid: {:?}",
             ffmpeg_bin
@@ -396,7 +466,7 @@ pub fn move_ffmpeg(from_path: PathBuf, to_path: PathBuf) -> Result<(), String> {
     // Validate the copied ffmpeg
     let new_ffmpeg_bin = build_ffmpeg_bin_path(&to_path);
 
-    if !validate_command(&new_ffmpeg_bin) {
+    if !validate_command(&new_ffmpeg_bin).await {
         // Validation failed - clean up the new directory
         let _ = fs::remove_dir_all(&to_path);
         return Err(format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,7 +353,7 @@ pub fn run() {
 /// Returns `true` if ffmpeg is installed and functional, `false` otherwise.
 #[tauri::command]
 async fn validate_ffmpeg(app: AppHandle) -> bool {
-    ffmpeg::validate_ffmpeg(&app)
+    ffmpeg::validate_ffmpeg(&app).await
 }
 
 /// Downloads and installs the ffmpeg binary for the current platform.
@@ -739,7 +739,7 @@ async fn update_lib_path(app: AppHandle, new_path: String) -> Result<(), String>
 
     // Move ffmpeg (if it exists)
     if old_ffmpeg_path.exists() {
-        ffmpeg::move_ffmpeg(old_ffmpeg_path.clone(), new_ffmpeg_path)?;
+        ffmpeg::move_ffmpeg(old_ffmpeg_path.clone(), new_ffmpeg_path).await?;
     }
 
     // Update settings with new lib_path

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -280,7 +280,7 @@
     "cannot_continue": "The application cannot continue",
     "message_label": "Error message:",
     "code_label": "Error code:",
-    "ffmpeg_not_found": "ffmpeg was not found.",
+    "ffmpeg_not_found": "ffmpeg was not found or could not be initialized.",
     "cookie_invalid": "Cookie is invalid.",
     "user_info_failed": "Failed to obtain user information.",
     "user_info_failed_other": "Failed to obtain user information (not login related).",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -280,7 +280,7 @@
     "cannot_continue": "La aplicación no puede continuar",
     "message_label": "Mensaje de error:",
     "code_label": "Código de error:",
-    "ffmpeg_not_found": "ffmpeg no se encontró.",
+    "ffmpeg_not_found": "ffmpeg no se encontró o no se pudo inicializar.",
     "cookie_invalid": "Cookie inválida.",
     "user_info_failed": "No se pudo obtener la información del usuario.",
     "user_info_failed_other": "No se pudo obtener la información del usuario (no relacionado con sesión).",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -280,7 +280,7 @@
     "cannot_continue": "L'application ne peut pas continuer",
     "message_label": "Message d'erreur:",
     "code_label": "Code d'erreur:",
-    "ffmpeg_not_found": "ffmpeg introuvable.",
+    "ffmpeg_not_found": "ffmpeg est introuvable ou n'a pas pu être initialisé.",
     "cookie_invalid": "Cookie invalide.",
     "user_info_failed": "Impossible d'obtenir les informations utilisateur.",
     "user_info_failed_other": "Impossible d'obtenir les informations utilisateur (autre qu'absence de connexion).",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -280,7 +280,7 @@
     "cannot_continue": "アプリを続行することができません",
     "message_label": "エラーメッセージ:",
     "code_label": "エラーコード:",
-    "ffmpeg_not_found": "ffmpegが見つかりません。",
+    "ffmpeg_not_found": "ffmpegが見つからないか、初期化できませんでした。",
     "cookie_invalid": "Cookieが無効です。",
     "user_info_failed": "ユーザ情報が取得できませんでした。",
     "user_info_failed_other": "ユーザ情報が取得できません（未ログイン以外）。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -280,7 +280,7 @@
     "cannot_continue": "애플리케이션을 계속 실행할 수 없습니다",
     "message_label": "오류 메시지:",
     "code_label": "오류 코드:",
-    "ffmpeg_not_found": "ffmpeg 를 찾을 수 없습니다.",
+    "ffmpeg_not_found": "ffmpeg 를 찾을 수 없거나 초기화할 수 없습니다.",
     "cookie_invalid": "쿠키가 유효하지 않습니다.",
     "user_info_failed": "사용자 정보를 가져올 수 없습니다.",
     "user_info_failed_other": "사용자 정보를 가져올 수 없습니다(로그인 문제 제외).",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -280,7 +280,7 @@
     "cannot_continue": "应用无法继续运行",
     "message_label": "错误信息:",
     "code_label": "错误代码:",
-    "ffmpeg_not_found": "未找到 ffmpeg。",
+    "ffmpeg_not_found": "未找到 ffmpeg 或无法初始化。",
     "cookie_invalid": "Cookie 无效。",
     "user_info_failed": "无法获取用户信息。",
     "user_info_failed_other": "无法获取用户信息（非未登录原因）。",

--- a/src/pages/error/index.tsx
+++ b/src/pages/error/index.tsx
@@ -134,13 +134,16 @@ function ErrorPage() {
           {t('errorPage.code_label')} {errorCode}
         </div>
       </div>
-      {errorCode === 6 && (
+      {/* Why: errorCode 1 is included because the strengthened ffmpeg
+          validation now rejects and removes a corrupt binary (issue #440);
+          a relaunch triggers a clean re-download instead of forcing a quit. */}
+      {(errorCode === 1 || errorCode === 6) && (
         <div className="text-muted-foreground text-sm">
           {t('errorPage.try_restart')}
         </div>
       )}
       <div className="m-3 flex gap-3">
-        {errorCode === 6 && (
+        {(errorCode === 1 || errorCode === 6) && (
           <Button onClick={handleRelaunch} variant="default" className="p-3">
             {t('errorPage.restart_app')}
           </Button>


### PR DESCRIPTION
## Summary

Strengthens ffmpeg validation to detect a partially corrupted binary — the suspected cause of #440, where a long video was downloaded with truncated audio. Previously `validate_command` only checked that `--help` succeeded, which a corrupted binary with a broken codec pipeline can still pass, silently producing broken merges.

- **`validate_command`** now runs a real AAC encode probe (`-f lavfi -i anullsrc -t 0.05 -c:a aac -f null -`) with a 60s timeout. `kill_on_drop(true)` ensures the probe child is reaped on timeout (also avoids Windows `remove_dir_all` races).
- **`install_ffmpeg`** validates after extraction and removes the ffmpeg dir on failure, forcing a clean re-download on the next launch.
- **`validate_ffmpeg` / `move_ffmpeg`** made `async` to await the probe (all callers are already in async contexts).
- **`/error` page** shows a "Restart App" button for `errorCode` 1 (ffmpeg failure) so users can trigger re-install without quitting.
- **i18n**: `ffmpeg_not_found` message widened to "not found or could not be initialized" across all 6 locales.

## Related Issue

References #440

This is preventive hardening, not a direct fix. #440 did not reproduce in our environment (mac/Win11 downloaded the same file with full 3h29m audio). The suspected cause on the reporter's side is either a corrupted Bilibili CDN payload or a partially corrupted locally-installed ffmpeg. This PR addresses the latter — detecting and self-healing a corrupt ffmpeg — while the reporter was also given a manual reinstall workaround in the issue.

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `cargo build` succeeds
- [x] `npm run typecheck` / `npm run lint` clean
- [x] i18n key count consistent (582 across all 6 locales)
- [x] `npm run tauri dev` — app starts; backend log shows `validate_command: running functional AAC encode probe` → `validate_ffmpeg: ffmpeg is valid`
- [ ] Corrupt the ffmpeg binary and confirm it is detected + re-installed on next launch (destructive test, deferred)

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)