### PR TITLE
feat(cleanup): sweep subtitle temp files and show startup status

### DIFF
--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -25,8 +25,9 @@ pub struct CleanupResult {
 /// Cleans up orphaned temporary files older than 24 hours.
 ///
 /// Scans the lib directory for temp files matching:
-/// - `temp_video_*.m4s`
-/// - `temp_audio_*.m4s`
+/// - `temp_video_*.m4s` - Temporary video segments
+/// - `temp_audio_*.m4s` - Temporary audio segments
+/// - `temp_sub_*.srt` - Temporary subtitle files
 ///
 /// Files older than 24 hours are deleted.
 pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> CleanupResult {
@@ -86,6 +87,7 @@ pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> Cleanu
 /// Matches files with the following naming conventions:
 /// - `temp_video_*.m4s` - Temporary video segments
 /// - `temp_audio_*.m4s` - Temporary audio segments
+/// - `temp_sub_*.srt` - Temporary subtitle files
 ///
 /// # Arguments
 ///
@@ -102,6 +104,7 @@ pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> Cleanu
 /// # use crate::handlers::cleanup::is_temp_file;
 /// assert!(is_temp_file(Path::new("temp_video_123.m4s")));
 /// assert!(is_temp_file(Path::new("temp_audio_456.m4s")));
+/// assert!(is_temp_file(Path::new("temp_sub_789.srt")));
 /// assert!(!is_temp_file(Path::new("final_video.mp4")));
 /// ```
 fn is_temp_file(path: &Path) -> bool {
@@ -110,6 +113,9 @@ fn is_temp_file(path: &Path) -> bool {
         None => return false,
     };
 
-    (file_name.starts_with("temp_video_") || file_name.starts_with("temp_audio_"))
-        && file_name.ends_with(".m4s")
+    let is_video = file_name.starts_with("temp_video_") && file_name.ends_with(".m4s");
+    let is_audio = file_name.starts_with("temp_audio_") && file_name.ends_with(".m4s");
+    let is_subtitle = file_name.starts_with("temp_sub_") && file_name.ends_with(".srt");
+
+    is_video || is_audio || is_subtitle
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1190,9 +1190,11 @@ async fn fetch_watch_history(
 /// Scans the lib directory for temp files matching:
 /// - `temp_video_*.m4s`
 /// - `temp_audio_*.m4s`
+/// - `temp_sub_*.srt`
 ///
-/// Files older than 24 hours are deleted. This is a fire-and-forget
-/// operation that logs errors instead of returning them.
+/// Files older than 24 hours are deleted. Errors during the scan or
+/// individual deletions are logged, and the counts are returned via
+/// `CleanupResult`.
 ///
 /// # Arguments
 ///

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -133,12 +133,26 @@ export const useInit = () => {
     // Fire & forget OS detection (don't await)
     getOs()
 
-    // Clean up orphaned temp files (fire-and-forget, non-blocking)
-    invoke<{ deletedCount: number; failedCount: number }>(
-      'cleanup_temp_files',
-    ).catch(() => {
-      // Silently ignore cleanup failures
-    })
+    // Clean up orphaned temp files from previous sessions. Awaited so the
+    // status label stays visible during cleanup (mirroring the ffmpeg
+    // check step), even though it usually completes in a blink.
+    setMessage(t('init.cleanup_in_progress'))
+    try {
+      const result = await invoke<{
+        deletedCount: number
+        failedCount: number
+      }>('cleanup_temp_files')
+      if (result.deletedCount > 0 || result.failedCount > 0) {
+        setMessage(
+          t('init.cleanup_completed', {
+            deleted: result.deletedCount,
+            failed: result.failedCount,
+          }),
+        )
+      }
+    } catch {
+      // Silently ignore cleanup failures (non-fatal for startup)
+    }
 
     // Version checking is handled by UpdaterProvider (non-blocking dialog)
     const settings = await getAppSettings()

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -273,7 +273,9 @@
     "update_done_restart": "Update finished. Restarting...",
     "update_failed": "Failed to check or apply update",
     "cookie_success": "Cookie retrieval succeeded",
-    "cookie_failed": "Cookie retrieval failed"
+    "cookie_failed": "Cookie retrieval failed",
+    "cleanup_in_progress": "Cleaning up temporary files...",
+    "cleanup_completed": "Cleaned up {{deleted}} temporary files ({{failed}} failed)"
   },
   "errorPage": {
     "title": "An error occurred",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -273,7 +273,9 @@
     "update_done_restart": "Actualización completada. Reiniciando...",
     "update_failed": "Error en la actualización",
     "cookie_success": "Cookie obtenida correctamente",
-    "cookie_failed": "Error al obtener cookie"
+    "cookie_failed": "Error al obtener cookie",
+    "cleanup_in_progress": "Limpiando archivos temporales...",
+    "cleanup_completed": "Limpiados {{deleted}} archivos temporales ({{failed}} fallidos)"
   },
   "errorPage": {
     "title": "Ocurrió un error",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -273,7 +273,9 @@
     "update_done_restart": "Mise à jour terminée. Redémarrage...",
     "update_failed": "Échec de la mise à jour",
     "cookie_success": "Récupération du cookie réussie",
-    "cookie_failed": "Échec de la récupération du cookie"
+    "cookie_failed": "Échec de la récupération du cookie",
+    "cleanup_in_progress": "Nettoyage des fichiers temporaires...",
+    "cleanup_completed": "{{deleted}} fichiers temporaires nettoyés ({{failed}} échoués)"
   },
   "errorPage": {
     "title": "Une erreur est survenue",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -273,7 +273,9 @@
     "update_done_restart": "アップデートが完了しました。アプリを再起動します...",
     "update_failed": "アップデートの確認または適用に失敗しました",
     "cookie_success": "Cookieの取得に成功しました",
-    "cookie_failed": "Cookieの取得に失敗しました"
+    "cookie_failed": "Cookieの取得に失敗しました",
+    "cleanup_in_progress": "一時ファイルをクリーンアップしています...",
+    "cleanup_completed": "{{deleted}}個の一時ファイルをクリーンアップしました（{{failed}}個失敗）"
   },
   "errorPage": {
     "title": "エラーが発生しました",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -273,7 +273,9 @@
     "update_done_restart": "업데이트 완료. 재시작 중...",
     "update_failed": "업데이트 확인 또는 적용 실패",
     "cookie_success": "쿠키 가져오기 성공",
-    "cookie_failed": "쿠키 가져오기 실패"
+    "cookie_failed": "쿠키 가져오기 실패",
+    "cleanup_in_progress": "임시 파일 정리 중...",
+    "cleanup_completed": "{{deleted}}개의 임시 파일을 정리했습니다 ({{failed}}개 실패)"
   },
   "errorPage": {
     "title": "오류가 발생했습니다",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -273,7 +273,9 @@
     "update_done_restart": "更新完成，正在重启...",
     "update_failed": "更新检查或应用失败",
     "cookie_success": "Cookie 获取成功",
-    "cookie_failed": "Cookie 获取失败"
+    "cookie_failed": "Cookie 获取失败",
+    "cleanup_in_progress": "正在清理临时文件...",
+    "cleanup_completed": "已清理 {{deleted}} 个临时文件（{{failed}} 个失败）"
   },
   "errorPage": {
     "title": "发生错误",


### PR DESCRIPTION
## Summary

Extend the startup orphan-file cleanup to also sweep subtitle temp files (`temp_sub_*.srt`), which were previously stranded forever (the old pattern only matched `temp_video_*`/`temp_audio_*`). The cleanup is also awaited instead of fire-and-forget so the splash can show it as a visible startup status step (in-progress + completed counts), mirroring the ffmpeg check UX.

The 24h age threshold is intentionally kept, so files that may still be written by another concurrently running session are never deleted.

## Related Issue

<!-- No related open issue found via keyword search -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `npm run tauri dev` to launch the app
- [x] Place a `temp_sub_*.srt` (and/or `temp_video_*.m4s`) older than 24h in the configured lib path
- [x] Restart the app and confirm the splash shows the cleanup in-progress label, then the completed count
- [x] Verify stale temp files (>24h) are deleted while files <24h old remain untouched
- [x] Confirm a cleanup failure does not block startup (swallowed in try/catch)

## Screenshots / Videos (Optional)

N/A — splash status label, transient by design.

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — updated `is_temp_file` doctest to cover the subtitle pattern
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)