### PR TITLE
chore: ignore Playwright MCP artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ e2e-tests/screenshots/
 
 # Local references (API docs, etc.)
 references/
+
+# Playwright MCP artifacts
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/` to `.gitignore` to exclude locally generated Playwright MCP artifacts from version control.

## Context
The Playwright MCP server writes local artifacts under `.playwright-mcp/` during browser automation (console logs, element/page screenshots, page snapshots). These are machine-local and should not be tracked in version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)