### PR TITLE
chore(settings): change default font size from 16px to 14px

### DIFF
--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -129,7 +129,7 @@ pub struct Settings {
     )]
     pub open_devtools_on_startup: Option<bool>,
     /// Base font size in pixels (12-20). Applied as root font-size for rem-based scaling.
-    /// Defaults to 16 (browser default) if not specified.
+    /// Defaults to 14 if not specified.
     #[serde(rename = "fontSize", default, skip_serializing_if = "Option::is_none")]
     pub font_size: Option<u8>,
     /// Whether to skip the splash screen animation on startup.

--- a/src/features/settings/lib/fontSize.ts
+++ b/src/features/settings/lib/fontSize.ts
@@ -1,9 +1,12 @@
 import type { FontSizePreset } from '@/features/settings/type'
 
 /**
- * Default font size in pixels (browser standard).
+ * Default font size in pixels.
+ *
+ * Slightly smaller than the browser default (16px) to fit more
+ * content on screen while remaining readable.
  */
-export const FONT_SIZE_DEFAULT: FontSizePreset = 16
+export const FONT_SIZE_DEFAULT: FontSizePreset = 14
 
 /**
  * Minimum allowed font size in pixels.

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -1,3 +1,4 @@
+import { FONT_SIZE_DEFAULT } from '@/features/settings/lib/fontSize'
 import type { Settings } from '@/features/settings/type'
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
@@ -16,7 +17,7 @@ const initialState: SettingsState = {
   dialogOpen: false,
   autoRenameDuplicates: true,
   showGithubStars: true,
-  fontSize: 16,
+  fontSize: FONT_SIZE_DEFAULT,
   trimMode: 'copy',
   audioFormat: 'mp3',
   theme: 'light',

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -68,7 +68,7 @@ export interface Settings {
    * Base font size in pixels (12-20).
    *
    * Applied as root font-size for rem-based scaling.
-   * Defaults to 16 (browser default) if not specified.
+   * Defaults to 14 if not specified.
    */
   fontSize?: FontSizePreset
   /**

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,7 +5,7 @@
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary

Change the default base font size from 16px to 14px for new and unconfigured users, to fit more content on screen while remaining readable.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] \`npm run dev\` — confirmed the UI renders at the 14px base font
- [x] Settings dialog font-size slider shows 14 for unconfigured users
- [x] \`npm run format:check\`, \`npm run lint\`, \`npm run typecheck\` all pass

## Breaking Changes

None. Only affects new/unconfigured users; existing users with a persisted \`fontSize\` keep their value.

## Checklist

- [x] \`/review-all\` executed (format → code-reviewer)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A for chore)
- [x] i18n files synced (N/A — no user-facing strings changed)

---

### Implementation Notes

- \`FONT_SIZE_DEFAULT\`: 16 → 14 (single source of truth)
- \`settingsSlice.ts\`: reference \`FONT_SIZE_DEFAULT\` in the Redux initialState instead of a hardcoded \`16\`, keeping the settings slider display and the applied value in sync
- \`index.css\`: \`:root { font-size: 14px }\` to align the pre-JS initial value (FOUC) with the JS default
- \`fontSize.ts\`, \`type.ts\`, \`settings.rs\`: update doc comments to reflect the new default

Reviewed by a 3-expert team (correctness / conventions / impact); found and fixed a Prettier import-order violation (would have failed CI \`format:check\`) and a stale Rust doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)