### PR TITLE
feat(settings): add font size keyboard shortcuts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from '@/app/store'
+import { useFontSizeShortcuts } from '@/features/settings/hooks/useFontSizeShortcuts'
 import { useThemeEffect } from '@/features/settings/hooks/useThemeEffect'
 import { UpdateNotification } from '@/features/updater'
 import IndexPage from '@/pages'
@@ -13,6 +14,7 @@ import { Route, Routes } from 'react-router'
 function App() {
   const theme = useSelector((state) => state.settings.theme) ?? 'light'
   useThemeEffect()
+  useFontSizeShortcuts()
 
   useEffect(() => {
     if (import.meta.env.DEV) return

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils'
+
+function Kbd({ className, ...props }: React.ComponentProps<'kbd'>) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        'bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium select-none',
+        "[&_svg:not([class*='size-'])]:size-3",
+        '[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn('inline-flex items-center gap-1', className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -29,6 +29,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
 import { Slider } from '@/components/ui/slider'
 import { callGetCurrentLibPath } from '@/features/settings/api/settingApi'
 import {
@@ -372,6 +373,13 @@ function SettingsForm() {
 
   const currentFontSize = parseFontSize(settings.fontSize)
 
+  // Show the platform-native modifier in shortcut hints (Cmd on macOS,
+  // Ctrl elsewhere). `userAgent` is used because `navigator.platform` is
+  // deprecated.
+  const isMac =
+    typeof navigator !== 'undefined' && /Mac/i.test(navigator.userAgent)
+  const shortcutModKey = isMac ? '⌘' : 'Ctrl'
+
   /**
    * Handles font size slider changes.
    *
@@ -442,7 +450,13 @@ function SettingsForm() {
         </FormItem>
         <div className="space-y-3">
           <div className="space-y-0.5">
-            <Label>{t('settings.font_size_label')}</Label>
+            <div className="flex items-center justify-between gap-2">
+              <Label>{t('settings.font_size_label')}</Label>
+              <KbdGroup>
+                <Kbd>{shortcutModKey}</Kbd>
+                <Kbd>+/-</Kbd>
+              </KbdGroup>
+            </div>
             <p className="text-muted-foreground text-sm">
               {t('settings.font_size_description')}
             </p>

--- a/src/features/settings/hooks/useFontSizeShortcuts.test.tsx
+++ b/src/features/settings/hooks/useFontSizeShortcuts.test.tsx
@@ -1,0 +1,148 @@
+import { store } from '@/app/store'
+import { useFontSizeShortcuts } from '@/features/settings/hooks/useFontSizeShortcuts'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { invoke } from '@tauri-apps/api/core'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Capture toast.info calls so we can assert the feedback payload.
+const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }))
+
+vi.mock('sonner', () => ({
+  toast: { info: (...args: unknown[]) => toastInfo(...args) },
+}))
+
+// i18next is not initialized in unit tests; stub `t` (and the default
+// `i18n` instance used by `@/i18n`) so we can assert the toast message
+// shape without booting the full i18n pipeline.
+vi.mock('i18next', () => {
+  const t = (key: string, opts?: Record<string, unknown>) =>
+    opts && typeof opts.size === 'number' ? `${key}:${opts.size}` : key
+  return {
+    t,
+    default: { t, language: 'en' },
+  }
+})
+
+// invoke is already mocked globally by src/test/setup.ts.
+const mockInvoke = invoke as unknown as ReturnType<typeof vi.fn>
+
+const baselineSettings: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  autoRenameDuplicates: true,
+  showGithubStars: true,
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+function press(key: string, init: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  })
+  const preventDefault = vi.spyOn(event, 'preventDefault')
+  window.dispatchEvent(event)
+  return { event, preventDefault }
+}
+
+describe('useFontSizeShortcuts', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baselineSettings))
+    document.documentElement.style.fontSize = ''
+    mockInvoke.mockClear()
+    toastInfo.mockClear()
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('increases font size on Ctrl+= and persists', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('=', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(15)
+    expect(document.documentElement.style.fontSize).toBe('15px')
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'set_settings',
+      expect.objectContaining({
+        settings: expect.objectContaining({ fontSize: 15 }),
+      }),
+    )
+    expect(toastInfo).toHaveBeenCalledWith(
+      'settings.font_size_changed:15',
+      expect.objectContaining({ id: 'font-size-shortcut' }),
+    )
+  })
+
+  it('treats Ctrl++ (shifted) the same as Ctrl+=', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('+', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(15)
+  })
+
+  it('decreases font size on Ctrl+-', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('-', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(13)
+    expect(document.documentElement.style.fontSize).toBe('13px')
+  })
+
+  it('accepts Cmd (metaKey) on macOS', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('+', { metaKey: true })
+    expect(store.getState().settings.fontSize).toBe(15)
+  })
+
+  it('clamps at MAX, shows the boundary toast, but skips persisting', () => {
+    store.dispatch(setSettings({ ...baselineSettings, fontSize: 20 }))
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('+', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(20)
+    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(toastInfo).toHaveBeenCalledWith(
+      'settings.font_size_changed:20',
+      expect.objectContaining({ id: 'font-size-shortcut' }),
+    )
+  })
+
+  it('clamps at MIN without persisting', () => {
+    store.dispatch(setSettings({ ...baselineSettings, fontSize: 12 }))
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('-', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(12)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys without a modifier', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    press('+')
+    press('-')
+    expect(store.getState().settings.fontSize).toBe(14)
+    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(toastInfo).not.toHaveBeenCalled()
+  })
+
+  it('calls preventDefault to suppress native webview zoom', () => {
+    renderHook(() => useFontSizeShortcuts(), { wrapper })
+    const { preventDefault } = press('+', { ctrlKey: true })
+    expect(preventDefault).toHaveBeenCalled()
+  })
+
+  it('detaches the listener on unmount', () => {
+    const { unmount } = renderHook(() => useFontSizeShortcuts(), { wrapper })
+    unmount()
+    press('+', { ctrlKey: true })
+    expect(store.getState().settings.fontSize).toBe(14)
+  })
+})

--- a/src/features/settings/hooks/useFontSizeShortcuts.ts
+++ b/src/features/settings/hooks/useFontSizeShortcuts.ts
@@ -1,0 +1,78 @@
+import { store } from '@/app/store'
+import {
+  FONT_SIZE_DEFAULT,
+  applyFontSize,
+  parseFontSize,
+} from '@/features/settings/lib/fontSize'
+import { useSettings } from '@/features/settings/useSettings'
+import { t } from 'i18next'
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+
+// Shared toast id so rapid presses replace the previous toast instead of
+// stacking, keeping the feedback unobtrusive while adjusting repeatedly.
+const FONT_SIZE_TOAST_ID = 'font-size-shortcut'
+
+/**
+ * Global keyboard shortcuts for base font-size adjustment.
+ *
+ * - Ctrl/Cmd + `+` or `=` -> increase by one step
+ * - Ctrl/Cmd + `-`        -> decrease by one step
+ *
+ * The listener is registered once (empty deps) and reads the latest
+ * settings straight from the Redux store singleton, so it never goes
+ * stale when settings change. Persistence runs through the canonical
+ * `saveByForm(silent=true)` path (Redux dispatch + backend save, with
+ * error logging handled there). A short toast shows the resulting size.
+ *
+ * Must be mounted exactly once at the app root (see `App.tsx`).
+ */
+export function useFontSizeShortcuts(): void {
+  const { saveByForm } = useSettings()
+  // saveByForm is recreated every render; keep the latest in a ref so the
+  // stable keydown listener always calls the current closure without
+  // re-subscribing on each settings change.
+  const saveByFormRef = useRef(saveByForm)
+  saveByFormRef.current = saveByForm
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return
+
+      let direction: 1 | -1
+      if (event.key === '+' || event.key === '=') {
+        direction = 1
+      } else if (event.key === '-') {
+        direction = -1
+      } else {
+        return
+      }
+
+      // Suppress the webview's native page zoom for this accelerator.
+      event.preventDefault()
+
+      const currentSettings = store.getState().settings
+      const current = currentSettings.fontSize ?? FONT_SIZE_DEFAULT
+      const updated = parseFontSize(current + direction)
+
+      // Apply + persist only when the value actually changes. At the
+      // min/max boundary we still show the toast so the user knows the
+      // keystroke was received and the limit was hit.
+      if (updated !== current) {
+        applyFontSize(updated)
+        void saveByFormRef.current(
+          { ...currentSettings, fontSize: updated },
+          true,
+        )
+      }
+
+      toast.info(t('settings.font_size_changed', { size: updated }), {
+        id: FONT_SIZE_TOAST_ID,
+        duration: 1500,
+      })
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -335,6 +335,7 @@
     "theme_dark": "Dark",
     "font_size_label": "Font Size",
     "font_size_description": "Adjust the base font size. Changes apply immediately.",
+    "font_size_changed": "Font size: {{size}}px",
     "current_version": "Current version: {{version}}",
     "update_check": {
       "aria_label": "Update check",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -335,6 +335,7 @@
     "theme_dark": "Oscuro",
     "font_size_label": "Tamaño de fuente",
     "font_size_description": "Ajusta el tamaño de fuente base. Los cambios se aplican inmediatamente.",
+    "font_size_changed": "Tamaño de fuente: {{size}}px",
     "current_version": "Versión actual: {{version}}",
     "update_check": {
       "aria_label": "Verificación de actualizaciones",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -335,6 +335,7 @@
     "theme_dark": "Sombre",
     "font_size_label": "Taille de police",
     "font_size_description": "Ajustez la taille de police de base. Les modifications sont appliquées immédiatement.",
+    "font_size_changed": "Taille de police : {{size}}px",
     "current_version": "Version actuelle : {{version}}",
     "update_check": {
       "aria_label": "Vérification des mises à jour",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -335,6 +335,7 @@
     "theme_dark": "ダーク",
     "font_size_label": "フォントサイズ",
     "font_size_description": "基本のフォントサイズを調整します。変更は即座に適用されます。",
+    "font_size_changed": "フォントサイズ: {{size}}px",
     "current_version": "現在のバージョン: {{version}}",
     "update_check": {
       "aria_label": "アップデート確認",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -335,6 +335,7 @@
     "theme_dark": "다크",
     "font_size_label": "글꼴 크기",
     "font_size_description": "기본 글꼴 크기를 조정합니다. 변경 사항이 즉시 적용됩니다.",
+    "font_size_changed": "글꼴 크기: {{size}}px",
     "current_version": "현재 버전: {{version}}",
     "update_check": {
       "aria_label": "업데이트 확인",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -335,6 +335,7 @@
     "theme_dark": "深色",
     "font_size_label": "字体大小",
     "font_size_description": "调整基础字体大小。更改会立即生效。",
+    "font_size_changed": "字体大小: {{size}}px",
     "current_version": "当前版本: {{version}}",
     "update_check": {
       "aria_label": "更新检查",


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts to adjust the base font size, with a visual hint in the settings dialog.

Closes #395

## Changes

- **Shortcuts**: `Ctrl/Cmd + +` (or `=`) increases, `Ctrl/Cmd + -` decreases the base font size (range 12–20px, clamped via the existing `parseFontSize`)
- **Toast feedback**: shows the new size (e.g. "Font size: 16px") on each press; rapid presses replace the previous toast instead of stacking
- **Settings UI**: displays the shortcut with the shadcn `Kbd` component next to the font-size label (OS-aware: `⌘` on macOS, `Ctrl` elsewhere)
- **i18n**: adds `settings.font_size_changed` across all 6 locales

## Implementation notes

- New hook `useFontSizeShortcuts` mounted once at the app root (`App.tsx`), beside `useThemeEffect`
- Reads fresh state via `store.getState()` inside a stable listener — no stale closure, no re-subscription churn
- Persists through the canonical `saveByForm(silent=true)` path (Redux dispatch + backend save)
- `Kbd` / `KbdGroup` installed via the official shadcn command (`npx shadcn@latest add kbd`)

## Verification

- [x] `npm run typecheck`, `npm run lint` pass
- [x] `npm run test` — 9 new cases pass (142 total)
- [x] Manual: shortcuts adjust size, boundaries clamp (with toast), slider stays in sync, persists across restart