### PR TITLE
fix(download-status): correct elapsed time running at ~2x speed

### DIFF
--- a/src/__tests__/unit/downloadStatusSelectors.test.ts
+++ b/src/__tests__/unit/downloadStatusSelectors.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { RootState } from '@/app/store'
+import { selectOverallSummary } from '@/features/download-status/model/selectors'
+import type { QueueItem } from '@/shared/queue/queueSlice'
+import type { Progress } from '@/shared/ui/Progress'
+
+/**
+ * Minimal state shape exercised by selectOverallSummary. Only the slices the
+ * selector (and its input selectors) read are populated; the rest of RootState
+ * is irrelevant here.
+ */
+type TestState = Pick<
+  RootState,
+  'downloadStatusDialog' | 'queue' | 'progress' | 'input'
+>
+
+function makeState(overrides: Partial<TestState> = {}): TestState {
+  return {
+    downloadStatusDialog: { dialogOpen: true, activeParentId: 'parent-1' },
+    queue: [],
+    progress: [],
+    input: { partInputs: [] } as unknown as TestState['input'],
+    ...overrides,
+  }
+}
+
+const child = (status: QueueItem['status']): QueueItem => ({
+  downloadId: 'parent-1-p1',
+  parentId: 'parent-1',
+  status,
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('selectOverallSummary - elapsedSeconds (real wall-clock time)', () => {
+  it('uses real elapsed time from parent.startedAtMs while running', () => {
+    // 10s of real time elapsed since start. The old logic summed audio + video
+    // stage elapsed times (each ~10s because they run in parallel via
+    // tokio::try_join!), which would have produced ~20s. A single parent clock
+    // yields the true 10s.
+    vi.spyOn(Date, 'now').mockReturnValue(11_000)
+    const state = makeState({
+      queue: [
+        { downloadId: 'parent-1', status: 'running', startedAtMs: 1_000 },
+        child('running'),
+      ],
+    })
+
+    expect(selectOverallSummary(state as RootState).elapsedSeconds).toBe(10)
+  })
+
+  it('freezes at completion time once parent.completedAtMs is set', () => {
+    // Download finished at 5s. Even after the clock advances to 60s, the
+    // displayed elapsed time stays pinned to the completion instant.
+    vi.spyOn(Date, 'now').mockReturnValue(60_000)
+    const state = makeState({
+      queue: [
+        {
+          downloadId: 'parent-1',
+          status: 'done',
+          startedAtMs: 1_000,
+          completedAtMs: 6_000,
+        },
+        child('done'),
+      ],
+      progress: [
+        {
+          downloadId: 'parent-1-p1',
+          stage: 'complete',
+          isComplete: true,
+          percentage: 100,
+        } as Progress,
+      ],
+    })
+
+    expect(selectOverallSummary(state as RootState).elapsedSeconds).toBe(5)
+  })
+
+  it('returns 0 when the parent has no startedAtMs yet', () => {
+    const state = makeState({
+      queue: [{ downloadId: 'parent-1', status: 'pending' }, child('pending')],
+    })
+
+    expect(selectOverallSummary(state as RootState).elapsedSeconds).toBe(0)
+  })
+})

--- a/src/features/download-status/model/selectors.ts
+++ b/src/features/download-status/model/selectors.ts
@@ -60,7 +60,6 @@ function pickStageData(entries: Progress[]): {
   isRetrying: boolean
   stage?: string
   isComplete: boolean
-  elapsedTime: number
 } {
   if (entries.length === 0) {
     return {
@@ -70,7 +69,6 @@ function pickStageData(entries: Progress[]): {
       merge: null,
       isRetrying: false,
       isComplete: false,
-      elapsedTime: 0,
     }
   }
   const complete = entries.find((p) => p.stage === 'complete')
@@ -83,8 +81,6 @@ function pickStageData(entries: Progress[]): {
       isRetrying: complete.isRetrying ?? false,
       stage: 'complete',
       isComplete: true,
-      // Sum ALL entries so completion doesn't lose audio+video time.
-      elapsedTime: entries.reduce((sum, e) => sum + (e.elapsedTime ?? 0), 0),
     }
   }
   const byStage = (stage: string) =>
@@ -112,10 +108,6 @@ function pickStageData(entries: Progress[]): {
       (merge?.isRetrying ?? false),
     stage: merge ? 'merge' : 'download',
     isComplete: false,
-    // Sum ALL stage elapsed times (audio + video + merge) for the total.
-    // Look at all entries including completed ones so earlier stages
-    // aren't lost when a later stage starts.
-    elapsedTime: entries.reduce((sum, e) => sum + (e.elapsedTime ?? 0), 0),
   }
 }
 
@@ -164,7 +156,6 @@ export const selectPartStatusRows = createSelector(
           isRetrying: rep.isRetrying,
           stage: rep.stage,
           isComplete: rep.isComplete,
-          elapsedTime: rep.elapsedTime,
         }
       })
       .filter((row): row is PartStatusRowModel => row !== null)
@@ -174,8 +165,12 @@ export const selectPartStatusRows = createSelector(
 
 /** ダイアログヘッダーの全体サマリ。 */
 export const selectOverallSummary = createSelector(
-  [selectPartStatusRows],
-  (rows): OverallSummary => {
+  [
+    selectResolvedParentId,
+    selectPartStatusRows,
+    (state: RootState) => state.queue,
+  ],
+  (parentId, rows, queue): OverallSummary => {
     // Exclude cancelled parts from totals/progress: they won't download, so
     // counting them in the denominator reads as "still pending" (e.g. 7/10
     // with 3 cancelled looks like 3 are left). cancelledCount is still
@@ -197,9 +192,19 @@ export const selectOverallSummary = createSelector(
             0,
           ) / totalParts
         : 0
-    // Sum elapsed times across non-cancelled parts. Serial downloads run one
-    // after another, so total wall-clock time = sum of each part's elapsed time.
-    const elapsedSeconds = active.reduce((sum, r) => sum + r.elapsedTime, 0)
+
+    // Calculate wall-clock time based on parent download timestamps.
+    // For parallel downloads (audio + video), we use the parent's actual
+    // start/completion times instead of summing stage elapsed times.
+    let elapsedSeconds = 0
+    if (parentId) {
+      const parent = queue.find((q) => q.downloadId === parentId)
+      if (parent?.startedAtMs) {
+        const endTime = parent.completedAtMs ?? Date.now()
+        elapsedSeconds = Math.max(0, (endTime - parent.startedAtMs) / 1000)
+      }
+    }
+
     // Any part in the merge stage blocks cancel-all: ffmpeg is a CLI
     // process that's unsafe to interrupt mid-merge.
     // @why: The merge stage runs an ffmpeg CLI child process. Cancelling kills

--- a/src/features/download-status/model/types.ts
+++ b/src/features/download-status/model/types.ts
@@ -44,8 +44,6 @@ export type PartStatusRowModel = {
   stage?: string
   /** 完了しているか（progress の complete ステージ有無） */
   isComplete: boolean
-  /** 経過時間 秒 */
-  elapsedTime: number
 }
 
 /**
@@ -84,7 +82,15 @@ export type OverallSummary = {
   isMerging: boolean
   /** 全体進捗 0..1（完了=1、進行中=percentage/100 の平均） */
   overallRatio: number
-  /** 経過時間 秒（全子の max(elapsedTime)） */
+  /**
+   * Elapsed time in seconds — real wall-clock time from the parent download's
+   * start to its completion (or now if still active).
+   *
+   * @why Derived from the parent QueueItem's startedAtMs/completedAtMs, not by
+   *   summing per-stage elapsed times. audio and video stages run in parallel
+   *   (tokio::try_join! in the backend), so summing their elapsed times would
+   *   make this advance at ~2x real time.
+   */
   elapsedSeconds: number
 }
 

--- a/src/shared/queue/queueSlice.ts
+++ b/src/shared/queue/queueSlice.ts
@@ -59,20 +59,44 @@ function aggregateParentStatuses(state: QueueItem[]): void {
     // 'cancelled' — that would abort the remaining parts in the serial
     // download loop. Only once every remaining part is done/cancelled does
     // the parent settle to 'cancelled' (or 'done' if nothing was skipped).
+    const previousStatus = parent.status
+    let nextStatus: QueueItemStatus
     if (statuses.includes('error')) {
-      parent.status = 'error'
+      nextStatus = 'error'
     } else if (statuses.includes('cancelling')) {
-      parent.status = 'cancelling'
+      nextStatus = 'cancelling'
     } else if (statuses.includes('running')) {
-      parent.status = 'running'
+      nextStatus = 'running'
     } else if (statuses.includes('pending')) {
-      parent.status = 'pending'
+      nextStatus = 'pending'
     } else if (statuses.every((s) => s === 'done')) {
-      parent.status = 'done'
+      nextStatus = 'done'
     } else if (statuses.includes('cancelled')) {
-      parent.status = 'cancelled'
+      nextStatus = 'cancelled'
     } else {
-      parent.status = 'pending'
+      nextStatus = 'pending'
+    }
+    parent.status = nextStatus
+
+    // @why: Record wall-clock timestamps on parent lifecycle transitions so the
+    //   download dialog can show real elapsed time. audio and video stages run
+    //   in parallel (tokio::try_join!), each emitting its own elapsed time —
+    //   summing them makes the timer advance at ~2x real time. A single parent
+    //   clock sidesteps that entirely. The existing-value guard keeps the
+    //   original start/completion time even if the parent is re-aggregated
+    //   (e.g. a later part starts after an earlier one finishes).
+    if (
+      nextStatus === 'running' &&
+      previousStatus !== 'running' &&
+      !parent.startedAtMs
+    ) {
+      parent.startedAtMs = Date.now()
+    }
+    if (
+      (nextStatus === 'done' || nextStatus === 'error') &&
+      !parent.completedAtMs
+    ) {
+      parent.completedAtMs = Date.now()
     }
   })
 
@@ -102,6 +126,10 @@ export type QueueItem = {
   outputPath?: string
   /** Video title */
   title?: string
+  /** Parent download start timestamp (ms since epoch) */
+  startedAtMs?: number
+  /** Parent download completion timestamp (ms since epoch) */
+  completedAtMs?: number
 }
 
 /**
@@ -254,6 +282,7 @@ export const queueSlice = createSlice({
 
       target.status = status
       if (errorMessage) target.errorMessage = errorMessage
+
       aggregateParentStatuses(state)
     },
     /**


### PR DESCRIPTION
## Summary

The download dialog's elapsed time advanced at **~2x real speed**.

## Root cause

`selectOverallSummary` summed per-stage elapsed times (`audio + video + merge`). audio and video stages run in parallel via `tokio::try_join!` in the backend, so each emits its own elapsed time — summing them doubles the real elapsed time. (During the merge phase it reads even faster.)

## Fix

Replace stage-summing with a single parent download clock:

- Record `startedAtMs`/`completedAtMs` on the parent's lifecycle transitions in `aggregateParentStatuses` (running → start, done/error → completion, guarded so re-aggregation never overwrites the original times)
- Compute `elapsedSeconds` as `(completedAtMs ?? Date.now()) - startedAtMs`

This is accurate regardless of parallel stages or retries. Re-evaluated on every 500ms progress event, so no timer is needed.

## Changes

- `src/shared/queue/queueSlice.ts` — add `startedAtMs`/`completedAtMs` to `QueueItem`; record on parent status transitions
- `src/features/download-status/model/selectors.ts` — compute `elapsedSeconds` from parent wall-clock; remove the dead stage-summing `elapsedTime` aggregation
- `src/features/download-status/model/types.ts` — drop unused `PartStatusRowModel.elapsedTime`; update `OverallSummary.elapsedSeconds` JSDoc
- `src/__tests__/unit/downloadStatusSelectors.test.ts` — regression tests (in-progress, frozen-at-completion, unset)

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (145 passed)
- [x] `cargo build` (backend unchanged)