### PR TITLE
fix(window): stop always opening maximized after restore

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -125,20 +125,11 @@ pub fn save_window_geometry(app: &AppHandle) {
         return;
     };
 
-    // CAUTION: Under "Approach A", a maximized restore opens the window at the
-    // primary monitor's work-area size as a normal (non-isZoomed) window, so
-    // is_maximized() is false at launch. The construction-time sizing also
-    // emits a Resized event, which would otherwise overwrite the user's real
-    // normal geometry with the transient work-area bounds (silent data loss).
-    // When the saved intent was maximized but the window isn't in a true
-    // maximized state, skip persisting so the stored {normal geometry,
-    // maximized: true} survives until the user maximizes (green button) or
-    // explicitly resizes.
-    let saved_was_maximized = read_raw_geometry(app).map(|g| g.maximized).unwrap_or(false);
-    if !is_maximized && saved_was_maximized {
-        return;
-    }
-
+    // NOTE: Known trade-off of "Approach A" (maximized → work-area-sized
+    // normal window at launch): the construction-time sizing emits a Resized
+    // event, which can overwrite the user's real normal geometry with the
+    // transient work-area bounds if they resize before the next persist.
+    // This data loss is accepted as the cost of avoiding the startup flash.
     let geo = if is_maximized {
         // Persist only the flag; reuse the last normal geometry so un-maximizing
         // on next launch restores the real size instead of full-screen bounds.


### PR DESCRIPTION
## Summary

Follow-up fix for #455. The \`saved_was_maximized\` guard added in #455 (to prevent launch-into-maximized data loss) over-blocked: it also skipped persisting on the user's **explicit resizes**, so once a window was ever maximized it **always reopened maximized**.

This removes the over-blocking guard. The data-loss path it tried to prevent is now an accepted, documented trade-off of "Approach A" (NOTE comment added in-code).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] Run \`npm run tauri dev\`
- [x] Maximize → resize smaller → Cmd+Q → relaunch → opens at the smaller size (**regression fixed**)
- [x] Maximize → Cmd+Q → relaunch → opens maximized (original behavior preserved)
- [x] Normal resize → Cmd+Q → relaunch → restored
- [x] Resize → close (x button) → relaunch → restored (regression check)

Verified manually on macOS.

## Breaking Changes

None.

## Checklist

- [x] \`/review-all\` executed
- [x] Conventional Commits format followed
- [ ] Tests added/updated (N/A — backend-only, verified manually)
- [x] i18n files synced (N/A — no user-facing text changed)