### PR TITLE
feat: add resolution converter tool

### DIFF
--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -23,6 +23,7 @@ pub mod favorites;
 pub mod ffmpeg;
 pub mod github;
 pub mod qr_login;
+pub mod resolution;
 pub mod settings;
 pub mod trim;
 pub mod updater;

--- a/src-tauri/src/handlers/resolution.rs
+++ b/src-tauri/src/handlers/resolution.rs
@@ -138,7 +138,9 @@ pub async fn extract_resolution(
     // libx264's default yuv420p requires even dimensions; `scale=-2:H`
     // guarantees an even width but not height, so reject odd heights and
     // enforce the same 120-4320 range the UI advertises.
-    if options.target_height < 120 || options.target_height > 4320 || options.target_height % 2 != 0
+    if options.target_height < 120
+        || options.target_height > 4320
+        || !options.target_height.is_multiple_of(2)
     {
         return Err("ERR::RESOLUTION_INVALID_HEIGHT".to_string());
     }

--- a/src-tauri/src/handlers/resolution.rs
+++ b/src-tauri/src/handlers/resolution.rs
@@ -1,0 +1,252 @@
+//! Resolution Conversion
+//!
+//! Downscale video resolution using ffmpeg scale filter. Independent of the
+//! Bilibili download pipeline: it operates only on local files specified by
+//! absolute paths.
+
+use crate::utils::ffmpeg_probe::probe_duration_sec;
+use crate::utils::ffmpeg_progress::parse_out_time;
+use crate::utils::paths::get_ffmpeg_path;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Stdio;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command as AsyncCommand;
+
+/// Event name for resolution conversion progress updates emitted to the frontend.
+const RESOLUTION_PROGRESS_EVENT: &str = "resolution://progress";
+
+/// Options for a resolution conversion operation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionOptions {
+    /// Absolute path to the input `.mp4` file.
+    pub input_path: String,
+    /// Absolute path for the output file. Must be `.mp4`.
+    pub output_path: String,
+    /// Target height (e.g. 1080, 720, 480, 360). Width is auto-calculated
+    /// via ffmpeg's `scale=-2:H` filter.
+    pub target_height: u32,
+}
+
+/// Result of a successful resolution conversion.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionResult {
+    /// Absolute path of the written output file.
+    pub output_path: String,
+}
+
+/// Progress payload emitted via {@link RESOLUTION_PROGRESS_EVENT} while ffmpeg runs.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionProgressPayload {
+    pub progress: f64,
+    pub current_time_sec: f64,
+    pub total_duration_sec: f64,
+}
+
+/// Builds the ffmpeg argument list for a resolution conversion.
+///
+/// Uses `scale=-2:H` filter to auto-calculate width based on the target height
+/// while preserving aspect ratio. `-crf 23` for constant quality. `-c:a copy`
+/// preserves the original audio track without re-encoding.
+pub fn build_ffmpeg_args(options: &ResolutionOptions) -> Vec<String> {
+    vec![
+        "-nostats".to_string(),
+        "-stats_period".to_string(),
+        "1".to_string(),
+        "-progress".to_string(),
+        "pipe:2".to_string(),
+        "-i".to_string(),
+        options.input_path.clone(),
+        "-vf".to_string(),
+        format!("scale=-2:{}", options.target_height),
+        "-c:v".to_string(),
+        "libx264".to_string(),
+        "-crf".to_string(),
+        "23".to_string(),
+        "-preset".to_string(),
+        "medium".to_string(),
+        "-c:a".to_string(),
+        "copy".to_string(),
+        "-y".to_string(),
+        options.output_path.clone(),
+    ]
+}
+
+fn is_mp4(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("mp4"))
+        .unwrap_or(false)
+}
+
+fn has_extension(path: &Path, ext: &str) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case(ext))
+        .unwrap_or(false)
+}
+
+/// Checks whether two paths refer to the same file on disk.
+fn is_same_file(input: &Path, output: &Path) -> bool {
+    let canon_input = std::fs::canonicalize(input).ok();
+    let canon_output = std::fs::canonicalize(output).ok().or_else(|| {
+        output
+            .parent()
+            .and_then(|p| std::fs::canonicalize(p).ok())
+            .and_then(|p| output.file_name().map(|n| p.join(n)))
+    });
+    match (canon_input, canon_output) {
+        (Some(a), Some(b)) => a == b,
+        _ => input == output,
+    }
+}
+
+/// Validates inputs and runs ffmpeg to produce the downscaled video file.
+///
+/// # Errors
+///
+/// Returns strings beginning with `ERR::RESOLUTION_*`:
+/// - `ERR::RESOLUTION_INPUT_NOT_FOUND`
+/// - `ERR::RESOLUTION_UNSUPPORTED_FORMAT` (input not `.mp4`)
+/// - `ERR::RESOLUTION_UNSUPPORTED_OUTPUT_FORMAT` (output not `.mp4`)
+/// - `ERR::RESOLUTION_SAME_PATH`
+/// - `ERR::RESOLUTION_INVALID_HEIGHT`
+/// - `ERR::RESOLUTION_FFMPEG_FAILED`
+pub async fn extract_resolution(
+    app: &AppHandle,
+    options: &ResolutionOptions,
+) -> Result<ResolutionResult, String> {
+    let input_path = Path::new(&options.input_path);
+    let output_path = Path::new(&options.output_path);
+
+    if !input_path.exists() {
+        return Err("ERR::RESOLUTION_INPUT_NOT_FOUND".to_string());
+    }
+    if !is_mp4(input_path) {
+        return Err("ERR::RESOLUTION_UNSUPPORTED_FORMAT".to_string());
+    }
+    if !has_extension(output_path, "mp4") {
+        return Err("ERR::RESOLUTION_UNSUPPORTED_OUTPUT_FORMAT".to_string());
+    }
+    if is_same_file(input_path, output_path) {
+        return Err("ERR::RESOLUTION_SAME_PATH".to_string());
+    }
+    // libx264's default yuv420p requires even dimensions; `scale=-2:H`
+    // guarantees an even width but not height, so reject odd heights and
+    // enforce the same 120-4320 range the UI advertises.
+    if options.target_height < 120 || options.target_height > 4320 || options.target_height % 2 != 0
+    {
+        return Err("ERR::RESOLUTION_INVALID_HEIGHT".to_string());
+    }
+
+    let ffmpeg_path = get_ffmpeg_path(app);
+    let args = build_ffmpeg_args(options);
+
+    let total_duration_sec = probe_duration_sec(&ffmpeg_path, &options.input_path).await;
+
+    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    cmd.args(&args);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("ERR::RESOLUTION_FFMPEG_FAILED: spawn {e}"))?;
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "ERR::RESOLUTION_FFMPEG_FAILED: no stderr".to_string())?;
+
+    let mut stderr_reader = BufReader::new(stderr);
+    let app_for_progress = app.clone();
+    let stderr_task = tokio::spawn(async move {
+        let mut stderr_lines = String::new();
+        let mut line = String::new();
+        while stderr_reader.read_line(&mut line).await.unwrap_or(0) > 0 {
+            stderr_lines.push_str(&line);
+
+            if let Some(total) = total_duration_sec {
+                if total > 0.0 {
+                    if let Some(current) = parse_out_time(&line) {
+                        let progress = (current / total * 100.0).clamp(0.0, 100.0);
+                        let _ = app_for_progress.emit(
+                            RESOLUTION_PROGRESS_EVENT,
+                            ResolutionProgressPayload {
+                                progress,
+                                current_time_sec: current,
+                                total_duration_sec: total,
+                            },
+                        );
+                    }
+                }
+            }
+
+            line.clear();
+        }
+        stderr_lines
+    });
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("ERR::RESOLUTION_FFMPEG_FAILED: wait {e}"))?;
+
+    let stderr_output = stderr_task.await.unwrap_or_default();
+
+    if !status.success() {
+        return Err(format!(
+            "ERR::RESOLUTION_FFMPEG_FAILED\nExit code: {:?}\nstderr: {}",
+            status.code(),
+            stderr_output
+        ));
+    }
+
+    Ok(ResolutionResult {
+        output_path: options.output_path.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_args_uses_scale_filter_and_crf() {
+        let options = ResolutionOptions {
+            input_path: "input.mp4".to_string(),
+            output_path: "output.mp4".to_string(),
+            target_height: 720,
+        };
+        let args = build_ffmpeg_args(&options);
+        assert!(args.contains(&"-vf".to_string()));
+        assert!(args.contains(&"scale=-2:720".to_string()));
+        assert!(args.contains(&"-crf".to_string()));
+        assert!(args.contains(&"23".to_string()));
+        assert!(args.contains(&"-c:a".to_string()));
+        assert!(args.contains(&"copy".to_string()));
+    }
+
+    #[test]
+    fn build_args_includes_progress_flags() {
+        let options = ResolutionOptions {
+            input_path: "input.mp4".to_string(),
+            output_path: "output.mp4".to_string(),
+            target_height: 480,
+        };
+        let args = build_ffmpeg_args(&options);
+        assert!(args.contains(&"-nostats".to_string()));
+        assert!(args.contains(&"-progress".to_string()));
+        assert!(args.contains(&"pipe:2".to_string()));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use crate::handlers::favorites;
 use crate::handlers::ffmpeg;
 use crate::handlers::github;
 use crate::handlers::qr_login;
+use crate::handlers::resolution;
 use crate::handlers::settings;
 use crate::handlers::trim;
 use crate::handlers::updater;
@@ -189,6 +190,8 @@ pub fn run() {
             concat_videos,
             extract_audio,
             probe_audio_bitrate,
+            extract_resolution,
+            probe_video_resolution,
             generate_qr_code,
             poll_qr_status,
             qr_logout,
@@ -1270,6 +1273,30 @@ async fn extract_audio(
 async fn probe_audio_bitrate(app: AppHandle, input_path: String) -> Result<Option<u32>, String> {
     let ffmpeg_path = crate::utils::paths::get_ffmpeg_path(&app);
     Ok(crate::utils::ffmpeg_probe::probe_audio_bitrate_kbps(&ffmpeg_path, &input_path).await)
+}
+
+/// Downscale video resolution using ffmpeg scale filter.
+///
+/// Returns the absolute path of the written output file.
+#[tauri::command]
+async fn extract_resolution(
+    app: AppHandle,
+    options: resolution::ResolutionOptions,
+) -> Result<resolution::ResolutionResult, String> {
+    resolution::extract_resolution(&app, &options).await
+}
+
+/// Probes the video stream resolution (width × height) of a local media file.
+///
+/// Returns the video dimensions in pixels. Used by the frontend to display
+/// the current resolution and validate target height selection.
+#[tauri::command]
+async fn probe_video_resolution(
+    app: AppHandle,
+    input_path: String,
+) -> Result<Option<crate::utils::ffmpeg_probe::VideoResolution>, String> {
+    let ffmpeg_path = crate::utils::paths::get_ffmpeg_path(&app);
+    Ok(crate::utils::ffmpeg_probe::probe_video_resolution(&ffmpeg_path, &input_path).await)
 }
 
 /// Sets the simulate logout flag for development mode.

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -3,8 +3,72 @@
 //! Helpers for probing media file metadata (duration, etc.) using ffmpeg.
 
 use super::ffmpeg_progress::parse_hhmmss;
+use serde::Serialize;
 use std::path::Path;
 use tokio::process::Command as AsyncCommand;
+
+/// Video resolution dimensions.
+#[derive(Debug, Clone, Serialize)]
+pub struct VideoResolution {
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Probes the video stream resolution (width × height) of `input_path` by
+/// running `ffmpeg -i` and parsing the `<W>x<H>` token on the `Video:` line
+/// from stderr.
+///
+/// Mirrors {@link probe_audio_bitrate_kbps}: the bundled ffmpeg-only build
+/// ships no `ffprobe` binary, so we reuse the same `ffmpeg -i` stderr scrape
+/// instead of relying on a separate ffprobe invocation. Returns `None` when
+/// no video stream is found or the dimensions cannot be parsed.
+pub async fn probe_video_resolution(
+    ffmpeg_path: &Path,
+    input_path: &str,
+) -> Option<VideoResolution> {
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
+    cmd.arg("-i").arg(input_path);
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    // `ffmpeg -i` with no output exits non-zero, but still prints the input's
+    // stream metadata to stderr — which is exactly what we parse.
+    let output = cmd.output().await.ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for line in stderr.lines() {
+        // Match the video stream line, e.g.:
+        //   Stream #0:0[0x1](und): Video: h264 (High), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], ...
+        if line.contains("Video:") {
+            if let Some((width, height)) = parse_resolution(line) {
+                return Some(VideoResolution { width, height });
+            }
+        }
+    }
+    None
+}
+
+/// Extracts the first `<W>x<H>` token from an ffmpeg stream line.
+///
+/// Splits on whitespace/commas and finds a token whose two numeric halves are
+/// joined by `x` (e.g. `1920x1080`). Returns `None` if no such token exists.
+fn parse_resolution(line: &str) -> Option<(u32, u32)> {
+    for token in line.split([' ', ',']) {
+        if let Some(idx) = token.find('x') {
+            let (w, rest) = token.split_at(idx);
+            let h = &rest[1..]; // skip the 'x'
+            if let (Ok(width), Ok(height)) = (w.parse::<u32>(), h.parse::<u32>()) {
+                if width > 0 && height > 0 {
+                    return Some((width, height));
+                }
+            }
+        }
+    }
+    None
+}
 
 /// Probes the duration of `input_path` in seconds by running `ffmpeg -i`
 /// and parsing the `Duration: HH:MM:SS.xx` line from stderr.

--- a/src/features/resolution/api/resolutionApi.ts
+++ b/src/features/resolution/api/resolutionApi.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolution feature API layer.
+ *
+ * Thin wrappers around `invoke('extract_resolution', ...)` and
+ * `invoke('probe_video_resolution', ...)` to keep Tauri coupling in a single
+ * module — the rest of the feature depends on these functions, not on
+ * `invoke` directly.
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+
+import type { ResolutionOptions, ResolutionResult } from '../types'
+
+/**
+ * Invokes the backend `extract_resolution` command.
+ *
+ * @param options - Resolution conversion parameters; see {@link ResolutionOptions}
+ * @returns The output file path on success
+ * @throws Error with a message beginning with `ERR::RESOLUTION_*` on failure
+ */
+export async function extractResolution(
+  options: ResolutionOptions,
+): Promise<ResolutionResult> {
+  return invoke<ResolutionResult>('extract_resolution', { options })
+}
+
+/**
+ * Invokes the backend `probe_video_resolution` command.
+ *
+ * @param inputPath - Absolute path of the media file to probe
+ * @returns The video dimensions (width, height) in pixels, or `null` when unavailable
+ */
+export async function probeVideoResolution(
+  inputPath: string,
+): Promise<{ width: number; height: number } | null> {
+  return invoke<{ width: number; height: number } | null>(
+    'probe_video_resolution',
+    { inputPath },
+  )
+}

--- a/src/features/resolution/hooks/useResolution.ts
+++ b/src/features/resolution/hooks/useResolution.ts
@@ -69,8 +69,9 @@ export function useResolution(): UseResolutionResult {
   const { t } = useTranslation()
   const [inputPath, setInputPath] = useState<string | null>(null)
   const [outputPath, setOutputPath] = useState<string | null>(null)
-  const [targetHeight, setTargetHeightLocal] =
-    useState<number>(DEFAULT_TARGET_HEIGHT)
+  const [targetHeight, setTargetHeightLocal] = useState<number>(
+    DEFAULT_TARGET_HEIGHT,
+  )
   const [isCustomHeight, setIsCustomHeightLocal] = useState<boolean>(false)
   const [inputResolution, setInputResolution] = useState<{
     width: number
@@ -96,7 +97,9 @@ export function useResolution(): UseResolutionResult {
     }
   }, [])
 
-  const enabledResolutions = getEnabledResolutions(inputResolution?.height ?? null)
+  const enabledResolutions = getEnabledResolutions(
+    inputResolution?.height ?? null,
+  )
 
   const setTargetHeight = useCallback((value: number) => {
     setTargetHeightLocal(value)
@@ -130,7 +133,9 @@ export function useResolution(): UseResolutionResult {
       // Auto-pick the best-effort preset when not in custom mode so the
       // selected height never silently up-scales the new input.
       if (!isCustomHeight) {
-        setTargetHeightLocal(selectBestEffortResolution(resolution?.height ?? null))
+        setTargetHeightLocal(
+          selectBestEffortResolution(resolution?.height ?? null),
+        )
       }
       setStatus('idle')
     }
@@ -246,7 +251,10 @@ export function useResolution(): UseResolutionResult {
  * `movie.mp4` → `movie_resolution720.mp4`. Cross-platform path separator
  * detection via both `/` and `\`.
  */
-function makeDefaultOutputName(inputPath: string, targetHeight: number): string {
+function makeDefaultOutputName(
+  inputPath: string,
+  targetHeight: number,
+): string {
   const filename = inputPath.split(/[\\/]/).pop() ?? `output.mp4`
   const dot = filename.lastIndexOf('.')
   const base = dot > 0 ? filename.slice(0, dot) : filename

--- a/src/features/resolution/hooks/useResolution.ts
+++ b/src/features/resolution/hooks/useResolution.ts
@@ -1,0 +1,271 @@
+/**
+ * Resolution feature hook.
+ *
+ * Encapsulates all state and orchestration for the resolution conversion
+ * page: file dialogs, target-height selection (preset or custom), best-effort
+ * preset auto-select on input load, and invocation of `extract_resolution`.
+ * The target height is recomputed per input because it depends on the source
+ * resolution (up-scaling is disabled).
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { error as logError } from '@tauri-apps/plugin-log'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { extractResolution, probeVideoResolution } from '../api/resolutionApi'
+import {
+  DEFAULT_TARGET_HEIGHT,
+  getEnabledResolutions,
+  selectBestEffortResolution,
+} from '../lib/resolution'
+import type { ResolutionProgress } from '../types'
+
+export type ResolutionStatus =
+  | 'idle'
+  | 'probing'
+  | 'converting'
+  | 'success'
+  | 'error'
+
+/**
+ * Result returned by {@link useResolution}.
+ */
+export type UseResolutionResult = {
+  inputPath: string | null
+  outputPath: string | null
+  targetHeight: number
+  isCustomHeight: boolean
+  /** Presets selectable for the current input (gated by source height). */
+  enabledResolutions: readonly number[]
+  /** Probed source video resolution (width × height), or `null` when unknown. */
+  inputResolution: { width: number; height: number } | null
+  status: ResolutionStatus
+  /**
+   * Latest progress payload from `resolution://progress`, or `null` when no
+   * conversion is in flight. Drives the progress bar.
+   */
+  progress: ResolutionProgress | null
+  /** Wall-clock seconds since the current conversion started. `0` when idle. */
+  elapsedSec: number
+  /**
+   * Estimated seconds remaining based on current progress rate. `null` when
+   * progress is too small to estimate or no conversion is running.
+   */
+  remainingSec: number | null
+  setTargetHeight: (value: number) => void
+  setIsCustomHeight: (value: boolean) => void
+  handleBrowse: () => Promise<void>
+  handleChooseOutput: () => Promise<void>
+  handleConvert: () => Promise<void>
+  handleReveal: () => Promise<void>
+  reset: () => void
+}
+
+export function useResolution(): UseResolutionResult {
+  const { t } = useTranslation()
+  const [inputPath, setInputPath] = useState<string | null>(null)
+  const [outputPath, setOutputPath] = useState<string | null>(null)
+  const [targetHeight, setTargetHeightLocal] =
+    useState<number>(DEFAULT_TARGET_HEIGHT)
+  const [isCustomHeight, setIsCustomHeightLocal] = useState<boolean>(false)
+  const [inputResolution, setInputResolution] = useState<{
+    width: number
+    height: number
+  } | null>(null)
+  const [status, setStatus] = useState<ResolutionStatus>('idle')
+  const [progress, setProgress] = useState<ResolutionProgress | null>(null)
+  const [startedAtMs, setStartedAtMs] = useState<number | null>(null)
+  const [finalElapsedSec, setFinalElapsedSec] = useState<number | null>(null)
+
+  // Subscribe to ffmpeg progress events emitted by the Rust side. The
+  // listener stays mounted for the hook's lifetime; events are ignored
+  // unless a conversion is in flight.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined
+    void listen<ResolutionProgress>('resolution://progress', (event) => {
+      setProgress(event.payload)
+    }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
+  }, [])
+
+  const enabledResolutions = getEnabledResolutions(inputResolution?.height ?? null)
+
+  const setTargetHeight = useCallback((value: number) => {
+    setTargetHeightLocal(value)
+    setStatus('idle')
+    // CAUTION: reset output path so the filename is updated with the new
+    // height on re-select (the default name embeds the target height).
+    setOutputPath(null)
+  }, [])
+
+  const setIsCustomHeight = useCallback((value: boolean) => {
+    setIsCustomHeightLocal(value)
+    setStatus('idle')
+  }, [])
+
+  const handleBrowse = useCallback(async () => {
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: 'MP4 Video', extensions: ['mp4'] }],
+    })
+    if (typeof selected === 'string') {
+      setInputPath(selected)
+      setOutputPath(null)
+      setStatus('probing')
+      setInputResolution(null)
+      // Probe source video resolution to drive preset enablement + auto-select.
+      const resolution = await probeVideoResolution(selected).catch((e) => {
+        logError(`Failed to probe video resolution: ${e}`)
+        return null
+      })
+      setInputResolution(resolution)
+      // Auto-pick the best-effort preset when not in custom mode so the
+      // selected height never silently up-scales the new input.
+      if (!isCustomHeight) {
+        setTargetHeightLocal(selectBestEffortResolution(resolution?.height ?? null))
+      }
+      setStatus('idle')
+    }
+  }, [isCustomHeight])
+
+  const handleChooseOutput = useCallback(async () => {
+    if (!inputPath) return
+    const defaultName = makeDefaultOutputName(inputPath, targetHeight)
+    const selected = await save({
+      filters: [{ name: 'MP4 Video', extensions: ['mp4'] }],
+      defaultPath: defaultName,
+    })
+    if (typeof selected === 'string') {
+      setOutputPath(selected)
+      setStatus('idle')
+    }
+  }, [inputPath, targetHeight])
+
+  const handleReveal = useCallback(async () => {
+    if (!outputPath) return
+    await invoke('reveal_in_folder', { path: outputPath }).catch((e) => {
+      logError(`Failed to reveal in folder: ${e}`)
+    })
+  }, [outputPath])
+
+  const handleConvert = useCallback(async () => {
+    if (!inputPath || !outputPath) return
+    setProgress(null)
+    setFinalElapsedSec(null)
+    const startedAt = Date.now()
+    setStartedAtMs(startedAt)
+    setStatus('converting')
+    try {
+      await extractResolution({
+        inputPath,
+        outputPath,
+        targetHeight,
+      })
+      setStatus('success')
+      setFinalElapsedSec((Date.now() - startedAt) / 1000)
+      setProgress((prev) => ({
+        progress: 100,
+        currentTimeSec: prev?.currentTimeSec ?? 0,
+        totalDurationSec: prev?.totalDurationSec ?? 0,
+      }))
+      toast.success(t('resolution.success'), {
+        action: {
+          label: t('resolution.openFolder'),
+          onClick: () => {
+            void handleReveal()
+          },
+        },
+      })
+    } catch (e) {
+      setStatus('error')
+      setProgress(null)
+      setFinalElapsedSec(null)
+      const raw = e instanceof Error ? e.message : String(e)
+      const description = mapResolutionError(raw, t)
+      toast.error(t('resolution.failed'), { description })
+    } finally {
+      setStartedAtMs(null)
+    }
+  }, [inputPath, outputPath, targetHeight, t, handleReveal])
+
+  const reset = useCallback(() => {
+    setInputPath(null)
+    setOutputPath(null)
+    setTargetHeightLocal(DEFAULT_TARGET_HEIGHT)
+    setIsCustomHeightLocal(false)
+    setInputResolution(null)
+    setStatus('idle')
+    setProgress(null)
+    setStartedAtMs(null)
+    setFinalElapsedSec(null)
+  }, [])
+
+  // Derive elapsed/remaining on each render (same approach as useAudio).
+  const elapsedSec =
+    startedAtMs !== null
+      ? Math.max(0, (Date.now() - startedAtMs) / 1000)
+      : (finalElapsedSec ?? 0)
+  const remainingSec =
+    progress && progress.progress > 1
+      ? (elapsedSec * (100 - progress.progress)) / progress.progress
+      : null
+
+  return {
+    inputPath,
+    outputPath,
+    targetHeight,
+    isCustomHeight,
+    enabledResolutions,
+    inputResolution,
+    status,
+    progress,
+    elapsedSec,
+    remainingSec,
+    setTargetHeight,
+    setIsCustomHeight,
+    handleBrowse,
+    handleChooseOutput,
+    handleConvert,
+    handleReveal,
+    reset,
+  }
+}
+
+/**
+ * Builds a sensible default output filename from an input path and target height.
+ *
+ * Inserts `_resolution<H>` before the extension:
+ * `movie.mp4` → `movie_resolution720.mp4`. Cross-platform path separator
+ * detection via both `/` and `\`.
+ */
+function makeDefaultOutputName(inputPath: string, targetHeight: number): string {
+  const filename = inputPath.split(/[\\/]/).pop() ?? `output.mp4`
+  const dot = filename.lastIndexOf('.')
+  const base = dot > 0 ? filename.slice(0, dot) : filename
+  return `${base}_resolution${targetHeight}.mp4`
+}
+
+const RESOLUTION_ERROR_MAP: Record<string, string> = {
+  'ERR::RESOLUTION_INPUT_NOT_FOUND': 'resolution.error.input_not_found',
+  'ERR::RESOLUTION_UNSUPPORTED_FORMAT': 'resolution.error.unsupported_format',
+  'ERR::RESOLUTION_UNSUPPORTED_OUTPUT_FORMAT':
+    'resolution.error.unsupported_output_format',
+  'ERR::RESOLUTION_SAME_PATH': 'resolution.error.same_path',
+  'ERR::RESOLUTION_INVALID_HEIGHT': 'resolution.error.invalid_height',
+  'ERR::RESOLUTION_FFMPEG_FAILED': 'resolution.error.ffmpeg_failed',
+}
+
+function mapResolutionError(raw: string, t: (key: string) => string): string {
+  for (const [code, key] of Object.entries(RESOLUTION_ERROR_MAP)) {
+    if (raw.includes(code)) return t(key)
+  }
+  return raw
+}

--- a/src/features/resolution/index.ts
+++ b/src/features/resolution/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolution feature module.
+ *
+ * Provides downscaling of video resolution using ffmpeg scale filter.
+ * Supports preset height values (1080, 720, 480, 360) and custom height input.
+ *
+ * @module resolution
+ */
+
+// Public API: Components
+export { default as ResolutionForm } from './ui/ResolutionForm'
+
+// Public API: Hooks
+export {
+  useResolution,
+  type ResolutionStatus,
+  type UseResolutionResult,
+} from './hooks/useResolution'
+
+// Public API: Preset helpers
+export {
+  RESOLUTION_HEIGHT_PRESETS,
+  type ResolutionHeightPreset,
+  DEFAULT_TARGET_HEIGHT,
+  getEnabledResolutions,
+  selectBestEffortResolution,
+} from './lib/resolution'
+
+// Public API: Types
+export type {
+  ResolutionOptions,
+  ResolutionResult,
+  ResolutionProgress,
+} from './types'

--- a/src/features/resolution/index.ts
+++ b/src/features/resolution/index.ts
@@ -19,16 +19,16 @@ export {
 
 // Public API: Preset helpers
 export {
-  RESOLUTION_HEIGHT_PRESETS,
-  type ResolutionHeightPreset,
   DEFAULT_TARGET_HEIGHT,
+  RESOLUTION_HEIGHT_PRESETS,
   getEnabledResolutions,
   selectBestEffortResolution,
+  type ResolutionHeightPreset,
 } from './lib/resolution'
 
 // Public API: Types
 export type {
   ResolutionOptions,
-  ResolutionResult,
   ResolutionProgress,
+  ResolutionResult,
 } from './types'

--- a/src/features/resolution/lib/format.ts
+++ b/src/features/resolution/lib/format.ts
@@ -1,0 +1,20 @@
+/**
+ * Duration formatting utilities for the resolution feature.
+ */
+
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * @param sec - Duration in seconds
+ * @returns Formatted duration string (e.g. "01:23", "1:45:30")
+ */
+export function formatDuration(sec: number): string {
+  const hours = Math.floor(sec / 3600)
+  const minutes = Math.floor((sec % 3600) / 60)
+  const seconds = Math.floor(sec % 60)
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}

--- a/src/features/resolution/lib/resolution.ts
+++ b/src/features/resolution/lib/resolution.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure-function helpers for resolution preset selection.
+ *
+ * Kept free of React/i18n so they can be unit-tested in isolation. The UI
+ * layer calls {@link getEnabledResolutions} to decide which presets are
+ * selectable (presets that would up-scale the source are disabled) and
+ * {@link selectBestEffortResolution} to auto-pick a sensible default.
+ */
+
+/**
+ * Selectable target-height presets in descending order. Mirrors the common
+ * "720p / 480p / 360p" shorthand: the numeric value is the height in pixels
+ * and the width is auto-calculated by ffmpeg's `scale=-2:H` filter.
+ */
+export const RESOLUTION_HEIGHT_PRESETS = [1080, 720, 480, 360] as const
+
+export type ResolutionHeightPreset = (typeof RESOLUTION_HEIGHT_PRESETS)[number]
+
+/**
+ * Default target height used when the source resolution cannot be probed.
+ */
+export const DEFAULT_TARGET_HEIGHT: ResolutionHeightPreset = 720
+
+/**
+ * The smallest preset, always kept selectable as a floor even when the source
+ * is shorter — so the UI never ends up with every preset disabled.
+ */
+export const MIN_TARGET_HEIGHT: ResolutionHeightPreset =
+  RESOLUTION_HEIGHT_PRESETS[RESOLUTION_HEIGHT_PRESETS.length - 1]
+
+/**
+ * Returns the presets selectable for a given source height.
+ *
+ * Presets taller than the source are excluded because up-scaling cannot
+ * improve quality (the output can never look sharper than the source) and
+ * only wastes file size. The smallest preset is always included as a floor so
+ * conversion is never blocked entirely. Pass `null` when the source height is
+ * unknown: all presets become selectable.
+ *
+ * @param sourceHeight - Source video height in pixels, or `null` if unknown
+ * @returns Presets the user is allowed to pick
+ */
+export function getEnabledResolutions(
+  sourceHeight: number | null,
+): readonly ResolutionHeightPreset[] {
+  if (sourceHeight === null) return RESOLUTION_HEIGHT_PRESETS
+  return RESOLUTION_HEIGHT_PRESETS.filter(
+    (preset) => preset === MIN_TARGET_HEIGHT || preset <= sourceHeight,
+  )
+}
+
+/**
+ * Picks the best-effort default target height for a given source height.
+ *
+ * Selects the largest preset that does not exceed the source height, so the
+ * output stays as close to the source resolution as possible without
+ * up-scaling. Falls back to the floor preset when the source is shorter than
+ * every preset. Returns the configured default when the source height is
+ * unknown.
+ *
+ * @param sourceHeight - Source video height in pixels, or `null` if unknown
+ * @returns The recommended preset to pre-select
+ */
+export function selectBestEffortResolution(
+  sourceHeight: number | null,
+): ResolutionHeightPreset {
+  if (sourceHeight === null) return DEFAULT_TARGET_HEIGHT
+  for (const preset of [...RESOLUTION_HEIGHT_PRESETS].reverse()) {
+    if (preset <= sourceHeight) return preset
+  }
+  return MIN_TARGET_HEIGHT
+}

--- a/src/features/resolution/types.ts
+++ b/src/features/resolution/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolution feature type definitions.
+ *
+ * Mirrors the Rust DTOs in `src-tauri/src/handlers/resolution.rs`. Field names
+ * are camelCase to align with `#[serde(rename_all = "camelCase")]` on the
+ * backend.
+ */
+
+/**
+ * Request payload for the `extract_resolution` Tauri command.
+ */
+export type ResolutionOptions = {
+  /** Absolute path of the input `.mp4` file. */
+  inputPath: string
+  /** Absolute path for the output file. Must be `.mp4`. */
+  outputPath: string
+  /** Target height in pixels (e.g. 1080, 720, 480, 360). Width is auto-calculated. */
+  targetHeight: number
+}
+
+/**
+ * Successful response from the `extract_resolution` Tauri command.
+ */
+export type ResolutionResult = {
+  /** Absolute path of the written output file. */
+  outputPath: string
+}
+
+/**
+ * Payload for the `resolution://progress` Tauri event emitted by ffmpeg while
+ * converting. `progress` is 0–100. The frontend derives elapsed/remaining
+ * from `currentTimeSec`, `totalDurationSec`, and a wall-clock start time.
+ */
+export type ResolutionProgress = {
+  progress: number
+  currentTimeSec: number
+  totalDurationSec: number
+}

--- a/src/features/resolution/ui/ResolutionForm.tsx
+++ b/src/features/resolution/ui/ResolutionForm.tsx
@@ -1,0 +1,309 @@
+/**
+ * Resolution conversion form UI.
+ *
+ * Layout follows the audio page pattern: input file section, resolution
+ * section (with preset height values disabled above the source resolution,
+ * plus a custom-height option), output file section, actions. State and
+ * behavior come from {@link useResolution}; this component is responsible
+ * only for presentation.
+ */
+
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@/shared/animate-ui/radix/radio-group'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/animate-ui/radix/tooltip'
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/ui/button'
+import { Input } from '@/shared/ui/input'
+import type { TFunction } from 'i18next'
+import { FileUp, FolderOpen, Loader2, RotateCcw, Scaling } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useResolution } from '../hooks/useResolution'
+import { formatDuration } from '../lib/format'
+import { RESOLUTION_HEIGHT_PRESETS } from '../lib/resolution'
+
+export function ResolutionForm() {
+  const { t } = useTranslation()
+  const {
+    inputPath,
+    outputPath,
+    targetHeight,
+    isCustomHeight,
+    enabledResolutions,
+    inputResolution,
+    status,
+    progress,
+    elapsedSec,
+    remainingSec,
+    setTargetHeight,
+    setIsCustomHeight,
+    handleBrowse,
+    handleChooseOutput,
+    handleConvert,
+    handleReveal,
+    reset,
+  } = useResolution()
+
+  const isBusy = status === 'probing' || status === 'converting'
+  const isSuccess = status === 'success'
+  const canConvert =
+    Boolean(inputPath) && Boolean(outputPath) && !isBusy && !isSuccess
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">
+          {t('resolution.inputFile')}
+        </h2>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBrowse}
+            disabled={isBusy}
+          >
+            <FileUp className="size-4" />
+            {t('resolution.browse')}
+          </Button>
+          {inputPath ? (
+            <p
+              className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+              title={inputPath}
+            >
+              {inputPath}
+            </p>
+          ) : (
+            <span className="text-muted-foreground text-sm">
+              {t('resolution.noFileSelected')}
+            </span>
+          )}
+          {status === 'probing' && (
+            <Loader2 className="text-muted-foreground size-4 animate-spin" />
+          )}
+        </div>
+        {inputResolution !== null && (
+          <p className="text-muted-foreground mt-2 text-xs">
+            {t('resolution.sourceResolution', {
+              width: inputResolution.width,
+              height: inputResolution.height,
+            })}
+          </p>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">
+          {t('resolution.resolution.label')}
+        </h2>
+        <RadioGroup
+          value={isCustomHeight ? 'custom' : String(targetHeight)}
+          onValueChange={(v) => {
+            if (v === 'custom') {
+              setIsCustomHeight(true)
+            } else {
+              setIsCustomHeight(false)
+              setTargetHeight(Number(v))
+            }
+          }}
+          className="grid grid-cols-2 gap-3 sm:grid-cols-5"
+          disabled={isBusy}
+        >
+          {RESOLUTION_HEIGHT_PRESETS.map((height) => (
+            <ResolutionOption
+              key={height}
+              height={height}
+              isEnabled={enabledResolutions.includes(height)}
+              isDimmed={isCustomHeight}
+              inputResolution={inputResolution}
+              t={t}
+            />
+          ))}
+          <label
+            htmlFor="resolution-height-custom"
+            className={cn(
+              'flex items-center gap-3',
+              isCustomHeight ? 'cursor-pointer' : 'cursor-pointer opacity-50',
+            )}
+          >
+            <RadioGroupItem id="resolution-height-custom" value="custom" />
+            <span className="text-sm font-medium">
+              {t('resolution.resolution.custom')}
+            </span>
+          </label>
+        </RadioGroup>
+        {isCustomHeight && (
+          <div className="mt-3 flex items-center gap-3">
+            <label
+              htmlFor="custom-height-input"
+              className="text-sm font-medium"
+            >
+              {t('resolution.resolution.customHeightLabel')}
+            </label>
+            <Input
+              id="custom-height-input"
+              type="number"
+              min="120"
+              max="4320"
+              step="2"
+              value={targetHeight}
+              onChange={(e) => setTargetHeight(Number(e.target.value))}
+              disabled={isBusy}
+              className="w-24"
+            />
+            <span className="text-muted-foreground text-sm">px</span>
+          </div>
+        )}
+        <p className="text-muted-foreground mt-2 text-xs">
+          {t('resolution.resolution.hint')}
+        </p>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border p-3">
+        <h2 className="mb-3 text-sm font-medium">
+          {t('resolution.outputFile')}
+        </h2>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleChooseOutput}
+            disabled={!inputPath || isBusy}
+          >
+            <FolderOpen className="size-4" />
+            {t('resolution.chooseOutput')}
+          </Button>
+          {outputPath ? (
+            <p
+              className="text-muted-foreground min-w-0 flex-1 truncate text-sm"
+              title={outputPath}
+            >
+              {outputPath}
+            </p>
+          ) : (
+            <span className="text-muted-foreground text-sm">
+              {t('resolution.noOutputSelected')}
+            </span>
+          )}
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3">
+        {(isBusy || isSuccess) && progress && (
+          <>
+            <div className="bg-primary/20 relative h-2 flex-1 overflow-hidden rounded-full">
+              <div
+                className="bg-primary h-full transition-[width] duration-1000 ease-linear"
+                style={{ width: `${progress.progress}%` }}
+              />
+            </div>
+            <span className="text-sm font-medium whitespace-nowrap tabular-nums">
+              {Math.round(progress.progress)}%
+            </span>
+            <span className="text-muted-foreground text-sm whitespace-nowrap tabular-nums">
+              {t('resolution.elapsed')} {formatDuration(elapsedSec)}
+              {remainingSec !== null && (
+                <>
+                  {' / '}
+                  {t('resolution.remaining')} {formatDuration(remainingSec)}
+                </>
+              )}
+            </span>
+          </>
+        )}
+        <div className="ml-auto flex gap-3">
+          <Button
+            variant="outline"
+            onClick={handleReveal}
+            disabled={!isSuccess || !outputPath}
+            className={isSuccess && outputPath ? '' : 'invisible'}
+          >
+            <FolderOpen className="size-4" />
+            {t('resolution.openFolder')}
+          </Button>
+          <Button variant="ghost" onClick={reset} disabled={isBusy}>
+            <RotateCcw className="size-4" />
+            {t('resolution.clear')}
+          </Button>
+          <Button onClick={handleConvert} disabled={!canConvert}>
+            {status === 'converting' ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Scaling className="size-4" />
+            )}
+            {status === 'converting'
+              ? t('resolution.converting')
+              : t('resolution.convert')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * A single resolution preset radio option.
+ *
+ * When disabled (preset would up-scale the source), wraps the label in a
+ * tooltip so the user understands _why_ the option is unavailable. The
+ * wrapper `<span>` receives the hover because the disabled control itself
+ * has `pointer-events: none`.
+ */
+function ResolutionOption({
+  height,
+  isEnabled,
+  isDimmed,
+  inputResolution,
+  t,
+}: {
+  height: number
+  isEnabled: boolean
+  /** Extra dim when a sibling custom option is the active selection. */
+  isDimmed: boolean
+  inputResolution: { width: number; height: number } | null
+  t: TFunction
+}) {
+  const label = (
+    <label
+      htmlFor={`resolution-height-${height}`}
+      className={cn(
+        'flex items-center gap-3',
+        isEnabled && !isDimmed
+          ? 'cursor-pointer'
+          : 'cursor-not-allowed opacity-50',
+      )}
+    >
+      <RadioGroupItem
+        id={`resolution-height-${height}`}
+        value={String(height)}
+        disabled={!isEnabled}
+      />
+      <span className="text-sm font-medium">{height}p</span>
+    </label>
+  )
+
+  // No tooltip when enabled, or when the source resolution is unknown.
+  if (isEnabled || inputResolution === null) return label
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="max-w-xs">
+          {t('resolution.resolution.exceedsSource', {
+            height: inputResolution.height,
+          })}
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export default ResolutionForm

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "Toggle Sidebar",
       "openSidebar": "Open sidebar",
       "closeSidebar": "Close sidebar",
-      "audio": "Navigate to audio page"
+      "audio": "Navigate to audio page",
+      "resolution": "Navigate to resolution page"
     },
-    "audio": "Audio"
+    "audio": "Audio",
+    "resolution": "Resolution"
   },
   "trim": {
     "title": "Trim Video",
@@ -628,6 +630,40 @@
       "same_path": "Output path must differ from the input",
       "invalid_bitrate": "Invalid bitrate",
       "ffmpeg_failed": "ffmpeg failed to extract audio"
+    }
+  },
+  "resolution": {
+    "title": "Resolution Converter",
+    "description": "Downscale the video resolution. Audio is preserved as-is.",
+    "inputFile": "Input File",
+    "browse": "Browse",
+    "noFileSelected": "No file selected",
+    "sourceResolution": "Source resolution: {{width}}×{{height}}",
+    "resolution": {
+      "label": "Target Resolution",
+      "custom": "Custom",
+      "customHeightLabel": "Custom height (px)",
+      "hint": "Width is auto-calculated to preserve the aspect ratio.",
+      "exceedsSource": "Exceeds the source resolution ({{height}}p); up-scaling cannot improve quality."
+    },
+    "outputFile": "Output File",
+    "chooseOutput": "Choose Output",
+    "noOutputSelected": "No output selected",
+    "convert": "Convert",
+    "converting": "Converting...",
+    "clear": "Clear",
+    "success": "Resolution converted successfully",
+    "failed": "Resolution conversion failed",
+    "openFolder": "Open Folder",
+    "elapsed": "elapsed",
+    "remaining": "remaining",
+    "error": {
+      "input_not_found": "Input file not found",
+      "unsupported_format": "Input must be an MP4 file",
+      "unsupported_output_format": "Output must be an MP4 file",
+      "same_path": "Output path must differ from the input",
+      "invalid_height": "Invalid height (must be an even number between 120 and 4320)",
+      "ffmpeg_failed": "ffmpeg failed to convert resolution"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "Alternar barra lateral",
       "openSidebar": "Abrir barra lateral",
       "closeSidebar": "Cerrar barra lateral",
-      "audio": "Ir a la página de audio"
+      "audio": "Ir a la página de audio",
+      "resolution": "Ir a la página de resolución"
     },
-    "audio": "Audio"
+    "audio": "Audio",
+    "resolution": "Resolución"
   },
   "trim": {
     "title": "Recortar vídeo",
@@ -628,6 +630,40 @@
       "same_path": "La ruta de salida debe ser distinta de la entrada",
       "invalid_bitrate": "Tasa de bits no válida",
       "ffmpeg_failed": "ffmpeg no pudo extraer el audio"
+    }
+  },
+  "resolution": {
+    "title": "Conversor de resolución",
+    "description": "Reduce la resolución del vídeo. El audio se conserva.",
+    "inputFile": "Archivo de entrada",
+    "browse": "Examinar",
+    "noFileSelected": "Ningún archivo seleccionado",
+    "sourceResolution": "Resolución de origen: {{width}}×{{height}}",
+    "resolution": {
+      "label": "Resolución objetivo",
+      "custom": "Personalizada",
+      "customHeightLabel": "Altura personalizada (px)",
+      "hint": "El ancho se calcula automáticamente para mantener la relación de aspecto.",
+      "exceedsSource": "Supera la resolución de origen ({{height}}p); ampliar no mejora la calidad."
+    },
+    "outputFile": "Archivo de salida",
+    "chooseOutput": "Elegir salida",
+    "noOutputSelected": "Salida no seleccionada",
+    "convert": "Convertir",
+    "converting": "Convirtiendo...",
+    "clear": "Limpiar",
+    "success": "Resolución convertida correctamente",
+    "failed": "Error en la conversión de resolución",
+    "openFolder": "Abrir carpeta",
+    "elapsed": "transcurrido",
+    "remaining": "restante",
+    "error": {
+      "input_not_found": "Archivo de entrada no encontrado",
+      "unsupported_format": "La entrada debe ser un archivo MP4",
+      "unsupported_output_format": "La salida debe ser un archivo MP4",
+      "same_path": "La ruta de salida debe diferir de la entrada",
+      "invalid_height": "Altura no válida (debe ser un número par entre 120 y 4320)",
+      "ffmpeg_failed": "ffmpeg no pudo convertir la resolución"
     }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "Basculer la barre latérale",
       "openSidebar": "Ouvrir la barre latérale",
       "closeSidebar": "Fermer la barre latérale",
-      "audio": "Aller à la page audio"
+      "audio": "Aller à la page audio",
+      "resolution": "Aller à la page de résolution"
     },
-    "audio": "Audio"
+    "audio": "Audio",
+    "resolution": "Résolution"
   },
   "trim": {
     "title": "Découper la vidéo",
@@ -628,6 +630,40 @@
       "same_path": "Le chemin de sortie doit être différent de l'entrée",
       "invalid_bitrate": "Débit binaire invalide",
       "ffmpeg_failed": "ffmpeg n'a pas pu extraire l'audio"
+    }
+  },
+  "resolution": {
+    "title": "Convertisseur de résolution",
+    "description": "Réduisez la résolution de la vidéo. L'audio est conservé tel quel.",
+    "inputFile": "Fichier d'entrée",
+    "browse": "Parcourir",
+    "noFileSelected": "Aucun fichier sélectionné",
+    "sourceResolution": "Résolution source : {{width}}×{{height}}",
+    "resolution": {
+      "label": "Résolution cible",
+      "custom": "Personnalisée",
+      "customHeightLabel": "Hauteur personnalisée (px)",
+      "hint": "La largeur est calculée automatiquement pour préserver le rapport d'aspect.",
+      "exceedsSource": "Dépasse la résolution source ({{height}}p) ; l'agrandissement n'améliore pas la qualité."
+    },
+    "outputFile": "Fichier de sortie",
+    "chooseOutput": "Choisir la sortie",
+    "noOutputSelected": "Sortie non sélectionnée",
+    "convert": "Convertir",
+    "converting": "Conversion...",
+    "clear": "Effacer",
+    "success": "Résolution convertie avec succès",
+    "failed": "Échec de la conversion de résolution",
+    "openFolder": "Ouvrir le dossier",
+    "elapsed": "écoulé",
+    "remaining": "restant",
+    "error": {
+      "input_not_found": "Fichier d'entrée introuvable",
+      "unsupported_format": "L'entrée doit être un fichier MP4",
+      "unsupported_output_format": "La sortie doit être un fichier MP4",
+      "same_path": "Le chemin de sortie doit différer de l'entrée",
+      "invalid_height": "Hauteur invalide (doit être un nombre pair entre 120 et 4320)",
+      "ffmpeg_failed": "ffmpeg n’a pas pu convertir la résolution"
     }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "サイドバーを切り替え",
       "openSidebar": "サイドバーを開く",
       "closeSidebar": "サイドバーを閉じる",
-      "audio": "音声抽出ページへ移動"
+      "audio": "音声抽出ページへ移動",
+      "resolution": "解像度変換ページへ移動"
     },
-    "audio": "音声抽出"
+    "audio": "音声抽出",
+    "resolution": "解像度変換"
   },
   "trim": {
     "title": "動画トリム",
@@ -628,6 +630,40 @@
       "same_path": "出力パスは入力と異なる必要があります",
       "invalid_bitrate": "無効なビットレートです",
       "ffmpeg_failed": "ffmpegでの音声抽出に失敗しました"
+    }
+  },
+  "resolution": {
+    "title": "解像度変換",
+    "description": "動画の解像度をダウンスケールします。音声はそのまま保持します。",
+    "inputFile": "入力ファイル",
+    "browse": "参照",
+    "noFileSelected": "ファイルが選択されていません",
+    "sourceResolution": "ソース解像度: {{width}}×{{height}}",
+    "resolution": {
+      "label": "ターゲット解像度",
+      "custom": "カスタム",
+      "customHeightLabel": "カスタム高さ (px)",
+      "hint": "縦横比を保つよう幅を自動で計算します。",
+      "exceedsSource": "ソース解像度（{{height}}p）を超えます。アップスケールしても画質は向上しません。"
+    },
+    "outputFile": "出力ファイル",
+    "chooseOutput": "出力先を選択",
+    "noOutputSelected": "出力先が未選択",
+    "convert": "変換",
+    "converting": "変換中...",
+    "clear": "クリア",
+    "success": "解像度を変換しました",
+    "failed": "解像度変換に失敗しました",
+    "openFolder": "フォルダを開く",
+    "elapsed": "経過",
+    "remaining": "残り",
+    "error": {
+      "input_not_found": "入力ファイルが見つかりません",
+      "unsupported_format": "入力は MP4 ファイルである必要があります",
+      "unsupported_output_format": "出力は MP4 ファイルである必要があります",
+      "same_path": "出力パスは入力と異なる必要があります",
+      "invalid_height": "無効な高さです（120〜4320の偶数）",
+      "ffmpeg_failed": "ffmpeg が解像度変換に失敗しました"
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "사이드바 토글",
       "openSidebar": "사이드바 열기",
       "closeSidebar": "사이드바 닫기",
-      "audio": "오디오 추출 페이지로 이동"
+      "audio": "오디오 추출 페이지로 이동",
+      "resolution": "해상도 변환 페이지로 이동"
     },
-    "audio": "오디오 추출"
+    "audio": "오디오 추출",
+    "resolution": "해상도 변환"
   },
   "trim": {
     "title": "영상 트림",
@@ -628,6 +630,40 @@
       "same_path": "출력 경로는 입력과 달라야 합니다",
       "invalid_bitrate": "잘못된 비트레이트",
       "ffmpeg_failed": "ffmpeg 오디오 추출 실패"
+    }
+  },
+  "resolution": {
+    "title": "해상도 변환",
+    "description": "동영상 해상도를 축소합니다. 오디오는 그대로 유지됩니다.",
+    "inputFile": "입력 파일",
+    "browse": "찾아보기",
+    "noFileSelected": "선택된 파일이 없습니다",
+    "sourceResolution": "소스 해상도: {{width}}×{{height}}",
+    "resolution": {
+      "label": "대상 해상도",
+      "custom": "사용자 지정",
+      "customHeightLabel": "사용자 지정 높이 (px)",
+      "hint": "종횡비를 유지하도록 너비를 자동으로 계산합니다.",
+      "exceedsSource": "소스 해상도({{height}}p)를 초과합니다. 업스케일해도 화질이 개선되지 않습니다."
+    },
+    "outputFile": "출력 파일",
+    "chooseOutput": "출력 선택",
+    "noOutputSelected": "출력이 선택되지 않음",
+    "convert": "변환",
+    "converting": "변환 중...",
+    "clear": "지우기",
+    "success": "해상도가 변환되었습니다",
+    "failed": "해상도 변환에 실패했습니다",
+    "openFolder": "폴더 열기",
+    "elapsed": "경과",
+    "remaining": "남음",
+    "error": {
+      "input_not_found": "입력 파일을 찾을 수 없습니다",
+      "unsupported_format": "입력은 MP4 파일이어야 합니다",
+      "unsupported_output_format": "출력은 MP4 파일이어야 합니다",
+      "same_path": "출력 경로는 입력과 달라야 합니다",
+      "invalid_height": "잘못된 높이입니다 (120-4320 사이의 짝수여야 함)",
+      "ffmpeg_failed": "ffmpeg가 해상도 변환에 실패했습니다"
     }
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -29,9 +29,11 @@
       "toggleSidebar": "切换侧边栏",
       "openSidebar": "打开侧边栏",
       "closeSidebar": "关闭侧边栏",
-      "audio": "前往音频提取页面"
+      "audio": "前往音频提取页面",
+      "resolution": "转到分辨率转换页面"
     },
-    "audio": "音频提取"
+    "audio": "音频提取",
+    "resolution": "分辨率转换"
   },
   "trim": {
     "title": "裁剪视频",
@@ -628,6 +630,40 @@
       "same_path": "输出路径必须与输入不同",
       "invalid_bitrate": "无效的比特率",
       "ffmpeg_failed": "ffmpeg 提取音频失败"
+    }
+  },
+  "resolution": {
+    "title": "分辨率转换",
+    "description": "降低视频分辨率。音频保持不变。",
+    "inputFile": "输入文件",
+    "browse": "浏览",
+    "noFileSelected": "未选择文件",
+    "sourceResolution": "源分辨率：{{width}}×{{height}}",
+    "resolution": {
+      "label": "目标分辨率",
+      "custom": "自定义",
+      "customHeightLabel": "自定义高度 (px)",
+      "hint": "自动计算宽度以保持宽高比。",
+      "exceedsSource": "超过源分辨率（{{height}}p）；放大无法提升画质。"
+    },
+    "outputFile": "输出文件",
+    "chooseOutput": "选择输出",
+    "noOutputSelected": "未选择输出",
+    "convert": "转换",
+    "converting": "转换中...",
+    "clear": "清除",
+    "success": "分辨率转换成功",
+    "failed": "分辨率转换失败",
+    "openFolder": "打开文件夹",
+    "elapsed": "已用",
+    "remaining": "剩余",
+    "error": {
+      "input_not_found": "未找到输入文件",
+      "unsupported_format": "输入必须是 MP4 文件",
+      "unsupported_output_format": "输出必须是 MP4 文件",
+      "same_path": "输出路径必须与输入不同",
+      "invalid_height": "无效高度（必须是 120-4320 之间的偶数）",
+      "ffmpeg_failed": "ffmpeg 转换分辨率失败"
     }
   }
 }

--- a/src/pages/resolution/index.tsx
+++ b/src/pages/resolution/index.tsx
@@ -1,0 +1,28 @@
+import { ResolutionForm } from '@/features/resolution'
+import { PageTemplate } from '@/shared/layout'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Resolution conversion page content.
+ *
+ * Mounted by `PersistentPageLayout` at `/resolution`. Header explains the feature;
+ * the rest is delegated to {@link ResolutionForm}.
+ */
+export function ResolutionContent() {
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    document.title = `${t('resolution.title')} - ${t('app.title')}`
+  }, [t])
+
+  return (
+    <PageTemplate title={t('resolution.title')} description={t('resolution.description')}>
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+        <ResolutionForm />
+      </div>
+    </PageTemplate>
+  )
+}
+
+export default ResolutionContent

--- a/src/pages/resolution/index.tsx
+++ b/src/pages/resolution/index.tsx
@@ -17,7 +17,10 @@ export function ResolutionContent() {
   }, [t])
 
   return (
-    <PageTemplate title={t('resolution.title')} description={t('resolution.description')}>
+    <PageTemplate
+      title={t('resolution.title')}
+      description={t('resolution.description')}
+    >
       <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
         <ResolutionForm />
       </div>

--- a/src/shared/layout/PersistentPageLayout.tsx
+++ b/src/shared/layout/PersistentPageLayout.tsx
@@ -8,6 +8,7 @@ import { ConcatContent } from '@/pages/concat'
 import { FavoriteContent } from '@/pages/favorite'
 import { HistoryContent } from '@/pages/history'
 import { HomeContent } from '@/pages/home'
+import { ResolutionContent } from '@/pages/resolution'
 import { TrimContent } from '@/pages/trim'
 import { WatchHistoryContent } from '@/pages/watch-history'
 
@@ -24,6 +25,7 @@ const PAGES: readonly PageConfig[] = [
   { path: '/trim', Component: TrimContent },
   { path: '/concat', Component: ConcatContent },
   { path: '/audio', Component: AudioContent },
+  { path: '/resolution', Component: ResolutionContent },
 ] as const
 
 const VALID_PATHS: readonly string[] = PAGES.map((p) => p.path)

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -19,7 +19,15 @@ import {
 import { cn } from '@/shared/lib/utils'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import type { LucideIcon } from 'lucide-react'
-import { Combine, Eye, Home, Music, Scaling, Scissors, Star } from 'lucide-react'
+import {
+  Combine,
+  Eye,
+  Home,
+  Music,
+  Scaling,
+  Scissors,
+  Star,
+} from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.tsx
@@ -19,7 +19,7 @@ import {
 import { cn } from '@/shared/lib/utils'
 import { selectHasActiveDownloads } from '@/shared/queue'
 import type { LucideIcon } from 'lucide-react'
-import { Combine, Eye, Home, Music, Scissors, Star } from 'lucide-react'
+import { Combine, Eye, Home, Music, Scaling, Scissors, Star } from 'lucide-react'
 import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router'
@@ -127,6 +127,13 @@ export function NavigationSidebarHeader({
           icon: Music,
           label: t('nav.audio'),
           ariaLabel: t('nav.aria.audio'),
+          requiresAuth: false,
+        },
+        {
+          path: '/resolution',
+          icon: Scaling,
+          label: t('nav.resolution'),
+          ariaLabel: t('nav.aria.resolution'),
           requiresAuth: false,
         },
       ],


### PR DESCRIPTION
## Summary

Add a new **Resolution Converter** tool under the Tools sidebar group. It downscales local MP4 videos via ffmpeg's `scale=-2:H` filter (preserving aspect ratio), with CRF 23 fixed quality and the audio stream copied without re-encode. The architecture mirrors the existing audio extraction feature.

- **Backend** (`extract_resolution`, `probe_video_resolution`): scale-filter re-encode with `-c:a copy`. Source resolution is probed via `ffmpeg -i` stderr scrape (the bundled ffmpeg-only build ships no `ffprobe` binary). Validation rejects odd heights (libx264/yuv420p requires even dimensions) and enforces the 120-4320 range advertised by the UI.
- **Frontend** (new `resolution` feature module + thin page): presets 1080/720/480/360 with source-exceeding options disabled via tooltip; a custom even-height input is also available. Progress bar driven by the `resolution://progress` event.
- **Navigation**: sidebar entry + route registration in `PersistentPageLayout`.
- **i18n**: keys added across all 6 locales (en/ja/zh/ko/es/fr), counts in parity.

## Related Issue

Closes #392

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] Run `npm run tauri dev`
- [x] Open the Resolution Converter page from the sidebar
- [x] Select a local MP4 — source resolution is displayed
- [x] Presets above the source resolution are disabled with a tooltip
- [x] Convert to 360p and to a custom height — output plays correctly
- [x] Verified output: 1080p (84 MB) → 360p (22 MB, −74%) and 120p (7 MB, −91%); aspect ratio, duration, and audio (copy) preserved

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (code-reviewer found and we fixed 2 must-fix issues: odd-height ffmpeg failure + UI/backend height-range mismatch)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (`build_ffmpeg_args` unit tests)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)