### PR TITLE
fix: concat page scrolls and action buttons stay accessible (#461)

### DIFF
--- a/src/features/concat/ui/ConcatForm.test.tsx
+++ b/src/features/concat/ui/ConcatForm.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useConcat } from '../hooks/useConcat'
+
+import { ConcatForm } from './ConcatForm'
+
+vi.mock('../hooks/useConcat', () => ({
+  useConcat: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+/**
+ * Builds a `useConcat` return value with sensible defaults, overlaid with
+ * the given per-test overrides. Keeps each test focused on the state it
+ * actually exercises instead of re-declaring the full handler surface.
+ */
+function createMockUseConcat(
+  overrides: Partial<ReturnType<typeof useConcat>> = {},
+): ReturnType<typeof useConcat> {
+  return {
+    files: [],
+    outputPath: null,
+    status: 'idle',
+    validationError: null,
+    progress: null,
+    elapsedSec: 0,
+    remainingSec: null,
+    handleAddFiles: vi.fn(),
+    handleRemoveFile: vi.fn(),
+    handleReorderFiles: vi.fn(),
+    handleChooseOutput: vi.fn(),
+    handleConcat: vi.fn(),
+    handleReveal: vi.fn(),
+    reset: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useConcat>
+}
+
+describe('ConcatForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useConcat).mockReturnValue(createMockUseConcat())
+  })
+
+  // jsdom cannot compute real layout/scroll geometry, so these tests lock
+  // the structural contract that fixes issue #461: the action buttons stay
+  // rendered and the file list sits inside a bounded scroll region.
+
+  it('keeps action buttons rendered when the file list is long (#461)', () => {
+    vi.mocked(useConcat).mockReturnValue(
+      createMockUseConcat({
+        files: Array.from({ length: 50 }, (_, i) => `/p/video-${i}.mp4`),
+        outputPath: '/out.mp4',
+      }),
+    )
+
+    render(<ConcatForm />)
+
+    // The Concat / Clear buttons live in a `shrink-0` action row, so they
+    // remain in the DOM (and visible in a real browser) regardless of how
+    // many files are in the list.
+    expect(screen.getByText('concat.concat')).toBeInTheDocument()
+    expect(screen.getByText('concat.clear')).toBeInTheDocument()
+  })
+
+  it('wraps the file list in a bounded scroll region when files exist', () => {
+    vi.mocked(useConcat).mockReturnValue(
+      createMockUseConcat({
+        files: ['/p/a.mp4', '/p/b.mp4'],
+      }),
+    )
+
+    const { container } = render(<ConcatForm />)
+
+    // The file-list region uses the bounded-flex idiom so it scrolls
+    // internally without pushing the output section or action buttons
+    // off-screen.
+    const scrollRegion = container.querySelector('.overflow-y-auto')
+    expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto')
+  })
+})

--- a/src/features/concat/ui/ConcatForm.tsx
+++ b/src/features/concat/ui/ConcatForm.tsx
@@ -12,6 +12,11 @@ import { useTranslation } from 'react-i18next'
  * Renders the file list (with drag-and-drop reordering), output path
  * selector, progress bar, and action buttons. Delegates all state
  * management to the {@link useConcat} hook.
+ *
+ * Layout: a height-bounded flex column. The file-list section grows
+ * (`flex-1`) and scrolls internally, while the output section and action
+ * button row are pinned (`shrink-0`) so they stay visible regardless of
+ * how many files are in the list (issue #461).
  */
 export function ConcatForm() {
   const { t } = useTranslation()
@@ -36,14 +41,15 @@ export function ConcatForm() {
   const isSuccess = status === 'success'
   const canConcat =
     files.length >= 2 && Boolean(outputPath) && !isConcatting && !isSuccess
+  const canReveal = isSuccess && Boolean(outputPath)
   const validationErrorKey = validationError
     ? `concat.error.${validationError}`
     : null
 
   return (
-    <div className="flex flex-col gap-3">
-      <section className="overflow-hidden rounded-lg border p-3">
-        <div className="mb-3 flex items-center justify-between">
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border p-3">
+        <div className="mb-3 flex shrink-0 items-center justify-between">
           <h2 className="text-sm font-medium">{t('concat.fileList')}</h2>
           <Button
             variant="outline"
@@ -56,7 +62,12 @@ export function ConcatForm() {
           </Button>
         </div>
         {files.length > 0 ? (
-          <>
+          // Caution: `min-h-0` is load-bearing for issue #461. A flex item's
+          // min-height defaults to `auto` (its content size); removing
+          // min-h-0 makes this region refuse to shrink, so `overflow-y-auto`
+          // never fires, the section grows unbounded, and the output/action
+          // rows get pushed off-screen (the original #461 symptom).
+          <div className="min-h-0 flex-1 overflow-y-auto">
             <FileList
               files={files}
               isProcessing={isConcatting}
@@ -66,20 +77,20 @@ export function ConcatForm() {
             <p className="text-muted-foreground mt-2 text-xs">
               {t('concat.dragToReorder')}
             </p>
-          </>
+          </div>
         ) : (
           <p className="text-muted-foreground text-sm">
             {t('concat.noFilesSelected')}
           </p>
         )}
         {validationErrorKey && (
-          <p className="text-destructive mt-2 text-sm">
+          <p className="text-destructive mt-2 shrink-0 text-sm">
             {t(validationErrorKey)}
           </p>
         )}
       </section>
 
-      <section className="overflow-hidden rounded-lg border p-3">
+      <section className="shrink-0 overflow-hidden rounded-lg border p-3">
         <h2 className="mb-3 text-sm font-medium">{t('concat.outputFile')}</h2>
         <div className="flex items-center gap-3">
           <Button
@@ -106,7 +117,7 @@ export function ConcatForm() {
         </div>
       </section>
 
-      <div className="flex items-center gap-3">
+      <div className="flex shrink-0 items-center gap-3">
         {(isConcatting || isSuccess) && progress && (
           <>
             <div className="bg-primary/20 relative h-2 flex-1 overflow-hidden rounded-full">
@@ -133,8 +144,8 @@ export function ConcatForm() {
           <Button
             variant="outline"
             onClick={handleReveal}
-            disabled={!isSuccess || !outputPath}
-            className={isSuccess && outputPath ? '' : 'invisible'}
+            disabled={!canReveal}
+            className={canReveal ? '' : 'invisible'}
           >
             <FolderOpen className="size-4" />
             {t('concat.openFolder')}

--- a/src/pages/concat/index.tsx
+++ b/src/pages/concat/index.tsx
@@ -7,7 +7,9 @@ import { useTranslation } from 'react-i18next'
  * Page-level component for the video concatenation feature.
  *
  * Sets the document title and renders the header (title + description)
- * along with the {@link ConcatForm} inside a scrollable content area.
+ * along with the {@link ConcatForm}. The wrapper is a non-scrolling flex
+ * column that passes the bounded page height down; ConcatForm owns its
+ * own internal scroll region for the file list (issue #461).
  */
 export function ConcatContent() {
   const { t } = useTranslation()
@@ -21,7 +23,14 @@ export function ConcatContent() {
       title={t('concat.title')}
       description={t('concat.description')}
     >
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/*
+        Caution: do NOT re-add `overflow-y-auto` here to match sibling pages
+        (trim/audio/resolution). This wrapper intentionally stays a
+        non-scrolling flex column so the bounded height flows into
+        ConcatForm, whose action row is pinned via `shrink-0`; whole-body
+        scroll would push those buttons off-screen (issue #461).
+      */}
+      <div className="flex min-h-0 flex-1 flex-col pt-2 pb-4 sm:pt-3 sm:pb-6">
         <ConcatForm />
       </div>
     </PageTemplate>

--- a/src/shared/layout/PageLayout.tsx
+++ b/src/shared/layout/PageLayout.tsx
@@ -102,7 +102,16 @@ export function PageLayoutShell({ children }: PageLayoutShellProps) {
 
   return (
     <>
-      <SidebarProvider defaultOpen={true}>
+      {/*
+        CONSTRAINT: Bound the app shell to viewport height so the flex chain
+        (SidebarInset -> h-full wrappers -> flex-1 min-h-0 scroll regions)
+        resolves to definite heights. The sidebar primitive defaults to
+        `min-h-svh` (a floor, not a definite height); without this override,
+        growing content makes the wrapper exceed 100svh and `#root`'s
+        `overflow:hidden` (global.css) clips it, so page-level
+        `overflow-y-auto` regions never trigger (issue #461).
+      */}
+      <SidebarProvider defaultOpen={true} className="h-svh min-h-0">
         <Sidebar collapsible="icon">
           <NavigationSidebarHeader />
           <SidebarContent />

--- a/src/shared/layout/PageTemplate.tsx
+++ b/src/shared/layout/PageTemplate.tsx
@@ -27,8 +27,13 @@ export interface PageTemplateProps {
  *   or a responsive toolbar row (title / actions) when `actions` is provided.
  * - `children` are rendered inside a body wrapper that shares the header's
  *   horizontal padding (`px-4 sm:px-6`), so titles and content align. Each
- *   page controls its body height/scroll via children (scrollable form,
- *   virtualized list, or extra elements such as error banners).
+ *   page controls its body height/scroll via children. Two idioms:
+ *   1. Whole-body scroll — a single `min-h-0 flex-1 overflow-y-auto` child
+ *      scrolls the entire body (trim / audio / resolution).
+ *   2. Internal scroll regions — a `flex min-h-0 flex-1 flex-col` child
+ *      whose inner sections use `flex-1 min-h-0 overflow-y-auto` for the
+ *      scrollable area and `shrink-0` for pinned sections/actions, so action
+ *      buttons stay visible regardless of content length (concat).
  *
  * The root is `h-full` to stay compatible with PersistentPageLayout's
  * `display:none` persistence strategy (keeps the template mounted but hidden).


### PR DESCRIPTION
## Summary

Fixes #461 — the Concat page (`/concat`) could not scroll when many files were added, so the Concat/Clear action buttons became inaccessible.

## Root cause

The `SidebarProvider` wrapper used `min-h-svh` (a floor, not a definite height). When the file list grew, the wrapper exceeded 100svh and was clipped by `#root { overflow: hidden }` (`global.css`), so nested `overflow-y-auto` regions never triggered and the action buttons were pushed off-screen.

## Changes

- **Root-cause fix** (`src/shared/layout/PageLayout.tsx`): Added `className="h-svh min-h-0"` to `<SidebarProvider>`. This bounds the app shell to viewport height so the entire flex chain resolves to definite heights. The animate-ui sidebar primitive is NOT modified (override applied at the single call site).
- **ConcatForm refactor** (`src/features/concat/ui/ConcatForm.tsx`): Converted to a bounded flex column. The file-list section scrolls internally (`min-h-0 flex-1 overflow-y-auto`), while the output section, header, and action button row are pinned (`shrink-0`) so they stay visible regardless of file count.
- **`src/pages/concat/index.tsx`**: Replaced the page-level `overflow-y-auto` wrapper with a non-scrolling flex column that passes the bounded height down to ConcatForm.
- **Test** (`src/features/concat/ui/ConcatForm.test.tsx`): Added a structural regression test asserting action buttons stay rendered with 50 files and the file list sits in a bounded scroll region.
- **Docs** (`src/shared/layout/PageTemplate.tsx`): Extended the docblock documenting the two body-layout idioms (whole-body scroll vs internal scroll regions + pinned actions).

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test` (ConcatForm) ✓ 2 passed

## Notes

- The dnd-kit `KeyboardSensor` in `FileList.tsx` is intentionally untouched: keyboard reordering accessibility is preserved, and scroll works via mouse wheel / PageUp / PageDown when no drag handle is focused.
- No regression on other pages (trim/audio/resolution/home/history/favorite/watch-history) — verified via code review. Pages that fit the viewport render identically; pages that overflow now scroll correctly as a side benefit.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)