### PR TITLE
fix(watch-history): prevent duplicate entries in infinite scroll

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1940,7 +1940,7 @@ pub struct WatchHistoryResponse {
 /// - Response parse failure
 pub async fn fetch_watch_history(
     app: &AppHandle,
-    max: i32,
+    max: i64,
     view_at: i64,
 ) -> Result<WatchHistoryResponse, String> {
     log::info!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1203,7 +1203,7 @@ async fn fetch_favorite_videos(
 #[tauri::command]
 async fn fetch_watch_history(
     app: AppHandle,
-    max: i32,
+    max: i64,
     view_at: i64,
 ) -> Result<bilibili::WatchHistoryResponse, String> {
     bilibili::fetch_watch_history(&app, max, view_at).await

--- a/src/features/watch-history/hooks/useWatchHistory.ts
+++ b/src/features/watch-history/hooks/useWatchHistory.ts
@@ -85,7 +85,9 @@ export function useWatchHistory() {
     dispatch(setLoading(true))
     dispatch(setError(null))
     try {
-      const response = await fetchWatchHistory(20, 0)
+      // Why: max=0 & viewAt=0 hits the backend's first-page branch (no cursor),
+      // so Bilibili returns the newest entries without a stale target id.
+      const response = await fetchWatchHistory(0, 0)
       dispatch(setEntries(response.entries))
       dispatch(setCursor(response.cursor))
     } catch (err) {
@@ -103,7 +105,19 @@ export function useWatchHistory() {
     if (!cursor || cursor.isEnd || loadingMore) return
     dispatch(setLoadingMore(true))
     try {
-      const response = await fetchWatchHistory(20, cursor.viewAt)
+      // Why: pass cursor.max (target id of the last entry of the previous page)
+      // so Bilibili can exclude that boundary entry. A fixed value here made the
+      // API return overlapping entries on every subsequent load, which surfaced
+      // as duplicate list items (especially visible after switching date filters).
+      const response = await fetchWatchHistory(cursor.max, cursor.viewAt)
+      // Why: Bilibili returns an empty page and resets the cursor to {max:0, viewAt:0}
+      // (still isEnd=false) once the archive-filtered history is exhausted at the
+      // cursor position. Without this guard, the next fetchMore re-fetches page 0 and
+      // the list loops forever, duplicating entries.
+      if (response.entries.length === 0) {
+        dispatch(setCursor({ ...response.cursor, isEnd: true }))
+        return
+      }
       dispatch(appendEntries(response.entries))
       dispatch(setCursor(response.cursor))
     } catch (err) {


### PR DESCRIPTION
## Summary

Watch history infinite scroll duplicated entries — the same videos reappeared, and scrolling further looped through the same list forever. Three root causes, all fixed:

- **Hardcoded `max` cursor**: `fetchMore` passed a fixed `20` instead of `cursor.max` (Bilibili's target-id cursor), so the API could not exclude the boundary entry of the previous page.
- **`i32` overflow**: the `fetch_watch_history` Tauri command declared `max` as `i32`, rejecting the large i64 cursor value (e.g. `116392338655074`) with a deserialization error — this is what most likely forced the original hardcoded `20` workaround.
- **Endless loop on exhaustion**: with `business=archive`, once the filtered history is exhausted at the cursor position, Bilibili returns an empty page and resets the cursor to `{max:0, viewAt:0}` while keeping `isEnd=false`. The frontend kept fetching, re-fetched page 0, and appended duplicates forever.

Fix:
- `fetchMore` now passes `cursor.max` (i64); `fetchInitial` uses `(0, 0)` to hit the backend's first-page branch.
- `fetch_watch_history` `max` is `i64` in both the Tauri command (`lib.rs`) and the handler (`bilibili.rs`).
- An empty response is treated as end-of-list (`isEnd = true`), stopping the loop.

## Related Issue

None (no matching open issue found).

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] Watch history → scroll to the bottom on "All" → loading stops at the end, no loop, no duplicates
- [x] Switch between All / Month / Week filters during/after infinite load → no duplicated entries
- [x] `npm run lint`, `npm run typecheck`, `cargo build` all pass

## Breaking Changes

None.

## Checklist

- [x] \`/review-all\` executed
- [x] Conventional Commits format followed in commit messages
- [x] i18n files synced (N/A — no user-facing text changed)