### PR TITLE
🚀 Release v1.42.2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Patch release **v1.42.2** with 2 bug fixes since v1.42.1.

### Fixed
- **Window geometry restore on Windows** (`fix(window)`): window size/position was not restored on Windows restart. Ports 3 improvements from the sibling Jisui project into `src-tauri/src/window.rs`:
  - tolerate the Windows invisible resize border (~7 physical px) in `is_position_on_screen`
  - branch maximized restore by platform (Windows uses `builder.maximized(true)`)
  - call `store.save()` explicitly to beat the autosave debounce on process teardown
- **Watch history duplication** (`fix`): prevent duplicate entries in watch history infinite scroll.

## Related Issue

N/A — release PR.

## Type of Change

- [x] 🔧 Chore (release)

## Test Plan

- [x] CI passes on the release branch
- [ ] After merge, the CI/CD pipeline creates the GitHub Release and tags automatically (do **not** create manually)

## Breaking Changes

None.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] Version bumped in `src-tauri/tauri.conf.json` (1.42.1 → 1.42.2)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A: no user-facing text changed