### PR TITLE
fix: reject invalid media responses and fallback audio streams (#467)

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -47,3 +47,11 @@ pub const MAX_CDN_LOOPS: u8 = 3;
 /// where process spawn + codec init is slower; a hung ffmpeg (a symptom
 /// of corruption) is treated as validation failure.
 pub const FFMPEG_VALIDATION_TIMEOUT_SECS: u64 = 60;
+
+/// Minimum byte threshold for media files.
+///
+/// Any downloaded media file smaller than this is treated as invalid
+/// (likely an error page or API response instead of actual media).
+/// This threshold catches cases where CDN/URL issues cause downloads
+/// to return HTML/XML error pages masquerading as media files.
+pub const MIN_MEDIA_BYTES: u64 = 1024; // 1 KiB

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -628,6 +628,17 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
     let dash_data = data.dash.unwrap();
 
+    // Diagnostic: record the audio stream landscape and any VIP-only
+    // objects (dolby/flac) present in the manifest. Does not affect
+    // selection; lets us confirm from reporter logs whether a VIP account's
+    // manifest contained Hi-Res/Dolby entries (issue #467 investigation).
+    log::info!(
+        "[BE] download_video: dash audio landscape id={} audio_ids={:?} extra_keys={:?}",
+        options.download_id,
+        dash_data.audio.iter().map(|a| a.id).collect::<Vec<_>>(),
+        dash_data.extra.keys().collect::<Vec<_>>(),
+    );
+
     // Fallback if selected quality is unavailable (first = highest quality)
     // None means best available → -1 won't match any real quality ID.
     let requested_quality = options.quality.unwrap_or(-1);
@@ -658,6 +669,13 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         .iter()
         .find(|a| a.base_url == audio_url)
         .map(|a| a.id);
+
+    log::info!(
+        "[BE] download_video: resolved audio quality id={:?} (requested {:?}) for id={}",
+        resolved_audio_quality,
+        options.audio_quality,
+        options.download_id,
+    );
 
     // Emit quality resolved event to frontend
     let page = options.page.unwrap_or(1);
@@ -700,35 +718,32 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
         let cookie = Some(cookie_header);
 
-        // Download audio and video in parallel (cancel immediately if either fails)
-        tokio::try_join!(
-            retry_download(app, &options.download_id, Some("audio"), || {
-                download_url(
-                    app,
-                    audio_url.clone(),
-                    audio_backup_urls.clone(),
-                    temp_audio_path.clone(),
-                    cookie.clone(),
-                    true,
-                    Some(options.download_id.clone()),
-                    None,
-                    false, // emit_complete: will be emitted after merge
-                )
-            }),
-            retry_download(app, &options.download_id, Some("video"), || {
-                download_url(
-                    app,
-                    video_url.clone(),
-                    video_backup_urls.clone(),
-                    temp_video_path.clone(),
-                    cookie.clone(),
-                    true,
-                    Some(options.download_id.clone()),
-                    None,
-                    false, // emit_complete: will be emitted after merge
-                )
-            }),
-        )?;
+        // Download audio with fallback and video in parallel (cancel immediately if either fails)
+        // Audio uses fallback to handle invalid media responses from VIP-specific CDN edges
+        let audio_download = download_audio_with_fallback(
+            app,
+            &options.download_id,
+            audio_url.clone(),
+            audio_backup_urls.clone(),
+            temp_audio_path.clone(),
+            cookie.clone(),
+            &dash_data.audio,
+        );
+        let video_download = retry_download(app, &options.download_id, Some("video"), || {
+            download_url(
+                app,
+                video_url.clone(),
+                video_backup_urls.clone(),
+                temp_video_path.clone(),
+                cookie.clone(),
+                true,
+                Some(options.download_id.clone()),
+                None,
+                false, // emit_complete: will be emitted after merge
+            )
+        });
+
+        tokio::try_join!(audio_download, video_download)?;
 
         // Check for cancellation after download completes but before merge starts.
         // This TOCTOU fix prevents wasted ffmpeg launches when the user cancels
@@ -1144,6 +1159,189 @@ async fn fetch_video_info_for_history(
     let data = body.data?;
     let thumbnail_url = (!data.pic.is_empty()).then_some(data.pic);
     Some((data.title, thumbnail_url))
+}
+
+/// Extracts just the host (CDN origin) from a Bilibili media URL for
+/// logging, so signed query parameters (mid, upsig, deadline, ...) are
+/// never written to logs that may be shared for diagnostics.
+fn url_host(url: &str) -> String {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+        .unwrap_or_else(|| "<invalid>".to_string())
+}
+
+/// Downloads audio with fallback to alternative streams.
+///
+/// When primary audio URL fails with an invalid media response (e.g., 18-byte error
+/// page instead of actual audio), tries alternative audio streams from the quality
+/// list. This handles VIP-specific CDN edge cases where some audio formats are
+/// unavailable or return error responses.
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle
+/// * `download_id` - Unique download ID for progress tracking
+/// * `primary_url` - Primary audio URL to try first
+/// * `backup_urls` - Backup URLs for the primary stream
+/// * `output_path` - Where to save the downloaded audio
+/// * `cookie` - Cookie header for authentication
+/// * `all_audio_streams` - All available audio streams for fallback
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful download (primary or fallback).
+///
+/// # Errors
+///
+/// Returns `ERR::AUDIO_DOWNLOAD_FAILED` if all attempts fail.
+async fn download_audio_with_fallback(
+    app: &AppHandle,
+    download_id: &str,
+    primary_url: String,
+    backup_urls: Option<Vec<String>>,
+    output_path: PathBuf,
+    cookie: Option<String>,
+    all_audio_streams: &[crate::models::bilibili_api::XPlayerApiResponseVideo],
+) -> Result<(), String> {
+    // Resolve the requested (primary) audio quality id from the stream
+    // list so any fallback can be logged as an explicit
+    // "quality X -> Y" transition for traceability.
+    let primary_quality_id = all_audio_streams
+        .iter()
+        .find(|s| s.base_url == primary_url)
+        .map(|s| s.id);
+
+    log::info!(
+        "[BE] download_audio_with_fallback: starting audio download id={}, primary quality_id={:?}, host={}",
+        download_id,
+        primary_quality_id,
+        url_host(&primary_url)
+    );
+
+    // Try primary URL first
+    let primary_result = retry_download(app, download_id, Some("audio"), || {
+        download_url(
+            app,
+            primary_url.clone(),
+            backup_urls.clone(),
+            output_path.clone(),
+            cookie.clone(),
+            true,
+            Some(download_id.to_string()),
+            None,
+            false,
+        )
+    })
+    .await;
+
+    match primary_result {
+        Ok(()) => {
+            log::info!(
+                "[BE] download_audio_with_fallback: primary audio succeeded (quality_id={:?}) id={}",
+                primary_quality_id,
+                download_id
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            // Check if this is an invalid media response (18-byte error page)
+            // In this case, try alternative audio streams
+            // Why: ERR::NETWORK is grouped with the invalid-media error because
+            // both are tied to a specific URL/CDN edge rather than the whole
+            // environment, so a different stream URL may still succeed. This is
+            // the complement of the systemic errors (cancel/disk-full/file-exists)
+            // that are documented as affecting every remaining stream and abort.
+            if e.contains("ERR::INVALID_MEDIA_RESPONSE") || e.contains("ERR::NETWORK") {
+                log::warn!(
+                    "[BE] download_audio_with_fallback: primary audio (quality_id={:?}) failed with {} - trying fallback streams id={}",
+                    primary_quality_id,
+                    e,
+                    download_id
+                );
+
+                // Try alternative audio streams (excluding the already-tried primary URL)
+                for (idx, stream) in all_audio_streams.iter().enumerate() {
+                    // Skip the primary stream if it's in the list
+                    if stream.base_url == primary_url {
+                        continue;
+                    }
+
+                    log::info!(
+                        "[BE] download_audio_with_fallback: trying fallback audio stream {}/{} id={}, quality_id={}, host={}",
+                        idx + 1,
+                        all_audio_streams.len(),
+                        download_id,
+                        stream.id,
+                        url_host(&stream.base_url)
+                    );
+
+                    let fallback_result = retry_download(app, download_id, Some("audio"), || {
+                        download_url(
+                            app,
+                            stream.base_url.clone(),
+                            stream.backup_urls.clone(),
+                            output_path.clone(),
+                            cookie.clone(),
+                            true,
+                            Some(download_id.to_string()),
+                            None,
+                            false,
+                        )
+                    })
+                    .await;
+
+                    match fallback_result {
+                        Ok(()) => {
+                            log::info!(
+                                "[BE] download_audio_with_fallback: audio quality fallback {:?} -> {} succeeded id={}",
+                                primary_quality_id,
+                                stream.id,
+                                download_id
+                            );
+                            return Ok(());
+                        }
+                        Err(fallback_err) => {
+                            // Systemic errors (user cancel, full disk, ...)
+                            // affect every remaining stream — abort
+                            // immediately and preserve the true cause
+                            // instead of looping through the rest and
+                            // masking it as ERR::AUDIO_DOWNLOAD_FAILED.
+                            if fallback_err.contains("ERR::CANCELLED")
+                                || fallback_err.contains("ERR::DISK_FULL")
+                                || fallback_err.contains("ERR::FILE_EXISTS")
+                            {
+                                return Err(fallback_err);
+                            }
+                            log::warn!(
+                                "[BE] download_audio_with_fallback: fallback audio stream {} (quality_id={}) failed with {} id={}",
+                                idx + 1,
+                                stream.id,
+                                fallback_err,
+                                download_id
+                            );
+                            continue;
+                        }
+                    }
+                }
+
+                log::error!(
+                    "[BE] download_audio_with_fallback: all audio streams exhausted id={} (primary quality_id={:?})",
+                    download_id,
+                    primary_quality_id
+                );
+                Err("ERR::AUDIO_DOWNLOAD_FAILED".to_string())
+            } else {
+                // For other errors (disk full, cancelled, etc.), don't attempt fallback
+                log::error!(
+                    "[BE] download_audio_with_fallback: non-retryable error id={}: {}",
+                    download_id,
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
 }
 
 /// Fetches logged-in user information from Bilibili.

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -489,7 +489,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     log::info!(
         "[BE] download_video: starting download id={}, bvid={}, cid={}",
         options.download_id,
-        &options.bvid,
+        options.bvid,
         options.cid
     );
 
@@ -1242,7 +1242,7 @@ async fn download_audio_with_fallback(
                 primary_quality_id,
                 download_id
             );
-            return Ok(());
+            Ok(())
         }
         Err(e) => {
             // Check if this is an invalid media response (18-byte error page)

--- a/src-tauri/src/models/bilibili_api.rs
+++ b/src-tauri/src/models/bilibili_api.rs
@@ -112,6 +112,13 @@ pub struct XPlayerApiResponseDash {
     pub video: Vec<XPlayerApiResponseVideo>,
     /// Available audio stream qualities
     pub audio: Vec<XPlayerApiResponseVideo>,
+    /// Unparsed top-level DASH fields (e.g. `dolby`, `flac`) captured for
+    /// diagnostic logging only. These VIP-only audio objects are
+    /// intentionally NOT fed into stream selection (see issue #467
+    /// investigation), but recording their presence helps confirm whether
+    /// the manifest included them for a given account.
+    #[serde(flatten, default)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Individual video or audio stream.

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     constants::{
-        MAX_CDN_LOOPS, MIN_DATA_FOR_SPEED_CHECK, MIN_SPEED_THRESHOLD, REFERER,
+        MAX_CDN_LOOPS, MIN_DATA_FOR_SPEED_CHECK, MIN_MEDIA_BYTES, MIN_SPEED_THRESHOLD, REFERER,
         SPEED_CHECK_INTERVAL_SECS, USER_AGENT,
     },
     emits::Emits,
@@ -415,6 +415,20 @@ pub async fn download_url(
                             ));
                         }
 
+                        // Reject non-media responses. Bilibili serves a JSON
+                        // error body with HTTP 200 + matching Content-Length
+                        // for gated/expired stream URLs; without this check an
+                        // 18-byte error payload is accepted as a valid segment
+                        // and later breaks the ffmpeg merge (issue #467).
+                        if !is_media_content_type(resp.headers().get(header::CONTENT_TYPE)) {
+                            log::error!(
+                                "[BE] download_url: segment {} non-media content-type (likely error body), status={}",
+                                idx,
+                                resp.status()
+                            );
+                            return Err(anyhow::anyhow!("ERR::INVALID_MEDIA_RESPONSE"));
+                        }
+
                         // Download segment with progress tracking
                         let emits_cb = emits_c.clone();
                         let dl_total_cb = dl_total_c.clone();
@@ -543,7 +557,16 @@ pub async fn download_url(
     while let Some(res) = futs.next().await {
         match res {
             Ok(Ok(())) => {}
-            Ok(Err(_)) | Err(_) => seg_errors += 1,
+            Ok(Err(e)) => {
+                // Propagate invalid-media errors immediately so the caller's
+                // fallback logic runs without retrying the same error URL.
+                if e.to_string().contains("ERR::INVALID_MEDIA_RESPONSE") {
+                    emits.stop().await;
+                    return Err(e);
+                }
+                seg_errors += 1;
+            }
+            Err(_) => seg_errors += 1,
         }
     }
 
@@ -555,6 +578,20 @@ pub async fn download_url(
 
     // Final verification
     let final_downloaded = downloaded_total.load(Ordering::Relaxed);
+    // Why: a dedicated size floor is needed because the issue #467 error body
+    // was served with HTTP 200 and a matching Content-Length, so the
+    // `final_downloaded != total` check below would pass it as valid. This
+    // minimum-size check must run before the total-mismatch check to catch it.
+    if final_downloaded < MIN_MEDIA_BYTES {
+        log::error!(
+            "[BE] download_url: downloaded size too small: {} bytes (min {} bytes) - likely error response",
+            final_downloaded,
+            MIN_MEDIA_BYTES
+        );
+        // Stop the background emitter so it doesn't leak a progress loop.
+        emits.stop().await;
+        return Err(anyhow::anyhow!("ERR::INVALID_MEDIA_RESPONSE"));
+    }
     if final_downloaded != total {
         log::error!(
             "[BE] download_url: final size mismatch: {} vs {}",
@@ -765,6 +802,16 @@ async fn single_stream_fallback(
     let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
     let req = apply_cookie(client.get(&url).header(header::REFERER, REFERER), &cookie);
     let mut resp = req.send().await?;
+    // Reject non-media error responses before streaming to disk (see
+    // is_media_content_type). Mirrors the segmented path's guard so the
+    // fallback path cannot silently persist a JSON/text error payload.
+    if !is_media_content_type(resp.headers().get(header::CONTENT_TYPE)) {
+        log::error!(
+            "[BE] download_url: single-stream non-media content-type (likely error body), status={}",
+            resp.status()
+        );
+        return Err(anyhow::anyhow!("ERR::INVALID_MEDIA_RESPONSE"));
+    }
     let total = resp.content_length();
 
     // Setup emitter
@@ -941,4 +988,20 @@ async fn preallocate_file(path: &PathBuf, size: u64) -> Result<()> {
 
     file.set_len(size).await.map_err(map_io_error)?;
     Ok(())
+}
+
+/// Returns true when the response content-type looks like real media.
+///
+/// Bilibili's CDN serves m4s segments as `application/octet-stream` or
+/// `video/*`. When a stream URL is gated or expired it instead returns a
+/// short JSON or text error body with HTTP 200. Rejecting those makes the
+/// download fail fast as `ERR::INVALID_MEDIA_RESPONSE` instead of writing
+/// the error payload to disk. A missing content-type header is treated as
+/// valid to preserve existing behavior for CDNs that omit it.
+fn is_media_content_type(ct: Option<&reqwest::header::HeaderValue>) -> bool {
+    let Some(ct) = ct.and_then(|v| v.to_str().ok()) else {
+        return true;
+    };
+    let lower = ct.to_ascii_lowercase();
+    !(lower.contains("application/json") || lower.starts_with("text/"))
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -60,6 +60,9 @@ const ERROR_MAP: Record<string, string> = {
   'ERR::BANGUMI_ACCESS_DENIED': 'video.bangumi_access_denied',
   'ERR::BANGUMI_NO_DASH': 'video.bangumi_no_dash',
   'ERR::BANGUMI_DURL_NOT_SUPPORTED': 'video.bangumi_durl_not_supported',
+  // Audio download error codes
+  'ERR::INVALID_MEDIA_RESPONSE': 'video.invalid_media_response',
+  'ERR::AUDIO_DOWNLOAD_FAILED': 'video.audio_download_failed',
 }
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,6 +159,8 @@
     "rate_limited": "Too many requests. Please wait a moment and try again.",
     "video_quality_fallback": "Selected video quality ({{from}}) unavailable. Using {{to}}.",
     "audio_quality_fallback": "Selected audio quality ({{from}}) unavailable. Using {{to}}.",
+    "invalid_media_response": "Invalid media response from server (received error page instead of media).",
+    "audio_download_failed": "Failed to download audio after trying all available streams.",
     "queue_waiting_prefix": "Queued:",
     "reload_after_error": "Reload page to retry",
     "select_all": "Select All",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -159,6 +159,8 @@
     "rate_limited": "Demasiadas solicitudes. Por favor, espere un momento e inténtelo de nuevo.",
     "video_quality_fallback": "La calidad de video seleccionada ({{from}}) no está disponible. Usando {{to}}.",
     "audio_quality_fallback": "La calidad de audio seleccionada ({{from}}) no está disponible. Usando {{to}}.",
+    "invalid_media_response": "Respuesta de medios no válida del servidor (se recibió página de error).",
+    "audio_download_failed": "Error al descargar audio después de intentar todas las transmisiones disponibles.",
     "queue_waiting_prefix": "En cola:",
     "reload_after_error": "Recargar página para reintentar",
     "select_all": "Seleccionar todo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -159,6 +159,8 @@
     "rate_limited": "Trop de requêtes. Veuillez patienter un instant et réessayer.",
     "video_quality_fallback": "La qualité vidéo sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
     "audio_quality_fallback": "La qualité audio sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
+    "invalid_media_response": "Réponse média non valide du serveur (page d'erreur reçue).",
+    "audio_download_failed": "Échec du téléchargement audio après avoir essayé tous les flux disponibles.",
     "queue_waiting_prefix": "En file d'attente:",
     "reload_after_error": "Recharger la page pour réessayer",
     "select_all": "Tout sélectionner",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -159,6 +159,8 @@
     "rate_limited": "リクエストが多すぎます。しばらく待ってから再試行してください。",
     "video_quality_fallback": "選択した画質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
     "audio_quality_fallback": "選択した音質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
+    "invalid_media_response": "サーバーから無効なメディア応答がありました（エラーページを受信）。",
+    "audio_download_failed": "すべての利用可能なストリームを試しましたが、音声のダウンロードに失敗しました。",
     "queue_waiting_prefix": "キュー待ち:",
     "reload_after_error": "ページをリロードして再試行",
     "select_all": "全選択",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -159,6 +159,8 @@
     "rate_limited": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
     "video_quality_fallback": "선택한 화질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
     "audio_quality_fallback": "선택한 음질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
+    "invalid_media_response": "서버에서 잘못된 미디어 응답을 받았습니다(오류 페이지 수신).",
+    "audio_download_failed": "사용 가능한 모든 스트림을 시도했으나 오디오 다운로드에 실패했습니다.",
     "queue_waiting_prefix": "대기 중:",
     "reload_after_error": "페이지 새로고침 후 재시도",
     "select_all": "전체 선택",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -160,6 +160,8 @@
     "rate_limited": "请求过于频繁，请稍后再试。",
     "video_quality_fallback": "选定的视频清晰度 ({{from}}) 不可用，已使用 {{to}}。",
     "audio_quality_fallback": "选定的音频音质 ({{from}}) 不可用，已使用 {{to}}。",
+    "invalid_media_response": "服务器返回了无效的媒体响应（接收到错误页面而非媒体）。",
+    "audio_download_failed": "尝试了所有可用流后，音频下载失败。",
     "queue_waiting_prefix": "排队中:",
     "reload_after_error": "刷新页面后重试",
     "select_all": "全选",


### PR DESCRIPTION
## Summary

Fixes the root cause behind `ERR::MERGE_FAILED` for VIP accounts (#467): Bilibili serves a short JSON error body with HTTP 200 + a matching Content-Length for gated/expired audio stream URLs, and the downloader trusted the advertised size — so an 18-byte error payload was accepted as a valid segment and later broke the ffmpeg merge ("moov atom not found").

## Changes

- **Detect invalid media responses**: reject non-media CDN responses (`application/json`, `text/*`) in `download_url` and `single_stream_fallback` via `is_media_content_type`, returning `ERR::INVALID_MEDIA_RESPONSE` immediately (no wasted retries). Add `MIN_MEDIA_BYTES` (1 KiB) final size guard; aggregate loop propagates the error at once.
- **Audio fallback**: `download_audio_with_fallback` tries alternative audio streams on invalid-media/network errors; systemic errors (cancel/disk full) abort immediately to preserve the true cause; exhaustion → `ERR::AUDIO_DOWNLOAD_FAILED`.
- **Diagnostic logging** for root-cause investigation: dash audio landscape (ids + dolby/flac presence via `#[serde(flatten)] extra`), resolved audio quality, and a quality-transition trace on fallback. Media URLs are masked in logs (`url_host`).
- **i18n**: new error codes mapped across all 6 languages.

## Verification

- `cargo build`, `npm run typecheck`, `npm run lint`: all green.
- Non-VIP download verified (regression-free); fallback path reviewed but not triggered on a normal download.
- **Pending**: VIP reproducer verification — a pre-release Windows build will be shared with the reporter to confirm the fallback succeeds and capture the manifest logs that pin the exact root cause (whether the VIP audio array contains 30250/30251).

Do NOT close #467 yet — pending reporter confirmation.

Refs #467