### PR TITLE
feat: split splash into standalone window with backend-consolidated init

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,9 @@
         var c = d ? 'dark' : 'light'
         document.documentElement.classList.add(c)
         document.documentElement.style.colorScheme = c
-        document.documentElement.style.backgroundColor = d ? '#252525' : '#ffffff'
+        document.documentElement.style.backgroundColor = d
+          ? '#252525'
+          : '#ffffff'
       })()
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         var c = d ? 'dark' : 'light'
         document.documentElement.classList.add(c)
         document.documentElement.style.colorScheme = c
-        document.body.style.backgroundColor = d ? '#252525' : '#ffffff'
+        document.documentElement.style.backgroundColor = d ? '#252525' : '#ffffff'
       })()
     </script>
   </head>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,10 +2,11 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "splash"],
   "permissions": [
     "core:default",
     "core:window:allow-set-theme",
+    "core:window:allow-start-dragging",
     "process:default",
     "opener:default",
     "shell:allow-open",

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -167,9 +167,11 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         archive_path.clone(),
         None,
         true,
+        // Why: a fixed download_id lets the splash window filter the "progress"
+        // event and render a download progress bar during ffmpeg install.
+        Some("ffmpeg-install".to_string()),
         None,
-        None,
-        false, // emit_complete: ffmpeg download has no progress UI
+        true, // emit progress so the splash can show a download progress bar
     )
     .await
     .is_err()

--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -1,0 +1,160 @@
+//! Backend initialization sequence (consolidated init).
+//!
+//! Runs on the Rust side so the splash window (a separate webview) can show
+//! progress without sharing Redux state with the main window. Emits
+//! `init_step` labels for each step; the splash listens and renders them.
+//! The final result (settings, user, login_success) is stored in AppHandle
+//! State and read by the main window via `get_init_result` on startup, so the
+//! main window never re-runs the heavy init.
+
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::handlers::{bilibili, cleanup, cookie, ffmpeg, qr_login};
+use crate::models::frontend_dto::User;
+use crate::models::qr_login::{CookieRefreshInfo, LoginMethod};
+use crate::models::settings::Settings;
+
+/// Payload for a synchronous init step (label only, no progress bar).
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitStep {
+    pub label_key: String,
+}
+
+/// Payload for an asynchronous init step (label + optional percentage).
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitProgress {
+    pub label_key: String,
+    pub percentage: Option<f64>,
+}
+
+/// Result of the backend init sequence, handed off to the main window.
+///
+/// Stored in AppHandle State (Mutex<InitResult>); the main window reads it via
+/// `get_init_result` instead of re-running init.
+#[derive(Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitResult {
+    pub settings: Option<Settings>,
+    pub user: Option<User>,
+    /// Error string from user-info fetch (None on success). Handed to the main
+    /// window so it can run interceptInvokeError (e.g. session-expiry toast).
+    pub user_error: Option<String>,
+    /// True when ffmpeg is valid or was successfully installed.
+    pub ffmpeg_success: bool,
+}
+
+/// Runs the backend initialization sequence, emitting progress events to the
+/// "splash" window and storing the result in AppHandle State.
+///
+/// Mirrors the previous frontend `useInit` orchestration so behavior is
+/// preserved (login-method branching, ffmpeg install, user fetch).
+#[tauri::command]
+pub async fn initialize(app: AppHandle) -> Result<(), String> {
+    // 1. Clean up orphaned temp files from previous sessions.
+    emit_step(&app, "init.cleanup_in_progress");
+    let _ = cleanup::cleanup_temp_files(&app, None);
+
+    // 2. ffmpeg validate / install (heaviest step; downloads on first run).
+    //    Settings are already loaded in setup and stored in InitResult, so
+    //    they are not reloaded here.
+    emit_step(&app, "init.checking_ffmpeg");
+    let mut ffmpeg_success = ffmpeg::validate_ffmpeg(&app).await;
+    if !ffmpeg_success {
+        emit_step(&app, "init.installing_ffmpeg");
+        ffmpeg_success = ffmpeg::install_ffmpeg(&app).await.unwrap_or(false);
+    }
+
+    // 3. Session restore. Honor the user-selected login method strictly (no
+    //    cross-method fallback), mirroring useInit.
+    let login_method = qr_login::get_login_method(&app)
+        .await
+        .unwrap_or(LoginMethod::Firefox);
+    match login_method {
+        LoginMethod::QrCode => {
+            let loaded = qr_login::load_stored_session(&app).await.unwrap_or(false);
+            if loaded {
+                let refresh_info =
+                    qr_login::check_cookie_refresh(&app)
+                        .await
+                        .unwrap_or(CookieRefreshInfo {
+                            refresh: false,
+                            timestamp: 0,
+                        });
+                if !refresh_info.refresh {
+                    emit_step(&app, "init.qr_session_restored");
+                } else {
+                    match qr_login::refresh_cookie(&app).await {
+                        Ok(_) => {
+                            emit_step(&app, "init.cookie_refreshed");
+                        }
+                        Err(_) => {
+                            // Refresh failed: clear the stale session, stay logged out.
+                            let _ = qr_login::logout(&app).await;
+                        }
+                    }
+                }
+            }
+        }
+        LoginMethod::Firefox => {
+            emit_step(&app, "init.reading_cookies");
+            let _ = cookie::get_cookie(&app).await;
+        }
+    }
+
+    // 4. User info. Capture the error string (if any) so the main window can
+    //    run interceptInvokeError (e.g. session-expiry toast) — mirroring the
+    //    previous frontend getUserInfo behavior.
+    emit_step(&app, "init.fetching_user");
+    let (user, user_error) = match bilibili::fetch_user_info(&app).await {
+        Ok(u) => (Some(u), None),
+        Err(e) => (None, Some(e)),
+    };
+
+    // 5. Store the result for the main window to read on startup.
+    if let Some(state) = app.try_state::<Mutex<InitResult>>() {
+        if let Ok(mut guard) = state.lock() {
+            // guard.settings is set in setup (before the splash is created);
+            // do not overwrite it here.
+            guard.user = user;
+            guard.user_error = user_error;
+            guard.ffmpeg_success = ffmpeg_success;
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the result of the backend init sequence. Called by the main window
+/// on startup (after finish_splash) to avoid re-running init.
+#[tauri::command]
+pub fn get_init_result(state: State<'_, Mutex<InitResult>>) -> InitResult {
+    state.lock().map(|g| g.clone()).unwrap_or_default()
+}
+
+/// Emits a synchronous init step (label only) to the splash window.
+fn emit_step(app: &AppHandle, label_key: &str) {
+    let _ = app.emit_to(
+        "splash",
+        "init_step",
+        InitStep {
+            label_key: label_key.to_string(),
+        },
+    );
+}
+
+/// Emits an asynchronous init step (label + percentage) to the splash window.
+#[allow(dead_code)]
+fn emit_progress(app: &AppHandle, label_key: &str, percentage: Option<f64>) {
+    let _ = app.emit_to(
+        "splash",
+        "init_progress",
+        InitProgress {
+            label_key: label_key.to_string(),
+            percentage,
+        },
+    );
+}

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -22,6 +22,7 @@ pub mod cookie;
 pub mod favorites;
 pub mod ffmpeg;
 pub mod github;
+pub mod init;
 pub mod qr_login;
 pub mod resolution;
 pub mod rotation;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use crate::handlers::cookie;
 use crate::handlers::favorites;
 use crate::handlers::ffmpeg;
 use crate::handlers::github;
+use crate::handlers::init;
 use crate::handlers::qr_login;
 use crate::handlers::resolution;
 use crate::handlers::rotation;
@@ -40,6 +41,7 @@ use crate::models::qr_login::LoginState;
 use crate::models::qr_login::QrCodeResult;
 use crate::models::qr_login::QrPollResult;
 use crate::models::qr_login::Session;
+use crate::models::settings::Language;
 use crate::models::settings::Settings;
 use crate::models::settings::UiTheme;
 use crate::store::HistoryStore;
@@ -203,7 +205,10 @@ pub fn run() {
             load_qr_session,
             check_cookie_refresh,
             refresh_cookie,
-            window::enable_window_resize,
+            window::show_splash,
+            window::finish_splash,
+            init::initialize,
+            init::get_init_result,
             // record_download_click  // NOTE: GA4 Analytics is currently disabled
             #[cfg(debug_assertions)]
             set_simulate_logout,
@@ -221,23 +226,54 @@ pub fn run() {
                     .expect("Failed to register mcp-bridge plugin");
             }
 
-            // Read settings for window theme before creating the window
-            let window_theme = crate::utils::paths::get_settings_path(app.handle())
-                .exists()
-                .then(|| {
-                    std::fs::read_to_string(crate::utils::paths::get_settings_path(app.handle()))
-                        .ok()
-                        .and_then(|content| serde_json::from_str::<Settings>(&content).ok())
-                        .and_then(|s| s.theme)
-                })
-                .flatten()
+            // Initialize init result store early so setup can populate settings
+            // into it right below (read by the main window via get_init_result).
+            app.manage(std::sync::Mutex::new(init::InitResult::default()));
+
+            // Read settings before creating the splash window so the splash can
+            // render labels in the user's language from the first frame (the
+            // language is passed via the splash URL). Why block_on: setup is
+            // synchronous but get_settings is async; this adds only a few ms
+            // (reading the settings store) and runs before the splash appears.
+            let settings = tauri::async_runtime::block_on(async {
+                crate::handlers::settings::get_settings(app.handle())
+                    .await
+                    .ok()
+            });
+            let window_theme = settings
+                .as_ref()
+                .and_then(|s| s.theme.clone())
                 .map(|t| match t {
                     UiTheme::Dark => tauri::Theme::Dark,
                     UiTheme::Light => tauri::Theme::Light,
                 });
+            let language = settings.as_ref().map(|s| {
+                match s.language {
+                    Language::En => "en",
+                    Language::Ja => "ja",
+                    Language::Fr => "fr",
+                    Language::Es => "es",
+                    Language::Zh => "zh",
+                    Language::Ko => "ko",
+                }
+                .to_string()
+            });
 
-            // Create main window with saved geometry (prevents startup flash)
-            window::create_main_window(app.handle(), window_theme)?;
+            // Store settings into InitResult so initialize doesn't reload them
+            // (settings are already read here; initialize focuses on ffmpeg /
+            // session / user which actually take time).
+            if let Some(ref s) = settings {
+                if let Some(state) = app.try_state::<std::sync::Mutex<init::InitResult>>() {
+                    if let Ok(mut guard) = state.lock() {
+                        guard.settings = Some(s.clone());
+                    }
+                }
+            }
+
+            // Create the splash window first. The main window is created by
+            // finish_splash once initialization completes, so the maximized
+            // restore never races a splash-time geometry lock.
+            window::create_splash_window(app.handle(), window_theme, language)?;
 
             // Initialize logging plugin with app_data_dir/logs path
             let log_dir = app
@@ -287,26 +323,9 @@ pub fn run() {
                 std::env::consts::OS
             );
 
-            // Log application exit and save window geometry on close
-            if let Some(window) = app.get_webview_window("main") {
-                let app_handle = app.handle().clone();
-                window.on_window_event(move |event| match event {
-                    tauri::WindowEvent::CloseRequested { .. } => {
-                        window::save_window_geometry(&app_handle);
-                        log::info!("[BE] Application exiting - main window closed");
-                    }
-                    // CAUTION: Cmd+Q (macOS) and programmatic exit() bypass
-                    // CloseRequested, so persisting here keeps the latest normal
-                    // geometry available even when the app exits without closing
-                    // the window normally. save_window_geometry internally skips
-                    // fullscreen and maximized states, so only real changes to
-                    // the normal geometry land on disk.
-                    tauri::WindowEvent::Resized { .. } | tauri::WindowEvent::Moved { .. } => {
-                        window::save_window_geometry(&app_handle);
-                    }
-                    _ => {}
-                });
-            }
+            // Main window event handlers (close/resize/move → save geometry) and
+            // devtools are registered in finish_splash after the main window is
+            // created, since it doesn't exist at setup time (only the splash).
 
             // Initialize cookie cache
             app.manage(CookieCache::default());
@@ -323,29 +342,8 @@ pub fn run() {
             // tauri::async_runtime::spawn(async move {
             //     crate::utils::analytics::init_analytics(&handle).await;
             // });
-            // Enable dev console in development environment
-            // Don't open console during E2E tests
-            // Respects the openDevtoolsOnStartup setting (defaults to true)
-            #[cfg(debug_assertions)]
-            {
-                if !crate::handlers::qr_login::is_e2e_testing() {
-                    let settings_path = crate::utils::paths::get_settings_path(app.handle());
-                    let should_open = if settings_path.exists() {
-                        std::fs::read_to_string(&settings_path)
-                            .ok()
-                            .and_then(|content| serde_json::from_str::<Settings>(&content).ok())
-                            .and_then(|s| s.open_devtools_on_startup)
-                            .unwrap_or(true)
-                    } else {
-                        true
-                    };
-
-                    if should_open {
-                        let window = app.get_webview_window("main").unwrap();
-                        window.open_devtools();
-                    }
-                }
-            }
+            // Devtools (debug) now opens from register_main_window_events after
+            // the main window is created.
             Ok(())
         });
 

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -257,7 +257,7 @@ fn register_main_window_events(app: &AppHandle) {
             };
             if should_open {
                 if let Some(win) = app.get_webview_window("main") {
-                    let _ = win.open_devtools();
+                    win.open_devtools();
                 }
             }
         }

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,9 +1,22 @@
 //! Window creation and geometry persistence.
 //!
-//! Creates the main application window programmatically with saved geometry
-//! to prevent the startup size flash that occurs when using tauri.conf.json
-//! defaults followed by async resize via tao's dispatch_async.
+//! Two-window model (Discord-style splash):
+//! - "splash": borderless, fixed-size, centered splash window shown on launch
+//!   while initialization runs behind it. The whole window is draggable via
+//!   `data-tauri-drag-region` on the frontend.
+//! - "main": the application window, created after the splash finishes, with
+//!   saved geometry / maximized restore.
+//!
+//! Why no splash-time geometry lock: the previous design locked the main
+//! window with resizable(false)+maximizable(false) during the splash and
+//! restored maximized via builder.maximized(true). On Windows, a maximized
+//! window is only clamped to the work area (excluding the taskbar) while
+//! WS_THICKFRAME (resizable) is present, so the locked+maximized restore
+//! covered the taskbar until enable_window_resize flipped resizable back on.
+//! Splitting the splash into its own window removes that conflict entirely —
+//! the main window is built resizable and maximizes correctly from the start.
 
+use crate::models::settings::{Settings, UiTheme};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, Theme, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
@@ -14,6 +27,11 @@ const MIN_WIDTH: f64 = 980.0;
 const MIN_HEIGHT: f64 = 609.0;
 const WINDOW_TITLE: &str = "Bilibili Downloader";
 const GEOMETRY_STORE_KEY: &str = "windowGeometry";
+
+// Splash window dimensions (logical). Square on all platforms for a consistent
+// Discord-style splash. Tunable; the frontend splash route fills this area.
+const SPLASH_WIDTH: f64 = 480.0;
+const SPLASH_HEIGHT: f64 = 480.0;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,7 +47,69 @@ struct WindowGeometry {
     maximized: bool,
 }
 
+impl WindowGeometry {
+    /// Fallback used when `read_raw_geometry` returns None.
+    const DEFAULT: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT,
+        maximized: false,
+    };
+}
+
+/// Creates the borderless, fixed-size, centered splash window.
+///
+/// Content is served from the frontend "/splashscreen" route. `decorations
+/// (false)` removes the title bar/borders; the frontend makes the whole
+/// window draggable via `data-tauri-drag-region`. Resizable/maximizable are
+/// disabled because the splash has a fixed size.
+pub fn create_splash_window(
+    app: &AppHandle,
+    theme: Option<Theme>,
+    language: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Pass the language as a query param so the splash can apply i18n before
+    // first paint (labels render in the user's language).
+    let url = match &language {
+        Some(lang) => format!("splashscreen?lang={}", lang),
+        None => "splashscreen".to_string(),
+    };
+    let _splash = WebviewWindowBuilder::new(app, "splash", WebviewUrl::App(url.into()))
+        .title(WINDOW_TITLE)
+        .theme(theme.or(Some(Theme::Light)))
+        .inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
+        .min_inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
+        .max_inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
+        .decorations(false)
+        .center()
+        .resizable(false)
+        // Why visible(false): the webview needs a frame to load the splash
+        // route before first paint. The frontend invokes show_splash once
+        // React has mounted, so the user never sees the blank/black loading
+        // frame.
+        .visible(false)
+        .build()?;
+    Ok(())
+}
+
+/// Shows the splash window after the frontend has mounted. Called via
+/// `show_splash` from SplashScreen's first effect to avoid a black frame
+/// while the webview loads the splash route.
+#[tauri::command]
+pub fn show_splash(app: AppHandle) -> Result<(), String> {
+    if let Some(splash) = app.get_webview_window("splash") {
+        splash.show().map_err(|e| format!("{e}"))?;
+        splash.set_focus().map_err(|e| format!("{e}"))?;
+    }
+    Ok(())
+}
+
 /// Creates the main application window with saved or default geometry.
+///
+/// Built resizable (no splash-time lock) so the OS-native maximize clamps to
+/// the work area on Windows. Call this from `finish_splash` after the splash
+/// window is done.
 pub fn create_main_window(
     app: &AppHandle,
     theme: Option<Theme>,
@@ -40,12 +120,6 @@ pub fn create_main_window(
     let mut builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
         .title(WINDOW_TITLE)
         .theme(theme.or(Some(Theme::Light)))
-        .resizable(false)
-        // Why: resizable(false) should auto-disable the maximize button per
-        // Tauri docs, but the Windows/tao backend ignores this — without an
-        // explicit maximizable(false) the button stays clickable during splash,
-        // letting users maximize and distort geometry (commit c4343ac).
-        .maximizable(false)
         .min_inner_size(MIN_WIDTH, MIN_HEIGHT);
 
     // Maximized restoration branches by platform because the correct approach
@@ -64,20 +138,18 @@ pub fn create_main_window(
     //   animate and cannot be suppressed through Tauri's public API, so the
     //   "normal-size -> maximized" resize is always visible, even with
     //   visible(false)+show() (show() flushes the pending animated frame
-    //   change). This was confirmed against tao's
-    //   platform_impl/macos/util/async.rs. So on macOS we instead size the
-    //   window to the primary monitor's work area at construction time. No
-    //   post-create resize ever happens, so there is no animation. Trade-off:
-    //   this yields a "maximized-sized normal window" rather than a true
-    //   isZoomed state, so un-maximizing does not restore the previous size
-    //   automatically.
+    //   change). So on macOS we instead size the window to the primary
+    //   monitor's work area at construction time. No post-create resize ever
+    //   happens, so there is no animation. Trade-off: this yields a
+    //   "maximized-sized normal window" rather than a true isZoomed state, so
+    //   un-maximizing does not restore the previous size automatically.
     if should_maximize {
         #[cfg(target_os = "windows")]
         {
             // Why: set the saved (pre-maximize normal) geometry as inner_size
-            // so un-maximizing auto-restores the previous size (resolves the
-            // macOS work-area trade-off). Build invisible, then maximize, then
-            // show so the normal-size frame never flashes on screen.
+            // so un-maximizing auto-restores the previous size. Build
+            // invisible, then maximize, then show so the normal-size frame
+            // never flashes on screen.
             if let Some(geo) = &geometry {
                 builder = builder
                     .inner_size(geo.width, geo.height)
@@ -115,20 +187,99 @@ pub fn create_main_window(
     Ok(())
 }
 
-/// Re-enables window resizing and maximizing after the splash screen completes.
+/// Closes the splash window and creates the main window with restored geometry.
 ///
-/// The window is created with `resizable(false)` and `maximizable(false)` to
-/// lock its geometry during the splash screen. This restores both so the user
-/// can resize and maximize the main window once initialization is done.
+/// Called from the frontend after initialization completes. The main window is
+/// built resizable so the OS-native maximize clamps to the work area (no
+/// taskbar occlusion during restore).
 #[tauri::command]
-pub fn enable_window_resize(app: AppHandle) -> Result<(), String> {
-    let window = app.get_webview_window("main").ok_or("Window not found")?;
-    // Constraint: set_resizable MUST run before set_maximizable. When the window
-    // is still non-resizable, Tauri/tao silently ignores set_maximizable on
-    // Windows, so reversing the order would leave the maximize button disabled.
-    window.set_resizable(true).map_err(|e| format!("{e}"))?;
-    window.set_maximizable(true).map_err(|e| format!("{e}"))?;
+pub async fn finish_splash(app: AppHandle) -> Result<(), String> {
+    log::info!("[BE] finish_splash: called");
+    let theme = read_window_theme(&app);
+    // Why async: WebviewWindowBuilder::build() must run on the main thread's
+    // event loop. A synchronous command occupies the main thread and deadlocks
+    // the window creation. An async command runs on a worker thread, freeing
+    // the main thread so build() can proceed.
+    create_main_window(&app, theme).map_err(|e| {
+        log::error!("[BE] finish_splash: create_main_window error: {e}");
+        format!("{e}")
+    })?;
+    log::info!("[BE] finish_splash: main window created");
+    register_main_window_events(&app);
+    // Close the splash AFTER the main window is up. Closing it first can leave
+    // zero windows momentarily and trigger process exit before main is shown.
+    if let Some(splash) = app.get_webview_window("splash") {
+        let _ = splash.close();
+    }
+    log::info!("[BE] finish_splash: done");
     Ok(())
+}
+
+/// Registers close/resize/move handlers (and opens devtools in debug) on the
+/// main window. Must run AFTER the main window is created (in finish_splash),
+/// since it doesn't exist at setup time anymore (only the splash does).
+fn register_main_window_events(app: &AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let app_handle = app.clone();
+    window.on_window_event(move |event| match event {
+        tauri::WindowEvent::CloseRequested { .. } => {
+            save_window_geometry(&app_handle);
+            log::info!("[BE] Application exiting - main window closed");
+        }
+        // CAUTION: Cmd+Q (macOS) and programmatic exit() bypass CloseRequested,
+        // so persisting here keeps the latest normal geometry available even
+        // when the app exits without closing the window normally.
+        // save_window_geometry internally skips fullscreen and maximized-only
+        // states, so only real changes to the normal geometry land on disk.
+        tauri::WindowEvent::Resized { .. } | tauri::WindowEvent::Moved { .. } => {
+            save_window_geometry(&app_handle);
+        }
+        _ => {}
+    });
+
+    // Devtools in debug builds (respects openDevtoolsOnStartup, skipped during
+    // E2E tests). Moved here from setup because the main window no longer
+    // exists at setup time.
+    #[cfg(debug_assertions)]
+    {
+        if !crate::handlers::qr_login::is_e2e_testing() {
+            let settings_path = crate::utils::paths::get_settings_path(app);
+            let should_open = if settings_path.exists() {
+                std::fs::read_to_string(&settings_path)
+                    .ok()
+                    .and_then(|content| serde_json::from_str::<Settings>(&content).ok())
+                    .and_then(|s| s.open_devtools_on_startup)
+                    .unwrap_or(true)
+            } else {
+                true
+            };
+            if should_open {
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.open_devtools();
+                }
+            }
+        }
+    }
+}
+
+/// Reads the saved UI theme (if any) to apply to windows. Shared by lib::setup
+/// (splash) and finish_splash (main) so both windows match the user theme.
+pub fn read_window_theme(app: &AppHandle) -> Option<Theme> {
+    crate::utils::paths::get_settings_path(app)
+        .exists()
+        .then(|| {
+            std::fs::read_to_string(crate::utils::paths::get_settings_path(app))
+                .ok()
+                .and_then(|content| serde_json::from_str::<Settings>(&content).ok())
+                .and_then(|s| s.theme)
+        })
+        .flatten()
+        .map(|t| match t {
+            UiTheme::Dark => Theme::Dark,
+            UiTheme::Light => Theme::Light,
+        })
 }
 
 /// Saves the current window geometry to the store.
@@ -162,41 +313,45 @@ pub fn save_window_geometry(app: &AppHandle) {
     let Ok(is_maximized) = window.is_maximized() else {
         return;
     };
+    let Ok(scale) = window.scale_factor() else {
+        return;
+    };
+    let Ok(size) = window.inner_size() else {
+        return;
+    };
+    let logical_w = size.width as f64 / scale;
+    let logical_h = size.height as f64 / scale;
+
+    // Why: maximize() can dispatch its Resized event before is_maximized()
+    // flips to true. Without the size check, a maximized window would be
+    // persisted with work-area-sized bounds as the "normal" geometry,
+    // corrupting the real normal size (so the next launch restores an
+    // oversized normal window). Treat any window covering the work area as
+    // maximized regardless of is_maximized() to prevent that.
+    let effective_maximized = is_maximized || is_maximize_sized(app, logical_w, logical_h);
 
     // NOTE: Known trade-off of "Approach A" (maximized → work-area-sized
     // normal window at launch): the construction-time sizing emits a Resized
     // event, which can overwrite the user's real normal geometry with the
     // transient work-area bounds if they resize before the next persist.
     // This data loss is accepted as the cost of avoiding the startup flash.
-    let geo = if is_maximized {
+    let geo = if effective_maximized {
         // Persist only the flag; reuse the last normal geometry so un-maximizing
         // on next launch restores the real size instead of full-screen bounds.
-        let prev = read_raw_geometry(app).unwrap_or(WindowGeometry {
-            x: 0.0,
-            y: 0.0,
-            width: DEFAULT_WIDTH,
-            height: DEFAULT_HEIGHT,
-            maximized: false,
-        });
+        let prev = read_raw_geometry(app).unwrap_or(WindowGeometry::DEFAULT);
         WindowGeometry {
             maximized: true,
             ..prev
         }
     } else {
-        let Ok(scale) = window.scale_factor() else {
-            return;
-        };
         let Ok(pos) = window.outer_position() else {
-            return;
-        };
-        let Ok(size) = window.inner_size() else {
             return;
         };
         WindowGeometry {
             x: pos.x as f64 / scale,
             y: pos.y as f64 / scale,
-            width: size.width as f64 / scale,
-            height: size.height as f64 / scale,
+            width: logical_w,
+            height: logical_h,
             maximized: false,
         }
     };
@@ -217,14 +372,8 @@ pub fn save_window_geometry(app: &AppHandle) {
 /// Returns the primary monitor's work area in logical coordinates as
 /// (width, height, x, y).
 ///
-/// The work area excludes the taskbar/Dock and menu bar, so sizing the window
-/// to it reproduces the "maximized" look at construction time without going
-/// through tao's animated maximized API (see create_main_window). Returns None
-/// if the primary monitor can't be queried.
-///
-/// Note: only used on macOS/Linux for the pseudo-maximize restore; Windows
-/// uses `builder.maximized(true)` instead (see create_main_window).
-#[cfg(not(target_os = "windows"))]
+/// Used by the macOS/Linux pseudo-maximize restore in create_main_window and
+/// by the maximize-size self-heal in read_saved_geometry.
 fn primary_monitor_work_area_logical(app: &AppHandle) -> Option<(f64, f64, f64, f64)> {
     let monitor = app.primary_monitor().ok().flatten()?;
     let scale = monitor.scale_factor();
@@ -265,6 +414,24 @@ fn read_saved_geometry(app: &AppHandle) -> Option<WindowGeometry> {
     geo.width = geo.width.max(MIN_WIDTH);
     geo.height = geo.height.max(MIN_HEIGHT);
 
+    // Self-heal: older versions could persist work-area-sized bounds alongside
+    // maximized: true (maximize()'s Resized raced ahead of is_maximized()).
+    // Restoring that as a normal window would cover the taskbar / sit off-
+    // screen during the splash. Since the window is re-maximized on launch
+    // anyway, fall back to a centered default normal geometry as the
+    // un-maximize restore target.
+    if geo.maximized && is_maximize_sized(app, geo.width, geo.height) {
+        geo.width = DEFAULT_WIDTH;
+        geo.height = DEFAULT_HEIGHT;
+        if let Some((mw, mh, _, _)) = primary_monitor_work_area_logical(app) {
+            geo.x = ((mw - DEFAULT_WIDTH) / 2.0).max(0.0);
+            geo.y = ((mh - DEFAULT_HEIGHT) / 2.0).max(0.0);
+        } else {
+            geo.x = 0.0;
+            geo.y = 0.0;
+        }
+    }
+
     if is_position_on_screen(app, geo.x, geo.y) && fits_on_any_monitor(app, geo.width, geo.height) {
         Some(geo)
     } else {
@@ -278,6 +445,24 @@ fn read_saved_geometry(app: &AppHandle) -> Option<WindowGeometry> {
 /// which causes position/size validation checks to fail safely.
 fn available_monitors(app: &AppHandle) -> Vec<tauri::Monitor> {
     app.available_monitors().unwrap_or_default()
+}
+
+/// Returns true if the given logical dimensions are at least as large as some
+/// monitor's work area — i.e. the size corresponds to a maximized window, not
+/// a normal user-chosen size.
+///
+/// Why: maximize() can dispatch its Resized event before is_maximized() flips
+/// to true, so without this guard a maximized window would be persisted with
+/// work-area-sized bounds as the "normal" geometry, corrupting the real normal
+/// size. It also self-heals store entries written that way by older versions.
+fn is_maximize_sized(app: &AppHandle, width: f64, height: f64) -> bool {
+    available_monitors(app).iter().any(|m| {
+        let work = m.work_area();
+        let scale = m.scale_factor();
+        let work_w = work.size.width as f64 / scale;
+        let work_h = work.size.height as f64 / scale;
+        width >= work_w && height >= work_h
+    })
 }
 
 /// Checks whether the given logical coordinates fall within any monitor's bounds.

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -1,27 +1,17 @@
+import { interceptInvokeError } from '@/app/lib/invokeErrorHandler'
 import { store, type RootState } from '@/app/store'
-import {
-  setProcessingFnc,
-  setInitiated as setValue,
-} from '@/features/init/model/initSlice'
-import {
-  checkCookieRefresh,
-  getLoginMethod,
-  loadQrSession,
-  qrLogout,
-  refreshCookie,
-} from '@/features/login'
+import { setInitiated as setValue } from '@/features/init/model/initSlice'
 import { applyFontSize, parseFontSize } from '@/features/settings'
-import { useSettings } from '@/features/settings/useSettings'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
 import { setSidebarOpen } from '@/features/sidebar'
-import { notifyInitComplete } from '@/features/splash'
-import { useUser } from '@/features/user'
+import { setUser } from '@/features/user/userSlice'
+import type { User } from '@/features/user/types'
 import { changeLanguage, type SupportedLang } from '@/shared/i18n'
 import { logger } from '@/shared/lib/logger'
-import { sleep } from '@/shared/lib/utils'
 import { getOs } from '@/shared/os/api/getOs'
 import { invoke } from '@tauri-apps/api/core'
 import { exit } from '@tauri-apps/plugin-process'
-import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 /** Languages supported by the application's i18n configuration. */
@@ -34,336 +24,118 @@ const SUPPORTED_LANGS: readonly SupportedLang[] = [
   'ko',
 ]
 
-/** Result of the application initialization sequence. */
+/** Backend init result, produced by the `initialize` command during splash. */
 export interface InitResult {
-  /** Status code: 0 for success, non-zero for failure. */
+  settings?: Settings
+  user?: User
+  /** Error string from user-info fetch (undefined on success). */
+  userError?: string
+  ffmpegSuccess: boolean
+}
+
+/** Result of the (now thin) frontend init. */
+export interface InitResultCode {
   code: number
-  /** Optional error detail when initialization fails. */
   detail?: string
 }
 
 /**
- * Custom hook for managing application initialization sequence.
+ * Frontend init handoff hook.
  *
- * Orchestrates the startup process including version checking, ffmpeg
- * validation/installation, cookie retrieval, user authentication, and
- * settings application. Provides status messages for each initialization
- * step and handles errors gracefully.
+ * The heavy init (cleanup, ffmpeg, settings load, session restore, user fetch)
+ * runs on the Rust side in the `initialize` command while the splash window is
+ * visible. This hook reads the result via `get_init_result` and applies only
+ * the frontend-specific bits (i18n, font size, sidebar state, user Redux), and
+ * re-runs the same invoke-error interception as the previous getUserInfo
+ * (e.g. ERR::UNAUTHORIZED → session-expiry toast).
  *
- * @returns An object containing initialization state and control methods.
- *
- * @example
- * ```typescript
- * const {
- *   initiated,
- *   processingFnc,
- *   initApp,
- *   quitApp
- * } = useInit()
- *
- * const result = await initApp()
- * if (result.code !== 0) {
- *   // Handle initialization error
- *   console.error('Init failed with code:', result.code, 'detail:', result.detail)
- * }
- * ```
+ * @returns Initiated flag and control methods (initApp, quitApp).
  */
 export const useInit = () => {
-  const { getUserInfo } = useUser()
-  const { getSettings } = useSettings()
-  const { t } = useTranslation()
-
   const initiated = useSelector((state: RootState) => state.init.initiated)
-  const progress = useSelector((state: RootState) => state.progress)
-  const processingFnc = useSelector(
-    (state: RootState) => state.init.processingFnc,
-  )
 
-  /**
-   * Type guard to check if a string is a supported language.
-   *
-   * Narrows an opaque `string` (typically read from persisted settings)
-   * to `SupportedLang` so it can be passed to `changeLanguage` without
-   * further runtime checks.
-   */
-  const isSupportedLang = (lang: string): lang is SupportedLang =>
-    (SUPPORTED_LANGS as readonly string[]).includes(lang)
-
-  /**
-   * Dispatches the initiated flag to the Redux store.
-   *
-   * @param value - True when initialization is complete.
-   */
   const setInitiated = (value: boolean) => {
     store.dispatch(setValue(value))
   }
 
-  /**
-   * Exits the application.
-   *
-   * Invokes the Tauri process exit function to terminate the app.
-   */
   const quitApp = async (): Promise<void> => {
     await exit()
   }
 
-  /**
-   * Executes the application initialization sequence.
-   *
-   * Performs the following steps in order:
-   * 1. OS detection (fire-and-forget)
-   * 2. App settings retrieval and language application
-   * 3. ffmpeg validation/installation
-   * 4. QR session restoration (if exists)
-   * 5. Firefox cookie validation (fallback)
-   * 6. User authentication check
-   *
-   * Note: Version checking is handled separately by UpdaterProvider
-   * which displays a non-blocking dialog when updates are available.
-   *
-   * TODO: Move invoke calls to api/ directory.
-   *
-   * @returns An object containing status code and optional error detail:
-   * - 0: Success
-   * - 1: ffmpeg check failed
-   */
-  const initApp = async (): Promise<InitResult> => {
-    logger.info('initApp: Starting initialization')
+  const isSupportedLang = (lang: string): lang is SupportedLang =>
+    (SUPPORTED_LANGS as readonly string[]).includes(lang)
 
-    // Fire & forget OS detection (don't await)
-    getOs()
-
-    // Clean up orphaned temp files from previous sessions. Awaited so the
-    // status label stays visible during cleanup (mirroring the ffmpeg
-    // check step), even though it usually completes in a blink.
-    setMessage(t('init.cleanup_in_progress'))
+  const applyLanguageSetting = async (language: string | undefined): Promise<void> => {
+    if (!language) return
     try {
-      const result = await invoke<{
-        deletedCount: number
-        failedCount: number
-      }>('cleanup_temp_files')
-      if (result.deletedCount > 0 || result.failedCount > 0) {
-        setMessage(
-          t('init.cleanup_completed', {
-            deleted: result.deletedCount,
-            failed: result.failedCount,
-          }),
-        )
+      const i18n = (await import('@/i18n')).default
+      if (i18n.language !== language && isSupportedLang(language)) {
+        logger.debug(`applyLanguageSetting: Applying language=${language}`)
+        await changeLanguage(language)
       }
     } catch {
-      // Silently ignore cleanup failures (non-fatal for startup)
+      // Silently ignore language setting failures (non-fatal).
+    }
+  }
+
+  const initApp = async (): Promise<InitResultCode> => {
+    logger.info('initApp: reading consolidated init result from backend')
+    // OS detection is fire-and-forget (frontend-only, cheap).
+    getOs()
+
+    let result: InitResult
+    try {
+      result = await invoke<InitResult>('get_init_result')
+    } catch (e) {
+      logger.error('initApp: failed to read init result, using defaults', e)
+      result = {
+        settings: undefined,
+        user: undefined,
+        userError: undefined,
+        ffmpegSuccess: false,
+      }
     }
 
-    // Version checking is handled by UpdaterProvider (non-blocking dialog)
-    const settings = await getAppSettings()
-    const skipSplash = settings?.skipSplashAnimation ?? false
+    // Apply frontend-specific settings from the result.
+    const settings = result.settings
+    if (settings) {
+      // Store into settingsSlice so the rest of the app (dialogs, selectors)
+      // sees the persisted settings instead of defaults.
+      store.dispatch(setSettings(settings))
+    }
     await applyLanguageSetting(settings?.language)
     applyFontSize(parseFontSize(settings?.fontSize))
-
-    // Preload sidebar state to prevent layout shift on main page render
     if (settings?.sidebarExpanded !== undefined) {
       store.dispatch(setSidebarOpen(settings.sidebarExpanded))
     }
 
-    // Early exit on ffmpeg check failure
-    if (!(await checkFfmpeg())) {
-      logger.warn('initApp: ffmpeg check failed')
-      await finalizeInit(skipSplash)
+    // User info (undefined if not logged in / fetch failed).
+    if (result.user) {
+      store.dispatch(setUser(result.user))
+    }
+
+    setInitiated(true)
+
+    // ffmpeg is required; if it failed to validate/install, surface an error
+    // (mirrors the previous useInit behavior of returning code 1 → /error).
+    if (!result.ffmpegSuccess) {
+      logger.warn('initApp: ffmpeg unavailable')
       return { code: 1 }
     }
 
-    // Honor the user-selected login method strictly. No cross-method
-    // fallback: if the user chose QR but has no session, they stay logged
-    // out (and can switch to Firefox in Settings).
-    const loginMethod = await getLoginMethod()
-    if (loginMethod === 'qrCode') {
-      await checkQrSession()
-    } else {
-      await checkCookie()
+    // If the backend user fetch failed, run the same error interception as the
+    // previous getUserInfo (e.g. ERR::UNAUTHORIZED → session-expiry toast),
+    // instead of silently ignoring.
+    if (result.userError) {
+      await interceptInvokeError(store, result.userError)
     }
 
-    // Fetch user info and store in Redux (hasCookie=false if no cookie)
-    await getUserInfo()
-
-    await finalizeInit(skipSplash)
-    logger.info('initApp: Initialization completed successfully')
+    logger.info('initApp: done')
     return { code: 0 }
-  }
-
-  /**
-   * Finalizes initialization by setting flag and sleeping briefly.
-   *
-   * Marks the app as initialized in the Redux store and notifies the splash
-   * screen so it can tear down. The 500ms sleep lets the splash animation
-   * finish naturally unless `skipSplash` is `true`, in which case the sleep
-   * is skipped entirely.
-   *
-   * @param skipSplash - When `true`, omits the 500ms splash-animation pause.
-   */
-  const finalizeInit = async (skipSplash: boolean): Promise<void> => {
-    logger.debug('finalizeInit: Finalizing initialization')
-    if (!skipSplash) {
-      await sleep(500)
-    }
-    setInitiated(true)
-    notifyInitComplete()
-  }
-
-  /**
-   * Applies language setting if different from current.
-   *
-   * Loads the i18n bundle dynamically, compares the persisted language
-   * preference to the active i18n language, and calls `changeLanguage`
-   * when they differ. Status messages are dispatched before and after the
-   * switch. Failures are swallowed because an unsupported language value
-   * should not block startup.
-   *
-   * @param language - Persisted language code. Early return when falsy.
-   */
-  const applyLanguageSetting = async (
-    language: string | undefined,
-  ): Promise<void> => {
-    if (!language) return
-
-    try {
-      const i18n = (await import('@/i18n')).default
-      if (i18n.language !== language) {
-        logger.debug(`applyLanguageSetting: Applying language=${language}`)
-        setMessage(t('init.applying_language', { lang: language }))
-        // Type guard: ensure language is a SupportedLang
-        if (isSupportedLang(language)) {
-          await changeLanguage(language)
-          setMessage(t('init.applied_language', { lang: language }))
-        }
-      }
-    } catch {
-      // Silently ignore language setting failures
-    }
-  }
-
-  /**
-   * Validates ffmpeg installation and installs if missing.
-   *
-   * Checks if ffmpeg is available in the system. If not found,
-   * automatically downloads and installs it. Displays status messages
-   * during the process.
-   *
-   * @returns True if ffmpeg is valid or successfully installed,
-   * false otherwise.
-   */
-  const checkFfmpeg = async (): Promise<boolean> => {
-    setMessage(t('init.checking_ffmpeg'))
-    const isValidFfmpeg = await invoke<boolean>('validate_ffmpeg')
-    if (isValidFfmpeg) {
-      logger.info('checkFfmpeg: ffmpeg is valid')
-      setMessage(t('init.ffmpeg_ok'))
-      return true
-    }
-
-    logger.info('checkFfmpeg: Installing ffmpeg')
-    setMessage(t('init.installing_ffmpeg'))
-    const isInstalled = await invoke<boolean>('install_ffmpeg')
-    if (isInstalled) {
-      logger.info('checkFfmpeg: ffmpeg installed successfully')
-      setMessage(t('init.ffmpeg_install_ok'))
-      return true
-    }
-
-    logger.error('checkFfmpeg: ffmpeg installation failed')
-    setMessage(t('init.ffmpeg_install_failed'))
-    return false
-  }
-
-  /**
-   * Retrieves application settings and updates the init status message.
-   *
-   * Wraps `useSettings().getSettings` purely so the init screen can show a
-   * localized "fetching settings" message while the Tauri store is read.
-   *
-   * @returns The current application settings, or `undefined` if the
-   * underlying store lookup returns nothing.
-   */
-  const getAppSettings = async () => {
-    setMessage(t('init.fetch_settings'))
-    return getSettings()
-  }
-
-  /**
-   * Retrieves cookies from the local Firefox profile via the Tauri backend.
-   *
-   * This is used as a fallback when no QR session is available.
-   *
-   * @returns Always returns `true` after invocation completes.
-   */
-  const checkCookie = async (): Promise<boolean> => {
-    logger.debug('checkCookie: Checking Firefox cookies')
-    await invoke('get_cookie')
-    return true
-  }
-
-  /**
-   * Restores previously saved QR code login session.
-   *
-   * Attempts to load a stored QR session from persistent storage and
-   * populate the cookie cache. This takes priority over Firefox cookies
-   * for users who logged in via QR code.
-   *
-   * Also checks if cookie refresh is needed and performs it if required.
-   *
-   * @returns True if a QR session was successfully restored, false otherwise.
-   */
-  const checkQrSession = async (): Promise<boolean> => {
-    try {
-      const loaded = await loadQrSession()
-      if (!loaded) {
-        return false
-      }
-
-      // Check if cookie refresh is needed
-      const refreshInfo = await checkCookieRefresh()
-      logger.info('refreshCookie: refreshInfo')
-      if (!refreshInfo.refresh) {
-        setMessage(t('init.qr_session_restored', 'Restored login session'))
-        return true
-      }
-
-      try {
-        await refreshCookie()
-        setMessage(t('init.cookie_refreshed', 'Login session refreshed'))
-        return true
-      } catch (e) {
-        logger.error(
-          'refreshCookie: Cookie refresh failed, clearing session',
-          e,
-        )
-        try {
-          await qrLogout()
-        } catch (logoutErr) {
-          logger.error('refreshCookie: Failed to clear session', logoutErr)
-        }
-        return false
-      }
-    } catch {
-      return false
-    }
-  }
-
-  /**
-   * Dispatches an initialization step message to the Redux store.
-   *
-   * The message is displayed to the user on the initialization screen
-   * to indicate the current progress step.
-   *
-   * @param message - The status message to display.
-   */
-  const setMessage = (message: string) => {
-    store.dispatch(setProcessingFnc(message))
   }
 
   return {
     initiated,
-    progress,
-    processingFnc,
     setInitiated,
     initApp,
     quitApp,

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -5,8 +5,8 @@ import { applyFontSize, parseFontSize } from '@/features/settings'
 import { setSettings } from '@/features/settings/settingsSlice'
 import type { Settings } from '@/features/settings/type'
 import { setSidebarOpen } from '@/features/sidebar'
-import { setUser } from '@/features/user/userSlice'
 import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
 import { changeLanguage, type SupportedLang } from '@/shared/i18n'
 import { logger } from '@/shared/lib/logger'
 import { getOs } from '@/shared/os/api/getOs'
@@ -65,7 +65,9 @@ export const useInit = () => {
   const isSupportedLang = (lang: string): lang is SupportedLang =>
     (SUPPORTED_LANGS as readonly string[]).includes(lang)
 
-  const applyLanguageSetting = async (language: string | undefined): Promise<void> => {
+  const applyLanguageSetting = async (
+    language: string | undefined,
+  ): Promise<void> => {
     if (!language) return
     try {
       const i18n = (await import('@/i18n')).default

--- a/src/features/settings/hooks/useThemeEffect.ts
+++ b/src/features/settings/hooks/useThemeEffect.ts
@@ -3,16 +3,8 @@ import type { Theme } from '@/features/settings/type'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useEffect } from 'react'
 
-let tauriThemeReady = false
-
-export function markTauriThemeReady() {
-  tauriThemeReady = true
-}
-
 export function useThemeEffect() {
-  const theme = useSelector((state) => state.settings.theme) as
-    | Theme
-    | undefined
+  const theme = useSelector((state) => state.settings.theme) as Theme | undefined
 
   useEffect(() => {
     const effective = theme ?? 'light'
@@ -24,10 +16,8 @@ export function useThemeEffect() {
 
     localStorage.setItem('ui-theme', effective)
 
-    if (tauriThemeReady) {
-      getCurrentWindow()
-        .setTheme(effective)
-        .catch(() => {})
-    }
+    // The splash now lives in its own window with its own light theme lock,
+    // so the main window can apply the saved theme immediately on mount.
+    getCurrentWindow().setTheme(effective).catch(() => {})
   }, [theme])
 }

--- a/src/features/settings/hooks/useThemeEffect.ts
+++ b/src/features/settings/hooks/useThemeEffect.ts
@@ -4,7 +4,9 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useEffect } from 'react'
 
 export function useThemeEffect() {
-  const theme = useSelector((state) => state.settings.theme) as Theme | undefined
+  const theme = useSelector((state) => state.settings.theme) as
+    | Theme
+    | undefined
 
   useEffect(() => {
     const effective = theme ?? 'light'
@@ -18,6 +20,8 @@ export function useThemeEffect() {
 
     // The splash now lives in its own window with its own light theme lock,
     // so the main window can apply the saved theme immediately on mount.
-    getCurrentWindow().setTheme(effective).catch(() => {})
+    getCurrentWindow()
+      .setTheme(effective)
+      .catch(() => {})
   }, [theme])
 }

--- a/src/features/splash/hooks/useSplashLifecycle.ts
+++ b/src/features/splash/hooks/useSplashLifecycle.ts
@@ -1,18 +1,10 @@
-import { store } from '@/app/store'
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { sleep } from '@/shared/lib/utils'
 
-import { markTauriThemeReady } from '@/features/settings/hooks/useThemeEffect'
-
 import { MIN_DISPLAY_MS } from '../lib/constants'
-import {
-  initCompletePromise,
-  notifySplashDone,
-  notifySplashFading,
-} from '../lib/splash-state'
 
 /** Represents the current visual state of the splash screen. */
 type SplashPhase = 'active' | 'fading' | 'done'
@@ -28,78 +20,52 @@ interface SplashLifecycle {
 }
 
 /**
- * Manages the full lifecycle of the splash screen.
+ * Drives the standalone splash window lifecycle.
  *
- * Orchestrates three phases:
- * 1. **active**  -- splash is visible; the native title bar is locked to the
- *    light theme to match the splash background; waits for both backend
- *    initialization and a minimum display duration before advancing (unless
- *    skip mode).
- * 2. **fading**  -- CSS opacity transition is running; the saved theme is
- *    applied just before the fade so the title bar switches in step with the
- *    fade-out (no post-splash theme lag). The caller is expected to call
- *    `onFadeComplete` when the transition ends.
- * 3. **done**    -- splash is removed from the DOM and resizing is enabled.
+ * The splash is its own borderless window (a separate webview from main), so
+ * it cannot share Redux state with the main window. Instead it:
+ * 1. locks its own native theme to light to match the splash background,
+ * 2. invokes the backend `initialize` command (the real step sequence lands
+ *    in Phase B-2; currently a skeleton that returns immediately),
+ * 3. waits for the minimum display time (unless skip mode),
+ * 4. fades out, then on fade completion invokes `finish_splash`, which closes
+ *    the splash and creates the main window.
  *
  * When `skipSplashAnimation` is enabled in settings, the minimum display time
  * and fade animation are skipped for fastest possible startup.
- *
- * @returns The current phase, a fade-completion callback, and skip mode flag.
  */
 export function useSplashLifecycle(): SplashLifecycle {
   const [phase, setPhase] = useState<SplashPhase>('active')
   const [skipMode, setSkipMode] = useState<boolean | null>(null)
   const disposedRef = useRef(false)
 
-  // Lock the native title bar to the light theme while the splash is visible
-  // so it matches the light splash background.
-  useEffect(() => {
-    getCurrentWindow()
-      .setTheme('light')
-      .catch(() => {})
-  }, [])
-
   useEffect(() => {
     disposedRef.current = false
 
     const run = async () => {
+      // Lock the splash window theme to light to match the splash background.
+      getCurrentWindow().setTheme('light').catch(() => {})
+
       let skip = false
       try {
-        const s = await invoke<{ skipSplashAnimation?: boolean }>(
-          'get_settings',
-        )
+        const s = await invoke<{ skipSplashAnimation?: boolean }>('get_settings')
         skip = s.skipSplashAnimation ?? false
       } catch {
-        // Default to normal splash on error
+        // default to normal splash on error
       }
-
       if (disposedRef.current) return
       setSkipMode(skip)
 
-      // Skip mode bypasses the minimum display time and fade phase entirely
-      if (skip) {
-        await initCompletePromise
-      } else {
-        await Promise.all([initCompletePromise, sleep(MIN_DISPLAY_MS)])
-      }
+      // Run backend initialization. Phase B-1: skeleton returns immediately.
+      // Phase B-2 will port the ffmpeg/cookie/user steps here and emit
+      // init_step / init_progress events that the splash UI renders.
+      await invoke('initialize').catch(() => {})
 
+      if (!skip) {
+        await sleep(MIN_DISPLAY_MS)
+      }
       if (disposedRef.current) return
 
-      // Apply the saved theme as the splash begins to fade (or, in skip mode,
-      // just before removal). Running this here rather than after the fade
-      // lets the title bar switch in step with the fade-out, so there is no
-      // visible theme lag once the splash is gone.
-      const theme = store.getState().settings.theme ?? 'light'
-      getCurrentWindow()
-        .setTheme(theme)
-        .catch(() => {})
-      // Caution: This arms useThemeEffect (useThemeEffect.ts), which gates its own
-      // setTheme behind the tauriThemeReady flag to avoid overriding the light lock
-      // while the splash is visible. Must stay after the splash-visible phase or the
-      // user's saved theme will clobber the intentional light lock prematurely.
-      markTauriThemeReady()
-
-      notifySplashFading()
       setPhase(skip ? 'done' : 'fading')
     }
 
@@ -110,16 +76,15 @@ export function useSplashLifecycle(): SplashLifecycle {
     }
   }, [])
 
-  // Enable resize after the splash is fully gone
-  useEffect(() => {
-    if (phase !== 'done') return
-    notifySplashDone()
-    invoke('enable_window_resize').catch(() => {})
-  }, [phase])
-
   const onFadeComplete = useCallback(() => {
     setPhase('done')
   }, [])
+
+  // Close the splash and create the main window once the splash is done.
+  useEffect(() => {
+    if (phase !== 'done') return
+    invoke('finish_splash').catch(() => {})
+  }, [phase])
 
   return { phase, onFadeComplete, skipMode }
 }

--- a/src/features/splash/hooks/useSplashLifecycle.ts
+++ b/src/features/splash/hooks/useSplashLifecycle.ts
@@ -44,11 +44,15 @@ export function useSplashLifecycle(): SplashLifecycle {
 
     const run = async () => {
       // Lock the splash window theme to light to match the splash background.
-      getCurrentWindow().setTheme('light').catch(() => {})
+      getCurrentWindow()
+        .setTheme('light')
+        .catch(() => {})
 
       let skip = false
       try {
-        const s = await invoke<{ skipSplashAnimation?: boolean }>('get_settings')
+        const s = await invoke<{ skipSplashAnimation?: boolean }>(
+          'get_settings',
+        )
         skip = s.skipSplashAnimation ?? false
       } catch {
         // default to normal splash on error

--- a/src/features/splash/ui/SplashScreen.tsx
+++ b/src/features/splash/ui/SplashScreen.tsx
@@ -1,6 +1,8 @@
-import { useRef } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useEffect, useRef, useState } from 'react'
+import { listen } from '@tauri-apps/api/event'
+import { useTranslation } from 'react-i18next'
 
-import { useSelector } from '@/app/store'
 import { cn } from '@/shared/lib/utils'
 
 import { useSplashLifecycle } from '../hooks/useSplashLifecycle'
@@ -8,67 +10,95 @@ import { useThreeScene } from '../hooks/useThreeScene'
 import { FADE_DURATION_MS } from '../lib/constants'
 
 /**
- * Full-screen splash overlay displayed while the application initializes.
+ * Standalone splash window content (Discord-style).
  *
- * In normal mode, renders a Three.js particle-and-TV animation, a title
- * heading, the current initialization step label, and an optional progress
- * bar. Once initialization completes (and the minimum display time elapses)
- * the component fades out and unmounts itself.
+ * Renders inside the borderless, fixed-size, centered window created by the
+ * Rust `create_splash_window`. The whole surface (including the Three.js
+ * canvas) is draggable via `data-tauri-drag-region`. Shows the Three.js
+ * animation + title, and at the bottom:
+ * - a small "what's happening now" label (driven by `init_step` events)
+ * - a determinate progress bar that appears only during ffmpeg download
+ *   (driven by `progress` events whose downloadId === "ffmpeg-install")
  *
- * When `skipSplashAnimation` is enabled, renders only a minimal CSS spinner
- * and the initialization step label for fastest possible startup.
+ * On fade completion `useSplashLifecycle` invokes `finish_splash`, which
+ * closes this window and creates the main window.
  */
 export function SplashScreen() {
   const { phase, onFadeComplete, skipMode } = useSplashLifecycle()
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const processingFnc = useSelector((state) => state.init.processingFnc)
-  const progress = useSelector((state) => state.progress)
+  const [stepLabel, setStepLabel] = useState<string>('')
+  const [ffmpegProgress, setFfmpegProgress] = useState<number | null>(null)
+  const { t } = useTranslation()
 
   useThreeScene(canvasRef, skipMode === false && phase !== 'done')
 
+  // Show the splash window once React has mounted. The window is created
+  // hidden (visible(false)) to avoid a black frame during webview load; this
+  // reveals it after first paint.
+  useEffect(() => {
+    invoke('show_splash').catch(() => {})
+  }, [])
+
+  // init_step: latest backend step label. progress: ffmpeg download %.
+  useEffect(() => {
+    const unlistenStep = listen<{ labelKey: string }>('init_step', (event) => {
+      setStepLabel(event.payload.labelKey)
+    })
+    const unlistenProgress = listen<{ downloadId: string; percentage: number }>(
+      'progress',
+      (event) => {
+        if (event.payload.downloadId === 'ffmpeg-install') {
+          setFfmpegProgress(event.payload.percentage)
+        }
+      },
+    )
+    return () => {
+      unlistenStep.then((fn) => fn())
+      unlistenProgress.then((fn) => fn())
+    }
+  }, [])
+
   if (phase === 'done') return null
 
-  // Rendering branch 1 of 3: settings still loading.
-  // Renders a blank splash background while settings are loading to prevent
-  // the circle-indicator flash that would otherwise appear before the 3D
-  // animation is ready to mount.
+  // Settings still loading: blank splash background to prevent a flash before
+  // the 3D animation is ready to mount.
   if (skipMode === null) {
     return (
       <div
         data-testid="splash-screen"
+        data-tauri-drag-region
         className="fixed inset-0 z-50 bg-[#f5f7fa]"
       />
     )
   }
 
-  // Rendering branch 2 of 3: skip mode active.
-  // Renders a minimal CSS spinner instead of the full 3D animation to
-  // minimize startup time when the user has opted out of the animation.
+  // Skip mode: minimal CSS spinner + step label instead of the full animation.
   if (skipMode === true) {
     return (
       <div
         data-testid="splash-screen"
+        data-tauri-drag-region
         className="bg-background fixed inset-0 z-50 flex flex-col items-center justify-center"
       >
         <div className="border-foreground/20 border-t-foreground h-8 w-8 animate-spin rounded-full border-2" />
-        {processingFnc && (
+        {stepLabel && (
           <p className="text-muted-foreground mt-4 text-sm select-none">
-            {processingFnc}
+            {t(stepLabel)}
           </p>
         )}
       </div>
     )
   }
 
-  // Rendering branch 3 of 3: full animation mode.
-  // Renders the complete splash experience: Three.js canvas, title heading,
-  // current initialization step label, and an optional progress bar.
-  const activeProgress = progress.find((p) => !p.isComplete)
-  const pct = activeProgress?.percentage ?? 0
+  // Full animation mode: Three.js particle animation + title + bottom label
+  // and, only while ffmpeg is installing, a determinate progress bar.
+  const showFfmpegBar =
+    stepLabel === 'init.installing_ffmpeg' && ffmpegProgress !== null
 
   return (
     <div
       data-testid="splash-screen"
+      data-tauri-drag-region
       className={cn(
         'fixed inset-0 z-50 flex flex-col items-center justify-center',
         'bg-[#f5f7fa]',
@@ -77,15 +107,16 @@ export function SplashScreen() {
       )}
       style={{ transitionDuration: `${FADE_DURATION_MS}ms` }}
       onTransitionEnd={function handleTransitionEnd(e) {
-        // Only react to the opacity transition bubbling up from the root
-        // container itself (not from child elements) to signal that the
-        // fade-out animation has completed and the splash can unmount.
         if (e.target === e.currentTarget && e.propertyName === 'opacity') {
           onFadeComplete()
         }
       }}
     >
-      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+      <canvas
+        ref={canvasRef}
+        data-tauri-drag-region
+        className="absolute inset-0 h-full w-full"
+      />
       <h1
         className={cn(
           'relative z-10 select-none',
@@ -99,18 +130,18 @@ export function SplashScreen() {
       >
         <span style={{ color: '#00A1D6' }}>Bilibili</span> Downloader
       </h1>
-      {processingFnc && (
-        <p className="relative z-10 mt-4 text-sm text-[#00A1D6]/60 select-none">
-          {processingFnc}
-        </p>
-      )}
-      {activeProgress && pct > 0 && (
-        <div className="relative z-10 mt-3 h-1 w-48 overflow-hidden rounded-full bg-black/10">
+      {showFfmpegBar && (
+        <div className="absolute bottom-14 left-6 right-6 z-10 h-1 overflow-hidden rounded-full bg-black/10">
           <div
-            className="h-full rounded-full bg-[#00A1D6]/70 transition-all duration-300"
-            style={{ width: `${pct}%` }}
+            className="h-full rounded-full bg-[#00A1D6] transition-all duration-300"
+            style={{ width: `${ffmpegProgress}%` }}
           />
         </div>
+      )}
+      {stepLabel && (
+        <p className="absolute bottom-6 left-6 right-6 z-10 truncate text-center text-[16px] font-medium text-[#6B7280] select-none">
+          {t(stepLabel)}
+        </p>
       )}
     </div>
   )

--- a/src/features/splash/ui/SplashScreen.tsx
+++ b/src/features/splash/ui/SplashScreen.tsx
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
-import { useEffect, useRef, useState } from 'react'
 import { listen } from '@tauri-apps/api/event'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/shared/lib/utils'
@@ -131,7 +131,7 @@ export function SplashScreen() {
         <span style={{ color: '#00A1D6' }}>Bilibili</span> Downloader
       </h1>
       {showFfmpegBar && (
-        <div className="absolute bottom-14 left-6 right-6 z-10 h-1 overflow-hidden rounded-full bg-black/10">
+        <div className="absolute right-6 bottom-14 left-6 z-10 h-1 overflow-hidden rounded-full bg-black/10">
           <div
             className="h-full rounded-full bg-[#00A1D6] transition-all duration-300"
             style={{ width: `${ffmpegProgress}%` }}
@@ -139,7 +139,7 @@ export function SplashScreen() {
         </div>
       )}
       {stepLabel && (
-        <p className="absolute bottom-6 left-6 right-6 z-10 truncate text-center text-[16px] font-medium text-[#6B7280] select-none">
+        <p className="absolute right-6 bottom-6 left-6 z-10 truncate text-center text-[16px] font-medium text-[#6B7280] select-none">
           {t(stepLabel)}
         </p>
       )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "Initializing...",
     "fetch_settings": "Fetching app settings...",
+    "reading_cookies": "Reading cookies...",
+    "fetching_user": "Fetching user info...",
     "applying_language": "Applying language ({{lang}})...",
     "applied_language": "Language switched to {{lang}}",
     "checking_ffmpeg": "Checking ffmpeg availability...",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "Inicializando...",
     "fetch_settings": "Obteniendo configuración de la app...",
+    "reading_cookies": "Leyendo cookies...",
+    "fetching_user": "Obteniendo información del usuario...",
     "applying_language": "Aplicando idioma ({{lang}})...",
     "applied_language": "Idioma cambiado a {{lang}}",
     "checking_ffmpeg": "Verificando ffmpeg...",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "Initialisation...",
     "fetch_settings": "Récupération des paramètres...",
+    "reading_cookies": "Lecture des cookies...",
+    "fetching_user": "Récupération des informations utilisateur...",
     "applying_language": "Application de la langue ({{lang}})...",
     "applied_language": "Langue changée en {{lang}}",
     "checking_ffmpeg": "Vérification de ffmpeg...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "初期化中...",
     "fetch_settings": "アプリ設定の取得中...",
+    "reading_cookies": "Cookieを読み込んでいます...",
+    "fetching_user": "ユーザー情報を取得しています...",
     "applying_language": "言語を適用中 ({{lang}})...",
     "applied_language": "言語を {{lang}} に切り替えました",
     "checking_ffmpeg": "ffmpegの有効性チェック中...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "초기화 중...",
     "fetch_settings": "앱 설정을 불러오는 중...",
+    "reading_cookies": "쿠키를 읽는 중...",
+    "fetching_user": "사용자 정보를 불러오는 중...",
     "applying_language": "언어 적용 중 ({{lang}})...",
     "applied_language": "언어가 {{lang}}(으)로 변경되었습니다",
     "checking_ffmpeg": "ffmpeg 확인 중...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -308,6 +308,8 @@
   "init": {
     "initializing": "初始化中...",
     "fetch_settings": "正在获取应用设置...",
+    "reading_cookies": "正在读取 Cookie...",
+    "fetching_user": "正在获取用户信息...",
     "applying_language": "正在应用语言 ({{lang}})...",
     "applied_language": "语言已切换为 {{lang}}",
     "checking_ffmpeg": "正在检查 ffmpeg...",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { UpdaterProvider } from '@/app/providers/UpdaterProvider'
 import { store } from '@/app/store'
 import { SplashScreen } from '@/features/splash'
 import { setupI18n } from '@/i18n'
+import { changeLanguage, type SupportedLang } from '@/shared/i18n'
 import { logger } from '@/shared/lib/logger'
 import { ErrorBoundary } from '@/shared/ui/ErrorBoundary'
 import '@/styles/index.css'
@@ -14,6 +15,16 @@ import { BrowserRouter } from 'react-router'
 // Initialize i18n once at startup
 setupI18n()
 
+// If this is the splash window, apply the user's language from the query param
+// (passed by create_splash_window) so splash labels render in the correct
+// language from the first frame.
+if (window.location.pathname.startsWith('/splashscreen')) {
+  const lang = new URLSearchParams(window.location.search).get('lang')
+  if (lang) {
+    changeLanguage(lang as SupportedLang).catch(() => {})
+  }
+}
+
 // Setup global error handler for unhandled promise rejections
 window.addEventListener('unhandledrejection', (event) => {
   logger.error(
@@ -22,17 +33,25 @@ window.addEventListener('unhandledrejection', (event) => {
   )
 })
 
+// Two-window model: the splash window is served at "/splashscreen" and the
+// main window at "/". Each is its own webview with its own Redux store; the
+// splash runs backend init then invokes finish_splash to create the main window.
+const isSplashWindow = window.location.pathname.startsWith('/splashscreen')
+
 createRoot(document.getElementById('root')!).render(
   <ErrorBoundary>
     <Provider store={store}>
-      <SplashScreen />
-      <ListenerProvider>
-        <UpdaterProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </UpdaterProvider>
-      </ListenerProvider>
+      {isSplashWindow ? (
+        <SplashScreen />
+      ) : (
+        <ListenerProvider>
+          <UpdaterProvider>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </UpdaterProvider>
+        </ListenerProvider>
+      )}
     </Provider>
   </ErrorBoundary>,
 )


### PR DESCRIPTION
## Summary

Split the splash screen into a standalone borderless window (Discord-style) and consolidate heavy initialization into a Rust `initialize` command. This fixes the Windows taskbar occlusion bug that occurred when launching while maximized.

Key changes:
- **Two-window model**: splash (borderless, draggable, centered, fixed-size 480x480) + main (created after splash finishes via `finish_splash`)
- **Backend-consolidated init**: `initialize` command runs cleanup/ffmpeg/cookie/user; main reads the result via `get_init_result` (no double init)
- **Taskbar fix**: root cause was the splash-time `resizable(false)` lock preventing the maximized window from clamping to the work area; resolved by splitting the splash out
- **Localized splash**: settings read in setup, language passed to splash via URL query → labels render in the user's language from first frame (no black frame: `visible(false)` → `show_splash` after React mount)
- **ffmpeg download progress bar**: shown in splash when ffmpeg needs to be installed
- **Geometry persistence**: guard against work-area-sized bounds being saved as the "normal" geometry

## Related Issue

N/A (no open issue found)

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Test Plan

- [x] Launch app maximized → taskbar stays visible (splash + main)
- [x] Splash shows init labels in user's language (Japanese)
- [x] ffmpeg download shows progress bar (ffmpeg removed → reinstalled)
- [x] Splash is draggable
- [x] Settings persist across restarts (theme/language/sidebar)
- [x] skipSplashAnimation: minimal spinner, no fade
- [x] splash → main transition: correct size/maximize

## Checklist

- [x] `/review-all` executed
- [x] Conventional Commits format followed
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)