### PR TITLE
feat(splash): render splash window with rounded corners and transparency

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,12 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+# macos-private-api: required to enable transparent windows on macOS — the
+# WebviewWindowBuilder::transparent() method is cfg-gated behind this feature
+# on macOS (no-op on Windows/Linux). Used by the splash window to render
+# rounded corners. App Store distribution is not a target (GitHub Releases
+# only), so private API use is acceptable here.
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -64,6 +64,12 @@ impl WindowGeometry {
 /// (false)` removes the title bar/borders; the frontend makes the whole
 /// window draggable via `data-tauri-drag-region`. Resizable/maximizable are
 /// disabled because the splash has a fixed size.
+///
+/// `transparent(true)` makes the OS window background transparent so the
+/// frontend can render rounded corners (via CSS `border-radius`): without it
+/// the area outside the rounded corners would be filled by the opaque window
+/// background and the rounded shape wouldn't be visible. The native window
+/// shadow still follows the rounded outline via the default `shadow(true)`.
 pub fn create_splash_window(
     app: &AppHandle,
     theme: Option<Theme>,
@@ -82,6 +88,7 @@ pub fn create_splash_window(
         .min_inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
         .max_inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
         .decorations(false)
+        .transparent(true)
         .center()
         .resizable(false)
         // Why visible(false): the webview needs a frame to load the splash

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
   },
   "app": {
     "withGlobalTauri": true,
+    "macOSPrivateApi": true,
     "windows": [],
     "security": {
       "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' http: https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'"

--- a/src/features/splash/ui/SplashScreen.tsx
+++ b/src/features/splash/ui/SplashScreen.tsx
@@ -67,8 +67,12 @@ export function SplashScreen() {
       <div
         data-testid="splash-screen"
         data-tauri-drag-region
-        className="fixed inset-0 z-50 bg-[#f5f7fa]"
-      />
+        className="fixed inset-0 z-50"
+      >
+        {/* Inner container carries the rounded background; the outer wrapper
+            stays transparent so the area outside the corners shows through. */}
+        <div className="h-full w-full rounded-2xl bg-[#f5f7fa]" />
+      </div>
     )
   }
 
@@ -78,14 +82,16 @@ export function SplashScreen() {
       <div
         data-testid="splash-screen"
         data-tauri-drag-region
-        className="bg-background fixed inset-0 z-50 flex flex-col items-center justify-center"
+        className="fixed inset-0 z-50"
       >
-        <div className="border-foreground/20 border-t-foreground h-8 w-8 animate-spin rounded-full border-2" />
-        {stepLabel && (
-          <p className="text-muted-foreground mt-4 text-sm select-none">
-            {t(stepLabel)}
-          </p>
-        )}
+        <div className="flex h-full w-full flex-col items-center justify-center rounded-2xl bg-[#f5f7fa]">
+          <div className="border-foreground/20 border-t-foreground h-8 w-8 animate-spin rounded-full border-2" />
+          {stepLabel && (
+            <p className="text-muted-foreground mt-4 text-sm select-none">
+              {t(stepLabel)}
+            </p>
+          )}
+        </div>
       </div>
     )
   }
@@ -100,8 +106,7 @@ export function SplashScreen() {
       data-testid="splash-screen"
       data-tauri-drag-region
       className={cn(
-        'fixed inset-0 z-50 flex flex-col items-center justify-center',
-        'bg-[#f5f7fa]',
+        'fixed inset-0 z-50',
         'transition-opacity ease-out',
         phase === 'fading' ? 'opacity-0' : 'opacity-100',
       )}
@@ -112,37 +117,42 @@ export function SplashScreen() {
         }
       }}
     >
-      <canvas
-        ref={canvasRef}
-        data-tauri-drag-region
-        className="absolute inset-0 h-full w-full"
-      />
-      <h1
-        className={cn(
-          'relative z-10 select-none',
-          'font-sans text-4xl font-extralight tracking-[0.3em]',
-          'fade-in animate-in duration-1000',
+      {/* Inner container: rounded background + overflow-hidden clips the
+          Three.js canvas to the rounded corners. The outer wrapper stays
+          transparent so the native window shadow follows the rounded shape. */}
+      <div className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden rounded-2xl bg-[#f5f7fa]">
+        <canvas
+          ref={canvasRef}
+          data-tauri-drag-region
+          className="absolute inset-0 h-full w-full"
+        />
+        <h1
+          className={cn(
+            'relative z-10 select-none',
+            'font-sans text-4xl font-extralight tracking-[0.3em]',
+            'fade-in animate-in duration-1000',
+          )}
+          style={{
+            color: '#333333ee',
+            textShadow: '0 0 40px rgba(0,161,214,0.2)',
+          }}
+        >
+          <span style={{ color: '#00A1D6' }}>Bilibili</span> Downloader
+        </h1>
+        {showFfmpegBar && (
+          <div className="absolute right-6 bottom-14 left-6 z-10 h-1 overflow-hidden rounded-full bg-black/10">
+            <div
+              className="h-full rounded-full bg-[#00A1D6] transition-all duration-300"
+              style={{ width: `${ffmpegProgress}%` }}
+            />
+          </div>
         )}
-        style={{
-          color: '#333333ee',
-          textShadow: '0 0 40px rgba(0,161,214,0.2)',
-        }}
-      >
-        <span style={{ color: '#00A1D6' }}>Bilibili</span> Downloader
-      </h1>
-      {showFfmpegBar && (
-        <div className="absolute right-6 bottom-14 left-6 z-10 h-1 overflow-hidden rounded-full bg-black/10">
-          <div
-            className="h-full rounded-full bg-[#00A1D6] transition-all duration-300"
-            style={{ width: `${ffmpegProgress}%` }}
-          />
-        </div>
-      )}
-      {stepLabel && (
-        <p className="absolute right-6 bottom-6 left-6 z-10 truncate text-center text-[16px] font-medium text-[#6B7280] select-none">
-          {t(stepLabel)}
-        </p>
-      )}
+        {stepLabel && (
+          <p className="absolute right-6 bottom-6 left-6 z-10 truncate text-center text-[16px] font-medium text-[#6B7280] select-none">
+            {t(stepLabel)}
+          </p>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,13 @@ if (window.location.pathname.startsWith('/splashscreen')) {
   if (lang) {
     changeLanguage(lang as SupportedLang).catch(() => {})
   }
+  // Why clear html/body background: the splash window is transparent (rounded
+  // corners rendered via CSS). index.html's inline theme script and index.css
+  // set an opaque html/body background, which would fill the area outside the
+  // rounded corners with a solid color (near-black in dark mode). Clearing it
+  // here lets the desktop show through the corner regions.
+  document.documentElement.style.backgroundColor = 'transparent'
+  document.body.style.backgroundColor = 'transparent'
 }
 
 // Setup global error handler for unhandled promise rejections


### PR DESCRIPTION
## Summary

Render the standalone splash window with rounded corners (rounded-2xl, 16px) consistently across platforms by enabling a transparent window.

Previously the splash was a sharp rectangle on macOS/Linux; only Windows 11 looked rounded due to OS-native corner rounding. The window code was shared, but OS-native rendering differed — macOS/Linux showed a square while Windows 11 rounded the corners automatically.

### Changes
- **window.rs**: add `.transparent(true)` to the splash `WebviewWindowBuilder`
- **Cargo.toml**: enable `macos-private-api` feature (`transparent()` is cfg-gated behind it on macOS, verified in tauri 2.10.3 source)
- **tauri.conf.json**: set `macOSPrivateApi: true` to match the Cargo feature allowlist
- **SplashScreen.tsx**: restructure the 3 render modes into a transparent outer wrapper + rounded inner container (`overflow-hidden`) so the Three.js canvas clips to the corners; unify background to `#f5f7fa`
- **main.tsx**: clear `html`/`body` background only in the splash window so the area outside the rounded corners reveals the desktop (WKWebView fills the opaque html/body background otherwise)

## Related Issue

N/A — originated from direct UI feedback that the splash looked square on macOS.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] Run `npm run tauri dev` and observe the splash on macOS
- [x] Verify splash displays rounded corners (16px) with transparent corners revealing the desktop
- [x] Verify the native window shadow follows the rounded outline
- [x] Verify the Three.js animation clips to the rounded corners (no square overflow)
- [x] Verify the fade-out → main window transition works
- [ ] Verify on Windows (WebView2) and Linux (WebKitGTK) — not run locally

## Breaking Changes

None. Visual-only change to the splash window.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated — N/A (visual-only change, no logic to test)
- [x] i18n files synced — no user-facing text changed

## Notes

`macos-private-api` Cargo feature + `macOSPrivateApi: true` are required to enable `transparent(true)` on macOS — the `transparent()` builder method is cfg-gated behind this feature on macOS (verified in tauri 2.10.3 source). The project is GitHub-Releases-only, so macOS private API use is acceptable (no App Store review).