### PR TITLE
fix(downloads): resolve progress bar 100% lock and segment retry issues

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -241,19 +241,29 @@ impl Emits {
 
     /// Stops the background update task without emitting a complete event.
     ///
-    /// This is used when the download is complete but we don't want to emit
-    /// a "complete" stage (e.g., for audio/video downloads that will be merged).
-    /// Sets percentage to 100% and emits a final progress event.
+    /// Emits a final progress event reflecting the actual bytes downloaded.
+    /// Called on both success paths (where bytes equal filesize, so the
+    /// percentage naturally reaches 100%) and error/cancel paths (where the
+    /// real progress is preserved instead of being forced to 100%).
+    ///
+    /// CAUTION: Do NOT force `percentage = 100` here. `stop()` is also used
+    /// on error paths (segment failures, size mismatch, cancellation), and
+    /// forcing 100% would mislead the frontend — combined with the frontend's
+    /// monotonic clamp, the progress bar would lock at 100% even while
+    /// `retry_download` keeps retrying in the background. On success paths
+    /// the bytes already equal filesize, so recalculating yields 100%.
+    ///
+    /// NOTE: This does NOT set `progress.is_complete = true`; only the
+    /// internal timer-stop flag is set. Use [`complete()`] for the final
+    /// completion signal that switches the frontend stage to "complete".
     pub async fn stop(&self) {
         let mut guard = self.inner.lock().await;
         guard.is_complete = true; // Stop background timer
 
-        // Set percentage to 100% and emit final progress event
-        if let Some(fs_mb) = guard.progress.filesize {
-            guard.progress.downloaded = Some(fs_mb);
-        }
-        guard.progress.percentage = 100.0;
-        let _ = self.app.emit("progress", guard.progress.clone());
+        // Recalculate from actual bytes so error paths preserve real progress
+        // instead of locking the frontend's monotonic clamp at 100%.
+        let bytes = *self.progress_tx.subscribe().borrow();
+        Self::send_progress_locked(&self.app, &mut guard, bytes);
     }
 
     /// Marks the download as complete and stops the update task.

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -337,7 +337,15 @@ pub async fn download_url(
                 }
             }
 
-            let mut attempt: u8 = 0;
+            // `http_retries` counts HTTP-layer failures (invalid status,
+            // request error) bounded by MAX_SEG_RETRIES. CDN-rotation
+            // failures (size mismatch, slow speed) use `cdn_rotation_count`.
+            // Keeping these budgets independent prevents CDN rotations from
+            // inflating the HTTP retry counter — which previously disabled
+            // the in-segment chunk-retry budget inside
+            // download_segment_with_speed_check and produced misleading
+            // `attempt 8/3` log lines.
+            let mut http_retries: u8 = 0;
             const MAX_SEG_RETRIES: u8 = 3;
             let size = e - s + 1;
             let mut cdn_rotation_count: u8 = 0;
@@ -351,9 +359,7 @@ pub async fn download_url(
             let seg_is_retrying = Arc::new(AtomicBool::new(false));
 
             loop {
-                attempt += 1;
-
-                // Check cancellation on each retry
+                // Check cancellation on each iteration
                 if let Some(ref t) = cancel_token_c {
                     if t.is_cancelled() {
                         let _ = emits_c.stop().await;
@@ -396,16 +402,17 @@ pub async fn download_url(
                                 && size == resp.content_length().unwrap_or(size));
 
                         if !is_valid_response {
+                            http_retries += 1;
                             log::warn!(
-                                "[BE] download_url: segment {} invalid status {} (attempt {}/{}, cdn_idx={})",
+                                "[BE] download_url: segment {} invalid status {} (http retry {}/{}, cdn_idx={})",
                                 idx,
                                 resp.status(),
-                                attempt + 1,
+                                http_retries,
                                 MAX_SEG_RETRIES,
                                 cdn_idx
                             );
-                            if attempt < MAX_SEG_RETRIES {
-                                backoff_sleep(attempt).await;
+                            if http_retries < MAX_SEG_RETRIES {
+                                backoff_sleep(http_retries).await;
                                 continue;
                             }
                             return Err(anyhow::anyhow!(
@@ -438,7 +445,7 @@ pub async fn download_url(
                             &mut resp,
                             idx,
                             size,
-                            attempt,
+                            http_retries,
                             MAX_SEG_RETRIES,
                             cdn_rotation_count,
                             cdn_urls_c.len(),
@@ -479,11 +486,15 @@ pub async fn download_url(
                                 continue;
                             }
                             Err(_) => {
+                                // Non-recoverable chunk error: the in-segment
+                                // chunk-retry budget inside
+                                // download_segment_with_speed_check is already
+                                // exhausted. Bail out immediately; the outer
+                                // retry_download handles retries, so no
+                                // attempt counter is shown here.
                                 log::warn!(
-                                    "[BE] download_url: segment {} download failed (attempt {}/{}, cdn_idx={})",
+                                    "[BE] download_url: segment {} download failed (cdn_idx={})",
                                     idx,
-                                    attempt + 1,
-                                    MAX_SEG_RETRIES,
                                     cdn_idx
                                 );
                                 return Err(anyhow::anyhow!("segment {} download failed", idx))
@@ -493,12 +504,12 @@ pub async fn download_url(
                         // Verify size
                         if received != size {
                             log::warn!(
-                                "[BE] download_url: segment {} size mismatch: expected {}, got {} (attempt {}/{}, cdn_idx={})",
+                                "[BE] download_url: segment {} size mismatch: expected {}, got {} (cdn rotation {}/{}, cdn_idx={})",
                                 idx,
                                 size,
                                 received,
-                                attempt + 1,
-                                MAX_SEG_RETRIES,
+                                cdn_rotation_count + 1,
+                                max_cdn_rotations,
                                 cdn_idx
                             );
                             // Size mismatch typically indicates CDN edge cache
@@ -534,15 +545,16 @@ pub async fn download_url(
                         return Ok(());
                     }
                     Err(e) => {
+                        http_retries += 1;
                         log::warn!(
-                            "[BE] download_url: segment {} request error: {e} (attempt {}/{}, cdn_idx={})",
+                            "[BE] download_url: segment {} request error: {e} (http retry {}/{}, cdn_idx={})",
                             idx,
-                            attempt + 1,
+                            http_retries,
                             MAX_SEG_RETRIES,
                             cdn_idx
                         );
-                        if attempt < MAX_SEG_RETRIES {
-                            backoff_sleep(attempt).await;
+                        if http_retries < MAX_SEG_RETRIES {
+                            backoff_sleep(http_retries).await;
                             continue;
                         }
                         return Err(anyhow::anyhow!("segment {} request error: {e}", idx));

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -445,8 +445,6 @@ pub async fn download_url(
                             &mut resp,
                             idx,
                             size,
-                            http_retries,
-                            MAX_SEG_RETRIES,
                             cdn_rotation_count,
                             cdn_urls_c.len(),
                             |chunk_len| {
@@ -486,12 +484,12 @@ pub async fn download_url(
                                 continue;
                             }
                             Err(_) => {
-                                // Non-recoverable chunk error: the in-segment
-                                // chunk-retry budget inside
-                                // download_segment_with_speed_check is already
-                                // exhausted. Bail out immediately; the outer
-                                // retry_download handles retries, so no
-                                // attempt counter is shown here.
+                                // Chunk-stream error (e.g. connection reset).
+                                // download_segment_with_speed_check returns
+                                // Err(false) immediately because the stream is
+                                // broken. Bail out; the outer retry_download
+                                // issues a fresh request, so no attempt counter
+                                // is shown here.
                                 log::warn!(
                                     "[BE] download_url: segment {} download failed (cdn_idx={})",
                                     idx,
@@ -652,8 +650,6 @@ pub async fn download_url(
 /// * `resp` - Mutable reference to the HTTP response to read from
 /// * `_idx` - Segment index (reserved for future error reporting)
 /// * `size` - Expected segment size in bytes
-/// * `attempt` - Current retry attempt number
-/// * `max_seg_retries` - Maximum number of retries allowed
 /// * `cdn_rotation_count` - Current CDN rotation count
 /// * `cdn_urls_len` - Total number of available CDN URLs
 /// * `on_chunk_received` - Callback invoked when each chunk is received
@@ -665,14 +661,11 @@ pub async fn download_url(
 ///   - `received` is the total bytes received
 ///   - `false` indicates no reconnect needed
 /// - `Err(true)`: Speed too slow, reconnect needed
-/// - `Err(false)`: Download failed (non-recoverable, max retries exceeded)
-#[allow(clippy::too_many_arguments)]
+/// - `Err(false)`: Chunk-stream error (non-recoverable; caller issues a fresh request)
 async fn download_segment_with_speed_check(
     resp: &mut reqwest::Response,
     _idx: usize,
     size: u64,
-    attempt: u8,
-    max_seg_retries: u8,
     cdn_rotation_count: u8,
     cdn_urls_len: usize,
     on_chunk_received: impl Fn(u64),
@@ -713,10 +706,10 @@ async fn download_segment_with_speed_check(
             }
             Ok(None) => break,
             Err(_) => {
-                if attempt < max_seg_retries {
-                    backoff_sleep(attempt).await;
-                    continue;
-                }
+                // Chunk-stream error (e.g. connection reset). The stream is
+                // broken, so retrying chunk() on the same response cannot
+                // recover — bail out and let the caller's download_url loop
+                // issue a fresh request (HTTP retry / CDN rotation).
                 return Err(false);
             }
         }

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -503,21 +503,21 @@ pub async fn download_url(
 
                         // Verify size
                         if received != size {
-                            log::warn!(
-                                "[BE] download_url: segment {} size mismatch: expected {}, got {} (cdn rotation {}/{}, cdn_idx={})",
-                                idx,
-                                size,
-                                received,
-                                cdn_rotation_count + 1,
-                                max_cdn_rotations,
-                                cdn_idx
-                            );
                             // Size mismatch typically indicates CDN edge cache
                             // corruption or rate-limit cutoff. Rotate to a
                             // different CDN immediately instead of retrying
                             // the same node, which tends to reproduce the
                             // same truncated response.
                             if cdn_rotation_count < max_cdn_rotations {
+                                log::warn!(
+                                    "[BE] download_url: segment {} size mismatch: expected {}, got {} (cdn rotation {}/{}, cdn_idx={})",
+                                    idx,
+                                    size,
+                                    received,
+                                    cdn_rotation_count + 1,
+                                    max_cdn_rotations,
+                                    cdn_idx
+                                );
                                 let next_cdn_idx =
                                     (cdn_rotation_count as usize + 1) % cdn_urls_c.len();
                                 log::info!(
@@ -532,9 +532,17 @@ pub async fn download_url(
                                 backoff_sleep(cdn_rotation_count).await;
                                 continue;
                             }
+                            // Rotation budget exhausted. Log cdn_rotation_count
+                            // (== max_cdn_rotations) rather than +1 so the
+                            // displayed attempt never exceeds the denominator.
                             log::warn!(
-                                "[BE] download_url: segment {} CDN rotation exhausted, giving up",
-                                idx
+                                "[BE] download_url: segment {} size mismatch: expected {}, got {} (cdn rotation exhausted {}/{}, cdn_idx={})",
+                                idx,
+                                size,
+                                received,
+                                cdn_rotation_count,
+                                max_cdn_rotations,
+                                cdn_idx
                             );
                             return Err(anyhow::anyhow!("segment {} size mismatch", idx));
                         }


### PR DESCRIPTION
## Summary

Fixes three download-progress consistency bugs reported during testing, plus an infinite-loop risk found by code review.

## Background

During a large download with frequent segment failures, the progress dialog showed both video and audio at 100% while the status stayed "downloading" — the bar was locked at 100% while `retry_download` kept retrying in the background. Logs also showed misleading `attempt 8/3` lines.

## Changes

1. **Progress bar locked at 100% on error paths** (`emits.rs`): `stop()` forced `percentage = 100` on every call, including error/cancel paths. Combined with the frontend's monotonic clamp, this locked the bar at 100% during retries. `stop()` now recalculates from actual bytes — success paths still reach 100% naturally, error paths preserve real progress.

2. **Misleading `attempt 8/3` logs** (`downloads.rs`): a single `attempt` counter was incremented every loop iteration, so CDN rotations inflated it past `MAX_SEG_RETRIES`. Split into independent budgets:
   - `http_retries` (invalid status / request error, max 3)
   - `cdn_rotation_count` (size mismatch / slow speed, max CDN×3)

3. **`cdn rotation 7/6` denominator overflow** (`downloads.rs`): the size-mismatch log showed `cdn_rotation_count + 1`, exceeding `max_cdn_rotations` on the final attempt. Now logs `cdn_rotation_count` directly when the budget is exhausted.

4. **Chunk-stream error infinite loop** (`downloads.rs`): `download_segment_with_speed_check` received `http_retries` as an immutable attempt counter, so a persistent chunk-stream error (e.g. connection reset) would loop `backoff+continue` forever. Dropped the `attempt`/`max_seg_retries` params and return `Err(false)` immediately, letting the caller issue a fresh request. (Found by code-reviewer.)

## Verification

- `cargo build` passes (warnings are pre-existing, unrelated)
- Manually verified: progress bar no longer locks at 100% during retries; merge starts immediately on real completion; logs show `http retry N/3` / `cdn rotation N/6` (max `6/6`, no `7/6`)

## Files

- `src-tauri/src/emits.rs` — `stop()` recalculate from actual bytes
- `src-tauri/src/utils/downloads.rs` — retry counter separation, log accuracy, chunk-error handling
