### PR TITLE
feat(notifications): add taskbar progress bar and completion flash

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "core:window:allow-set-theme",
+    "core:window:allow-set-progress-bar",
+    "core:window:allow-request-user-attention",
     "core:window:allow-start-dragging",
     "process:default",
     "opener:default",

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -168,6 +168,21 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub rotation_mode: Option<RotationMode>,
+    /// Whether to show download progress on the taskbar. Defaults to true.
+    #[serde(
+        rename = "showTaskbarProgress",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub show_taskbar_progress: Option<bool>,
+    /// Whether to flash the taskbar button when downloads complete.
+    /// Defaults to true.
+    #[serde(
+        rename = "flashTaskbarOnComplete",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub flash_taskbar_on_complete: Option<bool>,
     /// UI theme preference. Defaults to system preference if not set.
     #[serde(rename = "theme", default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<UiTheme>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,8 @@
 import { useSelector } from '@/app/store'
+import {
+  useDownloadCompletionNotifications,
+  useTaskbarProgress,
+} from '@/features/notifications'
 import { useFontSizeShortcuts } from '@/features/settings/hooks/useFontSizeShortcuts'
 import { useThemeEffect } from '@/features/settings/hooks/useThemeEffect'
 import { UpdateNotification } from '@/features/updater'
@@ -15,6 +19,8 @@ function App() {
   const theme = useSelector((state) => state.settings.theme) ?? 'light'
   useThemeEffect()
   useFontSizeShortcuts()
+  useTaskbarProgress()
+  useDownloadCompletionNotifications()
 
   useEffect(() => {
     if (import.meta.env.DEV) return

--- a/src/features/notifications/hooks/useDownloadCompletionNotifications.test.tsx
+++ b/src/features/notifications/hooks/useDownloadCompletionNotifications.test.tsx
@@ -11,7 +11,7 @@ import { getCurrentWindow, UserAttentionType } from '@tauri-apps/api/window'
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { Provider } from 'react-redux'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockRequestUserAttention = getCurrentWindow()
   .requestUserAttention as unknown as ReturnType<typeof vi.fn>

--- a/src/features/notifications/hooks/useDownloadCompletionNotifications.test.tsx
+++ b/src/features/notifications/hooks/useDownloadCompletionNotifications.test.tsx
@@ -1,0 +1,100 @@
+import { store } from '@/app/store'
+import { useDownloadCompletionNotifications } from '@/features/notifications/hooks/useDownloadCompletionNotifications'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import {
+  clearQueue,
+  enqueue,
+  updateQueueStatus,
+} from '@/shared/queue/queueSlice'
+import { getCurrentWindow, UserAttentionType } from '@tauri-apps/api/window'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const mockRequestUserAttention = getCurrentWindow()
+  .requestUserAttention as unknown as ReturnType<typeof vi.fn>
+
+const baselineSettings: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  autoRenameDuplicates: true,
+  showGithubStars: true,
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+  showTaskbarProgress: true,
+  flashTaskbarOnComplete: true,
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+function seedRunning() {
+  store.dispatch(
+    enqueue({ downloadId: 'child-1', parentId: 'parent-1', status: 'running' }),
+  )
+}
+
+describe('useDownloadCompletionNotifications', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baselineSettings))
+    store.dispatch(clearQueue())
+    mockRequestUserAttention.mockClear()
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('flashes Informational on active → settled with success', async () => {
+    seedRunning()
+    renderHook(() => useDownloadCompletionNotifications(), { wrapper })
+    store.dispatch(updateQueueStatus({ downloadId: 'child-1', status: 'done' }))
+    await waitFor(() => {
+      expect(mockRequestUserAttention).toHaveBeenCalledWith(
+        UserAttentionType.Informational,
+      )
+    })
+  })
+
+  it('flashes Critical when a part errored', async () => {
+    seedRunning()
+    renderHook(() => useDownloadCompletionNotifications(), { wrapper })
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'child-1', status: 'error' }),
+    )
+    await waitFor(() => {
+      expect(mockRequestUserAttention).toHaveBeenCalledWith(
+        UserAttentionType.Critical,
+      )
+    })
+  })
+
+  it('does NOT flash when all parts are cancelled', async () => {
+    seedRunning()
+    renderHook(() => useDownloadCompletionNotifications(), { wrapper })
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'child-1', status: 'cancelled' }),
+    )
+    await waitFor(() => {
+      expect(store.getState().queue[0]?.status).toBe('cancelled')
+    })
+    expect(mockRequestUserAttention).not.toHaveBeenCalled()
+  })
+
+  it('does NOT flash when flashTaskbarOnComplete is disabled', async () => {
+    store.dispatch(
+      setSettings({ ...baselineSettings, flashTaskbarOnComplete: false }),
+    )
+    seedRunning()
+    renderHook(() => useDownloadCompletionNotifications(), { wrapper })
+    store.dispatch(updateQueueStatus({ downloadId: 'child-1', status: 'done' }))
+    await waitFor(() => {
+      expect(store.getState().queue[0]?.status).toBe('done')
+    })
+    expect(mockRequestUserAttention).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/notifications/hooks/useDownloadCompletionNotifications.ts
+++ b/src/features/notifications/hooks/useDownloadCompletionNotifications.ts
@@ -1,0 +1,52 @@
+import { useSelector } from '@/app/store'
+import { logger } from '@/shared/lib/logger'
+import { getCurrentWindow, UserAttentionType } from '@tauri-apps/api/window'
+import { useEffect, useRef } from 'react'
+
+import { deriveDownloadPhase } from '../lib/downloadPhase'
+
+/**
+ * Flash the taskbar when all downloads settle.
+ *
+ * Listens to the queue, derives the phase, and on the single `active →
+ * settled` edge fires one taskbar flash:
+ *  - `Critical` when any part errored
+ *  - `Informational` on pure success
+ *
+ * "All cancelled" (`hasSuccess=false && hasError=false`) is skipped, so
+ * cancelling every part never triggers a flash.
+ *
+ * Stopping the flash is left to the OS: Tauri's `requestUserAttention`
+ * auto-stops once the window regains focus on both Windows and macOS, so no
+ * focus listener is needed here.
+ *
+ * Must be mounted exactly once at the app root (see App.tsx).
+ */
+export function useDownloadCompletionNotifications(): void {
+  const queue = useSelector((state) => state.queue)
+  const flashEnabled = useSelector(
+    (state) => state.settings.flashTaskbarOnComplete ?? true,
+  )
+
+  const prevPhaseRef = useRef<'idle' | 'active' | 'settled'>('idle')
+
+  useEffect(() => {
+    const current = deriveDownloadPhase(queue)
+    const prev = prevPhaseRef.current
+    prevPhaseRef.current = current.phase
+
+    if (prev !== 'active' || current.phase !== 'settled') return
+
+    // Skip pure all-cancelled completion (no success and no error).
+    if (!current.hasSuccess && !current.hasError) return
+
+    if (!flashEnabled) return
+
+    const attention = current.hasError
+      ? UserAttentionType.Critical
+      : UserAttentionType.Informational
+    getCurrentWindow()
+      .requestUserAttention(attention)
+      .catch((e) => logger.error('requestUserAttention failed', e))
+  }, [queue, flashEnabled])
+}

--- a/src/features/notifications/hooks/useTaskbarProgress.test.tsx
+++ b/src/features/notifications/hooks/useTaskbarProgress.test.tsx
@@ -1,0 +1,80 @@
+import { store } from '@/app/store'
+import { useTaskbarProgress } from '@/features/notifications/hooks/useTaskbarProgress'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { clearQueue, enqueue } from '@/shared/queue/queueSlice'
+import { getCurrentWindow, ProgressBarStatus } from '@tauri-apps/api/window'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+// setup.ts returns a single shared window instance, so this is the same
+// vi.fn the hook invokes.
+const mockSetProgressBar = getCurrentWindow()
+  .setProgressBar as unknown as ReturnType<typeof vi.fn>
+
+const baselineSettings: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  autoRenameDuplicates: true,
+  showGithubStars: true,
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+  showTaskbarProgress: true,
+  flashTaskbarOnComplete: true,
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+describe('useTaskbarProgress', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baselineSettings))
+    store.dispatch(clearQueue())
+    mockSetProgressBar.mockClear()
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('clears the progress bar when no downloads are active', () => {
+    renderHook(() => useTaskbarProgress(), { wrapper })
+    expect(mockSetProgressBar).toHaveBeenCalledWith({
+      status: ProgressBarStatus.None,
+    })
+  })
+
+  it('shows the progress bar while a child download is running', () => {
+    store.dispatch(
+      enqueue({
+        downloadId: 'child-1',
+        parentId: 'parent-1',
+        status: 'running',
+      }),
+    )
+    renderHook(() => useTaskbarProgress(), { wrapper })
+    // No progress entries yet, so overallRatio is 0, but the bar is shown.
+    expect(mockSetProgressBar).toHaveBeenCalledWith({ progress: 0 })
+  })
+
+  it('clears the bar when showTaskbarProgress is disabled', () => {
+    store.dispatch(
+      setSettings({ ...baselineSettings, showTaskbarProgress: false }),
+    )
+    store.dispatch(
+      enqueue({
+        downloadId: 'child-1',
+        parentId: 'parent-1',
+        status: 'running',
+      }),
+    )
+    renderHook(() => useTaskbarProgress(), { wrapper })
+    expect(mockSetProgressBar).toHaveBeenCalledWith({
+      status: ProgressBarStatus.None,
+    })
+  })
+})

--- a/src/features/notifications/hooks/useTaskbarProgress.test.tsx
+++ b/src/features/notifications/hooks/useTaskbarProgress.test.tsx
@@ -7,7 +7,7 @@ import { getCurrentWindow, ProgressBarStatus } from '@tauri-apps/api/window'
 import { renderHook } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { Provider } from 'react-redux'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // setup.ts returns a single shared window instance, so this is the same
 // vi.fn the hook invokes.

--- a/src/features/notifications/hooks/useTaskbarProgress.ts
+++ b/src/features/notifications/hooks/useTaskbarProgress.ts
@@ -1,0 +1,45 @@
+import { useSelector } from '@/app/store'
+import { selectOverallSummary } from '@/features/download-status/model/selectors'
+import { logger } from '@/shared/lib/logger'
+import { selectHasActiveDownloads } from '@/shared/queue/queueSlice'
+import { getCurrentWindow, ProgressBarStatus } from '@tauri-apps/api/window'
+import { useEffect } from 'react'
+
+/**
+ * Reflect download progress on the taskbar.
+ *
+ * Subscribes to the same `overallRatio` the download dialog's
+ * `OverallProgressBar` renders, plus the active-downloads flag, and drives
+ * `getCurrentWindow().setProgressBar`. Clears immediately
+ * (`ProgressBarStatus.None`) when no downloads are active or the setting is
+ * off, so a stale bar never lingers after completion.
+ *
+ * The percentage formula mirrors `OverallProgressBar.tsx` exactly
+ * (`Math.min(100, Math.round(ratio * 100))`) so the taskbar and the dialog
+ * always show the same value, including any future refinement to the ratio.
+ *
+ * Must be mounted exactly once at the app root (see App.tsx).
+ */
+export function useTaskbarProgress(): void {
+  const hasActive = useSelector(selectHasActiveDownloads)
+  const overallRatio = useSelector(
+    (state) => selectOverallSummary(state).overallRatio,
+  )
+  const enabled = useSelector(
+    (state) => state.settings.showTaskbarProgress ?? true,
+  )
+
+  useEffect(() => {
+    const win = getCurrentWindow()
+    if (enabled && hasActive) {
+      const progress = Math.min(100, Math.round(overallRatio * 100))
+      win
+        .setProgressBar({ progress })
+        .catch((e) => logger.error('setProgressBar failed', e))
+    } else {
+      win
+        .setProgressBar({ status: ProgressBarStatus.None })
+        .catch((e) => logger.error('setProgressBar(clear) failed', e))
+    }
+  }, [enabled, hasActive, overallRatio])
+}

--- a/src/features/notifications/index.ts
+++ b/src/features/notifications/index.ts
@@ -1,0 +1,2 @@
+export { useDownloadCompletionNotifications } from './hooks/useDownloadCompletionNotifications'
+export { useTaskbarProgress } from './hooks/useTaskbarProgress'

--- a/src/features/notifications/lib/downloadPhase.test.ts
+++ b/src/features/notifications/lib/downloadPhase.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import type { QueueItem } from '@/shared/queue/queueSlice'
+
+import { deriveDownloadPhase } from './downloadPhase'
+
+function item(
+  downloadId: string,
+  status: QueueItem['status'],
+  parentId?: string,
+): QueueItem {
+  return { downloadId, status, ...(parentId ? { parentId } : {}) }
+}
+
+describe('deriveDownloadPhase', () => {
+  it('returns idle for empty queue', () => {
+    expect(deriveDownloadPhase([])).toEqual({ phase: 'idle' })
+  })
+
+  it('returns idle when only orphan parents exist (no children)', () => {
+    const queue: QueueItem[] = [item('parent-1', 'done')]
+    expect(deriveDownloadPhase(queue)).toEqual({ phase: 'idle' })
+  })
+
+  it('returns active when any child is pending', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'running'),
+      item('parent-1-p1', 'done', 'parent-1'),
+      item('parent-1-p2', 'pending', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({ phase: 'active' })
+  })
+
+  it('returns active when any child is running', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'running'),
+      item('parent-1-p1', 'running', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({ phase: 'active' })
+  })
+
+  it('returns active when a parent is cancelling even if all children are terminal', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'cancelling'),
+      item('parent-1-p1', 'cancelled', 'parent-1'),
+      item('parent-1-p2', 'cancelled', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({ phase: 'active' })
+  })
+
+  it('returns settled with hasSuccess=true when all children done', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'done'),
+      item('parent-1-p1', 'done', 'parent-1'),
+      item('parent-1-p2', 'done', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({
+      phase: 'settled',
+      hasSuccess: true,
+      hasError: false,
+    })
+  })
+
+  it('returns settled with hasError=true when any child errored', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'error'),
+      item('parent-1-p1', 'done', 'parent-1'),
+      item('parent-1-p2', 'error', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({
+      phase: 'settled',
+      hasSuccess: true,
+      hasError: true,
+    })
+  })
+
+  it('returns settled with neither flag when all cancelled (skip notification)', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'cancelled'),
+      item('parent-1-p1', 'cancelled', 'parent-1'),
+      item('parent-1-p2', 'cancelled', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({
+      phase: 'settled',
+      hasSuccess: false,
+      hasError: false,
+    })
+  })
+
+  it('returns settled with hasSuccess=true even if some siblings cancelled', () => {
+    const queue: QueueItem[] = [
+      item('parent-1', 'done'),
+      item('parent-1-p1', 'done', 'parent-1'),
+      item('parent-1-p2', 'cancelled', 'parent-1'),
+    ]
+    expect(deriveDownloadPhase(queue)).toEqual({
+      phase: 'settled',
+      hasSuccess: true,
+      hasError: false,
+    })
+  })
+})

--- a/src/features/notifications/lib/downloadPhase.ts
+++ b/src/features/notifications/lib/downloadPhase.ts
@@ -1,0 +1,40 @@
+import type { QueueItem } from '@/shared/queue/queueSlice'
+
+export type DownloadPhase =
+  | { phase: 'idle' }
+  | { phase: 'active' }
+  | { phase: 'settled'; hasSuccess: boolean; hasError: boolean }
+
+/**
+ * Derive the download lifecycle phase from the current queue.
+ *
+ * - `idle`: no children (queue empty or only orphan parents).
+ * - `active`: at least one child is pending/running, or any parent is
+ *   cancelling.
+ * - `settled`: every child reached a terminal state (done/error/cancelled).
+ *   `hasSuccess`/`hasError` are derived from children statuses. Cancelled
+ *   children do NOT count toward either flag, so a pure all-cancelled
+ *   completion returns `hasSuccess=false && hasError=false`, which the
+ *   caller uses to skip the completion notification.
+ *
+ * Pure function — no Redux, no Tauri. Easy to unit-test in isolation.
+ */
+export function deriveDownloadPhase(queue: QueueItem[]): DownloadPhase {
+  const children = queue.filter((q) => q.parentId != null)
+  if (children.length === 0) return { phase: 'idle' }
+
+  // Active = any child pending/running OR any parent cancelling. A
+  // cancelling parent may have no running children left (see
+  // aggregateParentStatuses in queueSlice), so parents are checked
+  // separately to keep the flash from firing mid-cancel.
+  const hasActiveChild = children.some(
+    (c) => c.status === 'running' || c.status === 'pending',
+  )
+  const hasCancellingParent = queue.some((q) => q.status === 'cancelling')
+  if (hasActiveChild || hasCancellingParent) return { phase: 'active' }
+
+  // All children are terminal (done/error/cancelled).
+  const hasSuccess = children.some((c) => c.status === 'done')
+  const hasError = children.some((c) => c.status === 'error')
+  return { phase: 'settled', hasSuccess, hasError }
+}

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -588,6 +588,44 @@ function SettingsForm() {
           />
         </div>
         <Separator />
+        {/* Notifications Section */}
+        <div className="space-y-4">
+          <div className="space-y-0.5">
+            <Label>{t('settings.notifications_section_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.notifications_section_description')}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>{t('settings.taskbar_progress_label')}</Label>
+              <p className="text-muted-foreground text-sm">
+                {t('settings.taskbar_progress_description')}
+              </p>
+            </div>
+            <Switch
+              checked={settings.showTaskbarProgress ?? true}
+              onCheckedChange={(checked) => {
+                saveByForm({ ...settings, showTaskbarProgress: checked })
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>{t('settings.flash_taskbar_on_complete_label')}</Label>
+              <p className="text-muted-foreground text-sm">
+                {t('settings.flash_taskbar_on_complete_description')}
+              </p>
+            </div>
+            <Switch
+              checked={settings.flashTaskbarOnComplete ?? true}
+              onCheckedChange={(checked) => {
+                saveByForm({ ...settings, flashTaskbarOnComplete: checked })
+              }}
+            />
+          </div>
+        </div>
+        <Separator />
         <div className="space-y-2">
           <div className="space-y-0.5">
             <Label>{t('settings.trim_mode_label')}</Label>

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -21,6 +21,8 @@ const initialState: SettingsState = {
   trimMode: 'copy',
   audioFormat: 'mp3',
   theme: 'light',
+  showTaskbarProgress: true,
+  flashTaskbarOnComplete: true,
 }
 
 /**

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -105,6 +105,16 @@ export interface Settings {
    * Defaults to 'light' if not set.
    */
   theme?: Theme
+  /**
+   * Whether to show download progress on the taskbar.
+   * Defaults to true if not specified.
+   */
+  showTaskbarProgress?: boolean
+  /**
+   * Whether to flash the taskbar button when downloads complete.
+   * Defaults to true if not specified.
+   */
+  flashTaskbarOnComplete?: boolean
 }
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "Fast (Copy)",
     "rotation_mode_reencode": "Accurate (Re-encode)",
     "rotation_angle_label": "Default rotation angle",
-    "rotation_angle_description": "Choose the default rotation direction"
+    "rotation_angle_description": "Choose the default rotation direction",
+    "notifications_section_label": "Notifications",
+    "notifications_section_description": "Customize feedback when downloads finish.",
+    "taskbar_progress_label": "Taskbar Progress",
+    "taskbar_progress_description": "Show download progress on the taskbar.",
+    "flash_taskbar_on_complete_label": "Flash Taskbar on Completion",
+    "flash_taskbar_on_complete_description": "Flash the taskbar button when downloads finish."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "Rápido (Copiar)",
     "rotation_mode_reencode": "Preciso (Recodificar)",
     "rotation_angle_label": "Ángulo de rotación predeterminado",
-    "rotation_angle_description": "Elige la dirección de rotación predeterminada"
+    "rotation_angle_description": "Elige la dirección de rotación predeterminada",
+    "notifications_section_label": "Notificaciones",
+    "notifications_section_description": "Personaliza la retroalimentación al completar descargas.",
+    "taskbar_progress_label": "Progreso en la barra de tareas",
+    "taskbar_progress_description": "Muestra el progreso de descarga en la barra de tareas.",
+    "flash_taskbar_on_complete_label": "Parpadear barra al completar",
+    "flash_taskbar_on_complete_description": "Hace parpadear el botón de la barra de tareas al terminar."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "Rapide (Copie)",
     "rotation_mode_reencode": "Précis (Recodage)",
     "rotation_angle_label": "Angle de rotation par défaut",
-    "rotation_angle_description": "Choisissez la direction de rotation par défaut"
+    "rotation_angle_description": "Choisissez la direction de rotation par défaut",
+    "notifications_section_label": "Notifications",
+    "notifications_section_description": "Personnalisez les retours lors de la fin des téléchargements.",
+    "taskbar_progress_label": "Progression dans la barre des tâches",
+    "taskbar_progress_description": "Affiche la progression du téléchargement dans la barre des tâches.",
+    "flash_taskbar_on_complete_label": "Faire clignoter la barre à la fin",
+    "flash_taskbar_on_complete_description": "Fait clignoter le bouton de la barre des tâches à la fin des téléchargements."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "高速（コピー）",
     "rotation_mode_reencode": "正確（再エンコード）",
     "rotation_angle_label": "デフォルトの回転角度",
-    "rotation_angle_description": "既定の回転方向を選びます"
+    "rotation_angle_description": "既定の回転方向を選びます",
+    "notifications_section_label": "通知",
+    "notifications_section_description": "ダウンロード完了時のフィードバックをカスタマイズします。",
+    "taskbar_progress_label": "タスクバー進捗",
+    "taskbar_progress_description": "タスクバーにダウンロード進捗を表示します。",
+    "flash_taskbar_on_complete_label": "完了時にタスクバーを点滅",
+    "flash_taskbar_on_complete_description": "ダウンロード完了時にタスクバーボタンを点滅させます。"
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "빠름 (복사)",
     "rotation_mode_reencode": "정확 (재인코딩)",
     "rotation_angle_label": "기본 회전 각도",
-    "rotation_angle_description": "기본 회전 방향을 선택합니다"
+    "rotation_angle_description": "기본 회전 방향을 선택합니다",
+    "notifications_section_label": "알림",
+    "notifications_section_description": "다운로드 완료 시 피드백을 사용자 지정합니다.",
+    "taskbar_progress_label": "작업 표시줄 진행률",
+    "taskbar_progress_description": "작업 표시줄에 다운로드 진행률을 표시합니다.",
+    "flash_taskbar_on_complete_label": "완료 시 작업 표시줄 깜빡임",
+    "flash_taskbar_on_complete_description": "다운로드 완료 시 작업 표시줄 버튼을 깜빡입니다."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -445,7 +445,13 @@
     "rotation_mode_copy": "快速（复制）",
     "rotation_mode_reencode": "精确（重编码）",
     "rotation_angle_label": "默认旋转角度",
-    "rotation_angle_description": "选择默认旋转方向"
+    "rotation_angle_description": "选择默认旋转方向",
+    "notifications_section_label": "通知",
+    "notifications_section_description": "自定义下载完成时的反馈。",
+    "taskbar_progress_label": "任务栏进度",
+    "taskbar_progress_description": "在任务栏显示下载进度。",
+    "flash_taskbar_on_complete_label": "完成时闪烁任务栏",
+    "flash_taskbar_on_complete_description": "下载完成时闪烁任务栏按钮。"
   },
   "validation": {
     "path": {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -17,4 +17,33 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   trace: vi.fn(),
 }))
 
+// Mock @tauri-apps/api/window. useTaskbarProgress and
+// useDownloadCompletionNotifications call getCurrentWindow().setProgressBar /
+// requestUserAttention. A single hoisted instance is returned so tests can
+// grab the same vi.fn references and assert on them.
+const { mockCurrentWindow } = vi.hoisted(() => ({
+  mockCurrentWindow: {
+    setProgressBar: vi.fn().mockResolvedValue(undefined),
+    requestUserAttention: vi.fn().mockResolvedValue(undefined),
+    setTheme: vi.fn().mockResolvedValue(undefined),
+    isFocused: vi.fn().mockResolvedValue(true),
+    onFocusChanged: vi.fn().mockResolvedValue(() => {}),
+  },
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => mockCurrentWindow,
+  ProgressBarStatus: {
+    None: 'none',
+    Normal: 'normal',
+    Pending: 'pending',
+    Error: 'error',
+    Indeterminate: 'indeterminate',
+  },
+  UserAttentionType: {
+    Critical: 'critical',
+    Informational: 'informational',
+  },
+}))
+
 console.log('Tauri APIs mocked successfully')


### PR DESCRIPTION
## Summary

Add download completion feedback to the OS taskbar:

- **Taskbar progress bar** mirrors the download dialog's `overallRatio` (same value, same formula `Math.min(100, Math.round(ratio * 100))`), so any future refinement to the ratio propagates automatically to the taskbar.
- **Taskbar flash** on completion — `Critical` when any part errored, `Informational` on pure success. All-cancelled completions are skipped.
- Flash-stop is left to the OS (Tauri's `requestUserAttention` auto-stops on window focus on Windows and macOS), so no focus listener is needed.

New settings (default `true`): `showTaskbarProgress`, `flashTaskbarOnComplete`.

Push notifications were intentionally omitted due to the maintenance cost of tracking per-OS notification permission changes.

### Architecture

Frontend-driven (Redux is the single source of truth), reusing existing selectors:
- `deriveDownloadPhase(queue)` pure function — detects the `active → settled` edge and derives `hasSuccess` / `hasError` (cancelled children do not count, so pure all-cancelled completions are skipped).
- `useTaskbarProgress` — subscribes to `selectOverallSummary.overallRatio` + `selectHasActiveDownloads`, drives `getCurrentWindow().setProgressBar`.
- `useDownloadCompletionNotifications` — on the `active → settled` edge, calls `requestUserAttention(Critical | Informational)`.

No Rust command or plugin was added (Push notification dropped the `tauri-plugin-notification` dependency entirely).

## Related Issue

Closes #476

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (163 passed — includes `deriveDownloadPhase`, `useTaskbarProgress`, `useDownloadCompletionNotifications`)
- [x] `cargo build` (src-tauri)
- [x] i18n key count balanced across all 6 languages (677 each)
- [x] Manual (Windows): taskbar progress bar tracks the download, flash fires on completion
- [ ] Manual (macOS): Dock progress bar + Dock bounce
- [ ] Manual (Linux): libunity environments only

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None. New settings default to `true`, so existing users get the new feedback on first launch.

## Checklist

- [x] `/review-all` executed (code-reviewer passed clean; simplifier/doc-generator skipped — implementation is already minimal and documented)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (pure-function unit tests + renderHook tests for both hooks)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)