### PR TITLE
fix(video): remove non-functional retry button on download failure

### DIFF
--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -9,7 +9,7 @@ import { logger } from '@/shared/lib/logger'
 import type { Progress } from '@/shared/ui/Progress'
 import { Button } from '@/shared/ui/button'
 import { invoke } from '@tauri-apps/api/core'
-import { CheckCircle2, FolderOpen, RotateCcw } from 'lucide-react'
+import { CheckCircle2, FolderOpen } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { PartDownloadStatus } from '../hooks/usePartDownloadStatus'
@@ -175,7 +175,6 @@ function MergeStageProgress({ progressEntries, t }: MergeStageProgressProps) {
 type Props = {
   status: PartDownloadStatus
   isWaitingForTurn?: boolean
-  onRetry: () => void
   onCancel?: () => void
   /** True if audio is embedded (durl format), so only video stage is shown */
   hasEmbeddedAudio?: boolean
@@ -188,7 +187,6 @@ type Props = {
 export function PartDownloadProgress({
   status,
   isWaitingForTurn = false,
-  onRetry,
   onCancel,
   hasEmbeddedAudio = false,
 }: Props) {
@@ -291,19 +289,10 @@ export function PartDownloadProgress({
       )}
 
       {hasError && (
-        <div className={`flex ${MIN_HEIGHT} items-center justify-between`}>
+        <div className={`flex ${MIN_HEIGHT} items-center`}>
           <div className="text-destructive flex items-center gap-2 text-sm">
             <span>{errorMessage || t('video.download_failed_part')}</span>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onRetry}
-            className="h-8 px-2 text-xs"
-          >
-            <RotateCcw className="mr-1 h-3 w-3" />
-            {t('video.retry')}
-          </Button>
         </div>
       )}
 

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -469,13 +469,6 @@ const VideoPartCard = memo(function VideoPartCard({
   )
 
   /**
-   * Handles retry action by re-selecting the part for download.
-   */
-  const handleRetry = useCallback(() => {
-    store.dispatch(updatePartSelected({ index: page - 1, selected: true }))
-  }, [page])
-
-  /**
    * Handles cancel action by stopping the current download and deselecting the part.
    */
   const handleCancel = useCallback(() => {
@@ -962,7 +955,6 @@ const VideoPartCard = memo(function VideoPartCard({
           <PartDownloadProgress
             status={downloadStatus}
             isWaitingForTurn={isWaitingForTurn}
-            onRetry={handleRetry}
             onCancel={handleCancel}
             hasEmbeddedAudio={
               resolvedQuality

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -233,8 +233,6 @@
     "download_complete": "Complete",
     "open_file": "Open File",
     "open_folder": "Open Folder",
-    "redownload": "Redownload",
-    "retry": "Retry",
     "download_failed_part": "Download failed",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} remaining",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -233,8 +233,6 @@
     "download_complete": "Completo",
     "open_file": "Abrir archivo",
     "open_folder": "Abrir carpeta",
-    "redownload": "Descargar de nuevo",
-    "retry": "Reintentar",
     "download_failed_part": "Descarga fallida",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} restante",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -233,8 +233,6 @@
     "download_complete": "Terminé",
     "open_file": "Ouvrir le fichier",
     "open_folder": "Ouvrir le dossier",
-    "redownload": "Télécharger à nouveau",
-    "retry": "Réessayer",
     "download_failed_part": "Échec du téléchargement",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} restante",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -233,8 +233,6 @@
     "download_complete": "完了",
     "open_file": "ファイルを開く",
     "open_folder": "フォルダを開く",
-    "redownload": "再ダウンロード",
-    "retry": "再試行",
     "download_failed_part": "ダウンロードに失敗しました",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "残{{time}}",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -233,8 +233,6 @@
     "download_complete": "완료",
     "open_file": "파일 열기",
     "open_folder": "폴더 열기",
-    "redownload": "다시 다운로드",
-    "retry": "재시도",
     "download_failed_part": "다운로드 실패",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "{{time}} 남음",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -233,8 +233,6 @@
     "download_complete": "完成",
     "open_file": "打开文件",
     "open_folder": "打开文件夹",
-    "redownload": "重新下载",
-    "retry": "重试",
     "download_failed_part": "下载失败",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
     "time_remaining": "剩余 {{time}}",


### PR DESCRIPTION
## Summary

Remove the non-functional "Retry" button shown on part download failure.

The retry button was a no-op: `handleRetry` dispatched only `updatePartSelected({ selected: true })`, which is a no-op when the part is already selected (the common case after failure, since failure does not deselect the part), and it never invoked `download()`. Users reported the button did nothing when clicked.

## Related Issue

N/A (no matching open issue found)

## Type of Change

- [x] 🐛 Bug fix

## Changes

- Removed the retry `<Button>` from the error state in `PartDownloadProgress.tsx`
- Removed the `onRetry` prop and `RotateCcw` import
- Removed the `handleRetry` handler from `VideoPartCard.tsx`
- Removed the unused `video.retry` and `video.redownload` i18n keys across all 6 languages (en/ja/zh/ko/es/fr). `history.redownload` and `updater.actions.retry` are unrelated and retained.

## Why delete instead of fix?

A proper single-part retry would require re-issuing `parentId` and re-enqueuing via the VideoInfoContext download flow — significant complexity. The existing manual re-download flow (checkbox + main Download button) already clears stale error items and re-invokes `downloadVideo`, so deleting the broken button loses no functionality.

## Test Plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [ ] Manual: trigger a download failure (e.g. invalid video URL) and verify the error message shows with no retry button; re-select + Download re-downloads successfully

## Breaking Changes

None. The button was non-functional; removal has no behavioral impact.

## Checklist

- [ ] `/review-all` executed — skipped (3 specialist agents reviewed instead: code-reviewer / code-simplifier / silent-failure-hunter)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (deletion only)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)