### PR TITLE
fix(ui): unify settings dialog width with download status dialog

### DIFF
--- a/src/features/settings/dialog/SettingsDialog.tsx
+++ b/src/features/settings/dialog/SettingsDialog.tsx
@@ -32,7 +32,7 @@ function SettingsDialog() {
       open={settings.dialogOpen}
       onOpenChange={(open) => updateOpenDialog(open)}
     >
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-5xl">
         <DialogHeader>
           <DialogTitle>{t('settings.dialog_title')}</DialogTitle>
           <DialogDescription hidden></DialogDescription>


### PR DESCRIPTION
## Summary

Align the `SettingsDialog` width with the `DownloadStatusDialog`. The settings dialog's `DialogContent` used `max-w-2xl` (672px), which made it visibly narrower than the download status dialog (`max-w-5xl`, 1024px). Bumped the settings dialog to `max-w-5xl` so both primary dialogs share a consistent width.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Open the Settings dialog and the Download Status dialog
- [ ] Verify both dialogs have the same maximum width

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None.

## Checklist

- [x] \`/review-all\` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (N/A — single-line Tailwind class change)
- [ ] i18n files synced (N/A — no user-facing text changes)