### PR TITLE
fix(download): refresh signed URLs on retry and localize error display

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1340,6 +1340,7 @@ fn url_host(url: &str) -> String {
 /// # Errors
 ///
 /// Returns `ERR::AUDIO_DOWNLOAD_FAILED` if all attempts fail.
+#[allow(clippy::too_many_arguments)]
 async fn download_audio_with_fallback(
     app: &AppHandle,
     download_id: &str,

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -351,6 +351,7 @@ async fn download_bangumi_durl(
     options: &DownloadOptions,
     output_path: &Path,
     cookie_header: &str,
+    cookies: &[CookieEntry],
     player_result: BangumiPlayerResult,
 ) -> Result<String, String> {
     use crate::handlers::concurrency::DOWNLOAD_CANCEL_REGISTRY;
@@ -416,21 +417,66 @@ async fn download_bangumi_durl(
         ensure_free_space(output_path, total_needed)?;
     }
 
+    // Refetch inputs for attempt > 1 (bilibili signed URLs expire after 120 min).
+    let bd_refetch_cookies = cookies.to_vec();
+    let bd_refetch_bvid = options.bvid.clone();
+    let bd_cid = options.cid;
+    let bd_ep_id = options.ep_id;
+    let bd_video_url = video_url.clone();
+    let bd_backup_urls = backup_urls.clone();
+    let bd_output_path = output_path.to_path_buf();
+    let bd_cookie_header = cookie_header.to_string();
+    let bd_download_id = options.download_id.clone();
     // Download directly. Capture the result so we always remove the token
     // (success or error) to avoid a registry leak on the early-return path.
-    let result = retry_download(app, &options.download_id, Some("video"), || {
-        download_url(
-            app,
-            video_url.clone(),
-            backup_urls.clone(),
-            output_path.to_path_buf(),
-            Some(cookie_header.to_string()),
-            true,
-            Some(options.download_id.clone()),
-            Some("video"),
-            true,
-        )
-    })
+    let result = retry_download(
+        app,
+        &options.download_id,
+        Some("video"),
+        move |attempt: u8| {
+            // Re-clone per call: async move consumes captured values, but
+            // FnMut may invoke the closure up to MAX_ATTEMPTS times.
+            let cookies = bd_refetch_cookies.clone();
+            let bvid = bd_refetch_bvid.clone();
+            let video_url = bd_video_url.clone();
+            let backup_urls = bd_backup_urls.clone();
+            let output_path = bd_output_path.clone();
+            let cookie_header = bd_cookie_header.clone();
+            let download_id = bd_download_id.clone();
+            async move {
+                let (url, backups) = if attempt == 1 {
+                    (video_url.clone(), backup_urls.clone())
+                } else {
+                    log::info!(
+                        "[BE] download_bangumi_durl: playurl refetch attempt={} for bangumi durl",
+                        attempt
+                    );
+                    match refetch_durl_url(&cookies, &bvid, bd_cid, bd_ep_id).await {
+                        Ok(fresh) => fresh,
+                        Err(e) => {
+                            log::warn!(
+                                "[BE] bangumi durl refetch failed, retrying with stale URL: {}",
+                                e
+                            );
+                            (video_url.clone(), backup_urls.clone())
+                        }
+                    }
+                };
+                download_url(
+                    app,
+                    url,
+                    backups,
+                    output_path,
+                    Some(cookie_header),
+                    true,
+                    Some(download_id),
+                    Some("video"),
+                    true,
+                )
+                .await
+            }
+        },
+    )
     .await;
 
     // Always remove the cancellation token (success or error).
@@ -529,6 +575,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 options,
                 &output_path,
                 &cookie_header,
+                &cookies,
                 player_result,
             )
             .await;
@@ -591,19 +638,59 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 ensure_free_space(&output_path, vs + 5 * 1024 * 1024)?;
             }
 
-            retry_download(app, &options.download_id, Some("video"), || {
-                download_url(
-                    app,
-                    video_url.clone(),
-                    backup_urls.clone(),
-                    output_path.to_path_buf(),
-                    Some(cookie_header.to_string()),
-                    true,
-                    Some(options.download_id.clone()),
-                    Some("video"),
-                    true,
-                )
-            })
+            let d_refetch_cookies = cookies.clone();
+            let d_refetch_bvid = options.bvid.clone();
+            let d_cid = options.cid;
+            let d_ep_id = options.ep_id;
+            let d_output_path = output_path.clone();
+            retry_download(
+                app,
+                &options.download_id,
+                Some("video"),
+                move |attempt: u8| {
+                    // Re-clone per call: async move consumes captured values, but
+                    // FnMut may invoke the closure up to MAX_ATTEMPTS times.
+                    let cookies = d_refetch_cookies.clone();
+                    let bvid = d_refetch_bvid.clone();
+                    let video_url = video_url.clone();
+                    let backup_urls = backup_urls.clone();
+                    let output_path = d_output_path.to_path_buf();
+                    let cookie_header = cookie_header.to_string();
+                    let download_id = options.download_id.clone();
+                    async move {
+                        let (url, backups) = if attempt == 1 {
+                            (video_url.clone(), backup_urls.clone())
+                        } else {
+                            log::info!(
+                                "[BE] download_video: playurl refetch attempt={} for durl video",
+                                attempt
+                            );
+                            match refetch_durl_url(&cookies, &bvid, d_cid, d_ep_id).await {
+                                Ok(fresh) => fresh,
+                                Err(e) => {
+                                    log::warn!(
+                                        "[BE] durl refetch failed, retrying with stale URL: {}",
+                                        e
+                                    );
+                                    (video_url.clone(), backup_urls.clone())
+                                }
+                            }
+                        };
+                        download_url(
+                            app,
+                            url,
+                            backups,
+                            output_path,
+                            Some(cookie_header),
+                            true,
+                            Some(download_id),
+                            Some("video"),
+                            true,
+                        )
+                        .await
+                    }
+                },
+            )
             .await?;
 
             let output_path_str = output_path.to_string_lossy().to_string();
@@ -720,6 +807,13 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 
         // Download audio with fallback and video in parallel (cancel immediately if either fails)
         // Audio uses fallback to handle invalid media responses from VIP-specific CDN edges
+        let audio_refetch_ctx = AudioRefetchCtx {
+            cookies: cookies.clone(),
+            bvid: options.bvid.clone(),
+            cid: options.cid,
+            ep_id: options.ep_id,
+            audio_quality: resolved_audio_quality,
+        };
         let audio_download = download_audio_with_fallback(
             app,
             &options.download_id,
@@ -728,20 +822,71 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             temp_audio_path.clone(),
             cookie.clone(),
             &dash_data.audio,
+            &audio_refetch_ctx,
         );
-        let video_download = retry_download(app, &options.download_id, Some("video"), || {
-            download_url(
-                app,
-                video_url.clone(),
-                video_backup_urls.clone(),
-                temp_video_path.clone(),
-                cookie.clone(),
-                true,
-                Some(options.download_id.clone()),
-                None,
-                false, // emit_complete: will be emitted after merge
-            )
-        });
+        // Refetch inputs for attempt > 1 (bilibili signed URLs expire after
+        // 120 min). Cloned here because the move closure must own them, while
+        // `cookie` is shared with audio_download and `cookies` with subtitle prep.
+        let v_refetch_cookies = cookies.clone();
+        let v_refetch_bvid = options.bvid.clone();
+        let v_cid = options.cid;
+        let v_ep_id = options.ep_id;
+        let v_quality = resolved_video_quality;
+        let v_download_id = options.download_id.clone();
+        let v_video_url = video_url.clone();
+        let v_video_backups = video_backup_urls.clone();
+        let v_temp_video_path = temp_video_path.clone();
+        let v_cookie = cookie.clone();
+        let video_download = retry_download(
+            app,
+            &options.download_id,
+            Some("video"),
+            move |attempt: u8| {
+                // Re-clone per call: async move consumes captured values, but
+                // FnMut may invoke the closure up to MAX_ATTEMPTS times.
+                let cookies = v_refetch_cookies.clone();
+                let bvid = v_refetch_bvid.clone();
+                let video_url = v_video_url.clone();
+                let video_backup_urls = v_video_backups.clone();
+                let temp_video_path = v_temp_video_path.clone();
+                let cookie = v_cookie.clone();
+                let download_id = v_download_id.clone();
+                async move {
+                    let (url, backups) = if attempt == 1 {
+                        (video_url.clone(), video_backup_urls.clone())
+                    } else {
+                        log::info!(
+                            "[BE] download_video: playurl refetch attempt={} for video",
+                            attempt
+                        );
+                        match refetch_dash_urls(&cookies, &bvid, v_cid, v_ep_id, v_quality, None)
+                            .await
+                        {
+                            Ok(fresh) => (fresh.video_url, fresh.video_backup_urls),
+                            Err(e) => {
+                                log::warn!(
+                                    "[BE] video refetch failed, retrying with stale URL: {}",
+                                    e
+                                );
+                                (video_url.clone(), video_backup_urls.clone())
+                            }
+                        }
+                    };
+                    download_url(
+                        app,
+                        url,
+                        backups,
+                        temp_video_path,
+                        cookie,
+                        true,
+                        Some(download_id),
+                        None,
+                        false, // emit_complete: will be emitted after merge
+                    )
+                    .await
+                }
+            },
+        );
 
         tokio::try_join!(audio_download, video_download)?;
 
@@ -1203,6 +1348,7 @@ async fn download_audio_with_fallback(
     output_path: PathBuf,
     cookie: Option<String>,
     all_audio_streams: &[crate::models::bilibili_api::XPlayerApiResponseVideo],
+    refetch_ctx: &AudioRefetchCtx,
 ) -> Result<(), String> {
     // Resolve the requested (primary) audio quality id from the stream
     // list so any fallback can be logged as an explicit
@@ -1219,19 +1365,61 @@ async fn download_audio_with_fallback(
         url_host(&primary_url)
     );
 
+    // Refetch inputs for attempt > 1 (bilibili signed URLs expire after 120 min).
+    let a_refetch_cookies = refetch_ctx.cookies.clone();
+    let a_refetch_bvid = refetch_ctx.bvid.clone();
+    let a_cid = refetch_ctx.cid;
+    let a_ep_id = refetch_ctx.ep_id;
+    let a_quality = refetch_ctx.audio_quality;
+    let a_download_id = download_id.to_string();
+    // Clone the download args so the primary closure can own them without
+    // moving the originals (the fallback loop below still needs them).
+    let a_primary_url = primary_url.clone();
+    let a_backup_urls = backup_urls.clone();
+    let a_output_path = output_path.clone();
+    let a_cookie = cookie.clone();
+
     // Try primary URL first
-    let primary_result = retry_download(app, download_id, Some("audio"), || {
-        download_url(
-            app,
-            primary_url.clone(),
-            backup_urls.clone(),
-            output_path.clone(),
-            cookie.clone(),
-            true,
-            Some(download_id.to_string()),
-            None,
-            false,
-        )
+    let primary_result = retry_download(app, download_id, Some("audio"), move |attempt: u8| {
+        // Re-clone per call: async move consumes captured values, but FnMut may
+        // invoke the closure up to MAX_ATTEMPTS times.
+        let cookies = a_refetch_cookies.clone();
+        let bvid = a_refetch_bvid.clone();
+        let primary_url = a_primary_url.clone();
+        let backup_urls = a_backup_urls.clone();
+        let output_path = a_output_path.clone();
+        let cookie = a_cookie.clone();
+        let download_id = a_download_id.clone();
+        async move {
+            let (url, backups) = if attempt == 1 {
+                (primary_url.clone(), backup_urls.clone())
+            } else {
+                log::info!(
+                    "[BE] download_audio: playurl refetch attempt={} for primary audio",
+                    attempt
+                );
+                // video_quality = -1 (best) is unused; only the audio slot matters.
+                match refetch_dash_urls(&cookies, &bvid, a_cid, a_ep_id, -1, a_quality).await {
+                    Ok(fresh) => (fresh.audio_url, fresh.audio_backup_urls),
+                    Err(e) => {
+                        log::warn!("[BE] audio refetch failed, retrying with stale URL: {}", e);
+                        (primary_url.clone(), backup_urls.clone())
+                    }
+                }
+            };
+            download_url(
+                app,
+                url,
+                backups,
+                output_path,
+                cookie,
+                true,
+                Some(download_id),
+                None,
+                false,
+            )
+            .await
+        }
     })
     .await;
 
@@ -1276,20 +1464,26 @@ async fn download_audio_with_fallback(
                         url_host(&stream.base_url)
                     );
 
-                    let fallback_result = retry_download(app, download_id, Some("audio"), || {
-                        download_url(
-                            app,
-                            stream.base_url.clone(),
-                            stream.backup_urls.clone(),
-                            output_path.clone(),
-                            cookie.clone(),
-                            true,
-                            Some(download_id.to_string()),
-                            None,
-                            false,
-                        )
-                    })
-                    .await;
+                    // CONSTRAINT: fallback loop intentionally does NOT refetch playurl on
+                    // retry (issue #482 design decision). Each iteration already switches
+                    // to a different audio stream (different CDN edge), which is the
+                    // recovery mechanism here; refetching the same quality's signature
+                    // would add complexity (stream-id remapping) for little gain.
+                    let fallback_result =
+                        retry_download(app, download_id, Some("audio"), |_attempt: u8| {
+                            download_url(
+                                app,
+                                stream.base_url.clone(),
+                                stream.backup_urls.clone(),
+                                output_path.clone(),
+                                cookie.clone(),
+                                true,
+                                Some(download_id.to_string()),
+                                None,
+                                false,
+                            )
+                        })
+                        .await;
 
                     match fallback_result {
                         Ok(()) => {
@@ -1982,7 +2176,7 @@ async fn retry_download<F, Fut>(
     mut f: F,
 ) -> Result<(), String>
 where
-    F: FnMut() -> Fut,
+    F: FnMut(u8) -> Fut,
     Fut: std::future::Future<Output = Result<(), anyhow::Error>>,
 {
     const MAX_ATTEMPTS: u8 = 3;
@@ -2004,7 +2198,7 @@ where
             // Notify frontend to hide transfer rate display during retry.
             emit_retrying(true);
         }
-        match f().await {
+        match f(attempt).await {
             Ok(_) => {
                 if attempt > 1 {
                     emit_retrying(false);
@@ -3149,6 +3343,140 @@ async fn fetch_bangumi_details_for_download(
             // This will be handled by download_video with durl support
             Err("ERR::BANGUMI_DURL_NOT_SUPPORTED".into())
         }
+    }
+}
+
+/// Fresh signed stream URLs obtained by re-calling the playurl API on retry.
+///
+/// Bilibili CDN URLs carry a signature that expires after 120 minutes. When a
+/// segment download fails on retry (attempt > 1), the originally captured URL
+/// may have expired. This struct holds the re-fetched URLs so the retry uses a
+/// fresh signature instead of replaying the same stale URL.
+struct FreshDashUrls {
+    video_url: String,
+    video_backup_urls: Option<Vec<String>>,
+    audio_url: String,
+    audio_backup_urls: Option<Vec<String>>,
+}
+
+/// Refetch context passed into `download_audio_with_fallback` so the primary
+/// audio closure can re-fetch fresh signed URLs on retry (attempt > 1).
+///
+/// `audio_quality` is the resolved quality id of the primary stream (None when
+/// the user did not pick one and best-available was used). `video_quality` is
+/// not needed for an audio-only refetch, so it is omitted; `refetch_dash_urls`
+/// is called with -1 (best) for the video slot, whose result is discarded.
+struct AudioRefetchCtx {
+    cookies: Vec<CookieEntry>,
+    bvid: String,
+    cid: i64,
+    ep_id: Option<i64>,
+    audio_quality: Option<i32>,
+}
+
+/// Re-fetches fresh signed DASH stream URLs from the playurl API.
+///
+/// Dispatches by `ep_id.is_some()`: bangumi uses
+/// `fetch_bangumi_details_for_download`, regular videos use
+/// `fetch_video_details`. Both normalize to `XPlayerApiResponse` with a `dash`
+/// field, so the same selection logic applies. The caller resolves the same
+/// quality pair it originally selected (requested video quality + resolved
+/// audio quality). On error, callers fall back to the stale captured URL
+/// (see the retry closures) rather than aborting the retry loop.
+async fn refetch_dash_urls(
+    cookies: &[CookieEntry],
+    bvid: &str,
+    cid: i64,
+    ep_id: Option<i64>,
+    video_quality: i32,
+    audio_quality: Option<i32>,
+) -> Result<FreshDashUrls, String> {
+    log::info!(
+        "[BE] refetch_dash_urls: refreshing signed DASH URLs (ep_id={:?}, cid={}, vq={}, aq={:?})",
+        ep_id,
+        cid,
+        video_quality,
+        audio_quality
+    );
+    let details = if let Some(ep) = ep_id {
+        fetch_bangumi_details_for_download(cookies, ep, cid).await?
+    } else {
+        fetch_video_details(cookies, bvid, cid).await?
+    };
+    let data = details
+        .data
+        .ok_or_else(|| "refetch_dash_urls: playurl response has no data".to_string())?;
+    let dash = data
+        .dash
+        .ok_or_else(|| "refetch_dash_urls: playurl response has no dash".to_string())?;
+    let (video_url, video_backup_urls, _) = select_stream_url(&dash.video, video_quality)?;
+    let resolved_audio_quality =
+        audio_quality.unwrap_or_else(|| dash.audio.first().map(|a| a.id).unwrap_or(30280));
+    let (audio_url, audio_backup_urls, _) = select_stream_url(&dash.audio, resolved_audio_quality)?;
+    Ok(FreshDashUrls {
+        video_url,
+        video_backup_urls,
+        audio_url,
+        audio_backup_urls,
+    })
+}
+
+/// Re-fetches a fresh signed durl URL (MP4 / single-stream format) from the playurl API.
+///
+/// durl takes two structurally different shapes that must be handled separately:
+/// - Regular videos: `data.durl` (flat list of `DurlSegment`).
+/// - Bangumi: `result.durls` (per-quality nested entries; `fetch_bangumi_details_for_download`
+///   rejects durl, so we read `fetch_bangumi_player_result` directly here).
+///
+/// Re-selects the first segment (durl format has a single combined stream).
+async fn refetch_durl_url(
+    cookies: &[CookieEntry],
+    bvid: &str,
+    cid: i64,
+    ep_id: Option<i64>,
+) -> Result<(String, Option<Vec<String>>), String> {
+    log::info!(
+        "[BE] refetch_durl_url: refreshing signed durl URL (ep_id={:?}, cid={})",
+        ep_id,
+        cid
+    );
+    if let Some(ep) = ep_id {
+        let result = fetch_bangumi_player_result(cookies, ep, cid).await?;
+        let durls = result
+            .durls
+            .as_ref()
+            .filter(|d| !d.is_empty())
+            .ok_or_else(|| "refetch_durl_url: bangumi has no durls".to_string())?;
+        let entry = durls
+            .first()
+            .ok_or_else(|| "refetch_durl_url: empty durls".to_string())?;
+        let seg = entry
+            .durl
+            .first()
+            .ok_or_else(|| "refetch_durl_url: empty durl".to_string())?;
+        let backup = seg
+            .backup_url
+            .as_ref()
+            .map(|u| u.iter().map(|s| s.to_string()).collect());
+        Ok((seg.url.clone(), backup))
+    } else {
+        let details = fetch_video_details(cookies, bvid, cid).await?;
+        let data = details
+            .data
+            .ok_or_else(|| "refetch_durl_url: no data".to_string())?;
+        let durl = data
+            .durl
+            .as_ref()
+            .filter(|d| !d.is_empty())
+            .ok_or_else(|| "refetch_durl_url: no durl".to_string())?;
+        let seg = durl
+            .first()
+            .ok_or_else(|| "refetch_durl_url: empty durl".to_string())?;
+        let backup = seg
+            .backup_url
+            .as_ref()
+            .map(|u| u.iter().map(|s| s.to_string()).collect());
+        Ok((seg.url.clone(), backup))
     }
 }
 

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -16,6 +16,15 @@ use crate::{
     emits::Emits,
     handlers::concurrency::DOWNLOAD_CANCEL_REGISTRY,
 };
+
+/// Error type for segment download failures.
+#[derive(Debug)]
+enum SegmentError {
+    /// Reconnect required (slow speed)
+    Reconnect,
+    /// Download failed with error details
+    Failed(String),
+}
 use anyhow::Result;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -467,7 +476,7 @@ pub async fn download_url(
 
                         let (buf, received, _) = match download_result {
                             Ok(result) => result,
-                            Err(reconnect) if reconnect => {
+                            Err(SegmentError::Reconnect) => {
                                 // Switch to next CDN URL on reconnect (loops back to start)
                                 let next_cdn_idx =
                                     (cdn_rotation_count as usize + 1) % cdn_urls_c.len();
@@ -483,19 +492,20 @@ pub async fn download_url(
                                 backoff_sleep(cdn_rotation_count).await;
                                 continue;
                             }
-                            Err(_) => {
+                            Err(SegmentError::Failed(detail)) => {
                                 // Chunk-stream error (e.g. connection reset).
                                 // download_segment_with_speed_check returns
-                                // Err(false) immediately because the stream is
-                                // broken. Bail out; the outer retry_download
+                                // SegmentError::Failed with error details.
+                                // Bail out; the outer retry_download
                                 // issues a fresh request, so no attempt counter
                                 // is shown here.
                                 log::warn!(
-                                    "[BE] download_url: segment {} download failed (cdn_idx={})",
+                                    "[BE] download_url: segment {} download failed (cdn_idx={}): {}",
                                     idx,
-                                    cdn_idx
+                                    cdn_idx,
+                                    detail
                                 );
-                                return Err(anyhow::anyhow!("segment {} download failed", idx))
+                                return Err(anyhow::anyhow!("segment {} download failed: {}", idx, detail))
                             }
                         };
 
@@ -669,7 +679,7 @@ async fn download_segment_with_speed_check(
     cdn_rotation_count: u8,
     cdn_urls_len: usize,
     on_chunk_received: impl Fn(u64),
-) -> Result<(Vec<u8>, u64, bool), bool> {
+) -> Result<(Vec<u8>, u64, bool), SegmentError> {
     let mut buf = Vec::with_capacity(size.min(8 * 1024 * 1024) as usize);
     let mut received: u64 = 0;
 
@@ -695,7 +705,7 @@ async fn download_segment_with_speed_check(
                     cdn_rotation_count,
                     cdn_urls_len,
                 ) {
-                    SpeedCheckResult::Slow => return Err(true), // Reconnect needed
+                    SpeedCheckResult::Slow => return Err(SegmentError::Reconnect), // Reconnect needed
                     SpeedCheckResult::Acceptable => {
                         // Reset check counters for next interval
                         last_check_time = Instant::now();
@@ -705,12 +715,13 @@ async fn download_segment_with_speed_check(
                 }
             }
             Ok(None) => break,
-            Err(_) => {
+            Err(e) => {
                 // Chunk-stream error (e.g. connection reset). The stream is
                 // broken, so retrying chunk() on the same response cannot
                 // recover — bail out and let the caller's download_url loop
                 // issue a fresh request (HTTP retry / CDN rotation).
-                return Err(false);
+                let detail = e.to_string();
+                return Err(SegmentError::Failed(detail));
             }
         }
     }

--- a/src/features/download-status/ui/PartStatusRow.tsx
+++ b/src/features/download-status/ui/PartStatusRow.tsx
@@ -6,6 +6,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
+import { mapBackendError } from '@/shared/lib/mapBackendError'
 import { cn } from '@/shared/lib/utils'
 import { GitMerge } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -87,10 +88,13 @@ export function PartStatusRow({
     (part.status === 'pending' || part.status === 'running') &&
     part.stage !== 'merge' &&
     !part.isComplete
-  const rawName =
+  // Why: when an error has a known backend code, show the translated message
+  // instead of the raw ERR:: string; otherwise fall back to the part title.
+  const mappedErrorKey =
     part.status === 'error' && part.errorMessage
-      ? part.errorMessage
-      : part.title
+      ? mapBackendError(part.errorMessage)
+      : null
+  const rawName = mappedErrorKey ? t(mappedErrorKey) : part.title
   const MAX_TOOLTIP_CHARS = 100
   const tooltipName =
     rawName.length > MAX_TOOLTIP_CHARS

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -23,8 +23,10 @@ import { selectDuplicateIndices } from '@/features/video/model/selectors'
 import { setVideo } from '@/features/video/model/videoSlice'
 import { setError } from '@/shared/downloadStatus/downloadStatusSlice'
 import { logger } from '@/shared/lib/logger'
+import { mapBackendError } from '@/shared/lib/mapBackendError'
 import { clearProgressByDownloadId } from '@/shared/progress/progressSlice'
 import { clearQueue, clearQueueItem, enqueue } from '@/shared/queue/queueSlice'
+import { Check, Copy } from 'lucide-react'
 import {
   createContext,
   useCallback,
@@ -32,67 +34,11 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import type { Input, Video } from '../types'
-
-/**
- * Maps backend error codes to i18n translation keys.
- *
- * Backend returns error strings containing error codes like "ERR::VIDEO_NOT_FOUND".
- * This constant maps those codes to translation keys for localized user-facing messages.
- */
-const ERROR_MAP: Record<string, string> = {
-  'ERR::VIDEO_NOT_FOUND': 'video.video_not_found',
-  'ERR::COOKIE_MISSING': 'video.cookie_missing',
-  'ERR::API_ERROR': 'video.api_error',
-  'ERR::FILE_EXISTS': 'video.file_exists',
-  'ERR::DISK_FULL': 'video.disk_full',
-  'ERR::MERGE_FAILED': 'video.merge_failed',
-  'ERR::QUALITY_NOT_FOUND': 'video.quality_not_found',
-  'ERR::RATE_LIMITED': 'video.rate_limited',
-  // Bangumi error codes
-  'ERR::BANGUMI_NOT_FOUND': 'video.bangumi_not_found',
-  'ERR::BANGUMI_VIP_ONLY': 'video.bangumi_vip_only',
-  'ERR::BANGUMI_REGION_RESTRICTED': 'video.bangumi_region_restricted',
-  'ERR::BANGUMI_COPYRIGHT_RESTRICTED': 'video.bangumi_copyright_restricted',
-  'ERR::BANGUMI_ACCESS_DENIED': 'video.bangumi_access_denied',
-  'ERR::BANGUMI_NO_DASH': 'video.bangumi_no_dash',
-  'ERR::BANGUMI_DURL_NOT_SUPPORTED': 'video.bangumi_durl_not_supported',
-  // Audio download error codes
-  'ERR::INVALID_MEDIA_RESPONSE': 'video.invalid_media_response',
-  'ERR::AUDIO_DOWNLOAD_FAILED': 'video.audio_download_failed',
-}
-
-/**
- * Extracts localized error message from error string.
- *
- * Maps backend error codes to user-facing translation keys. Returns the original
- * error message if no known error code is found. Handles network errors specifically.
- *
- * @param error - The raw error string from the backend
- * @param t - Translation function for localized error messages
- * @returns Localized error message string, or null if already handled
- *
- * @example
- * ```typescript
- * const msg = getErrorMessage('ERR::VIDEO_NOT_FOUND', t);
- * // Returns localized "Video not found" message
- * ```
- */
-function getErrorMessage(
-  error: string,
-  t: (key: string) => string,
-): string | null {
-  // ERR::UNAUTHORIZED is handled by tauriBaseQuery/interceptInvokeError
-  if (isUnauthorizedError(error)) return null
-
-  for (const [code, key] of Object.entries(ERROR_MAP)) {
-    if (error.includes(code)) return t(key)
-  }
-  return error.includes('ERR::NETWORK::') ? t('video.network_error') : error
-}
 
 /**
  * Extracts the 'p' query parameter from a URL.
@@ -118,6 +64,70 @@ function extractPageFromUrl(url: string): number | null {
   } catch {
     return null
   }
+}
+
+/**
+ * Toast description body for a failed download.
+ *
+ * Wraps the localized error text so it is selectable (`select-text`) and adds
+ * a copy icon button that copies the displayed text (error message + retry
+ * hint) to the clipboard. The icon swaps to a check for 2s to confirm the
+ * copy, matching the existing Copy/Check pattern in VideoPartCard.
+ *
+ * Why a custom wrapper instead of sonner's `action`: sonner's action button
+ * only accepts a string label, so an icon button must live inside the
+ * description body.
+ *
+ * NOTE: the raw backend error string (ERR::...) is intentionally NOT copied
+ * here — it is already captured in the app log file for debugging.
+ */
+function DownloadErrorDescription({
+  text,
+  retryHint,
+}: {
+  text: string
+  retryHint?: string
+}) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    const copyText = retryHint ? `${text}\n${retryHint}` : text
+    try {
+      await navigator.clipboard.writeText(copyText)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard write can fail in some webview contexts; ignore silently
+      // rather than masking the original download error with a new toast.
+    }
+  }
+
+  return (
+    <span className="flex items-start gap-2">
+      <span className="select-text">
+        {text}
+        {retryHint && (
+          <>
+            <br />
+            {retryHint}
+          </>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="text-muted-foreground hover:text-foreground mt-0.5 shrink-0"
+        aria-label={t('video.copy_error')}
+      >
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </button>
+    </span>
+  )
 }
 
 /**
@@ -316,7 +326,8 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
         initInputsForVideo(v)
       } else if (fetchResult.error) {
         const raw = String(fetchResult.error)
-        const description = getErrorMessage(raw, t)
+        const key = mapBackendError(raw)
+        const description = key ? t(key) : isUnauthorizedError(raw) ? null : raw
         if (description) {
           toast.error(t('video.fetch_info'), {
             duration: 5000,
@@ -551,18 +562,41 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
           continue
         }
 
-        const description = getErrorMessage(raw, t)
+        const key = mapBackendError(raw)
+        // Constraint: when mapBackendError has no mapping AND the raw error is
+        // ERR::UNAUTHORIZED, return null so no toast is shown here. Session
+        // expiry is handled centrally by interceptInvokeError/handleSessionExpiry
+        // (src/app/lib/invokeErrorHandler.ts), which emits its own dedicated
+        // session-expiry toast — showing another one here would duplicate it.
+        const description = key ? t(key) : isUnauthorizedError(raw) ? null : raw
         if (description) {
+          // Bilibili-side transient errors: append a retry hint so the user
+          // knows the failure is likely temporary and a later retry may
+          // succeed. Confirmed by logs — when the built-in retry exhausts,
+          // a later manual retry typically succeeds (CDN-side instability).
+          const isTransientError =
+            raw.includes('ERR::NETWORK') ||
+            raw.includes('ERR::INVALID_MEDIA_RESPONSE') ||
+            raw.includes('ERR::AUDIO_DOWNLOAD_FAILED') ||
+            raw.includes('ERR::RATE_LIMITED')
+          const retryHint = isTransientError ? t('video.retry_hint') : undefined
           toast.error(t('video.download_failed'), {
             duration: Infinity,
-            description: t('video.download_failed_part_description', {
-              page: pi.page,
-              title: pi.title,
-              description,
-            }),
+            description: (
+              <DownloadErrorDescription
+                text={t('video.download_failed_part_description', {
+                  page: pi.page,
+                  title: pi.title,
+                  description,
+                })}
+                retryHint={retryHint}
+              />
+            ),
             closeButton: true,
           })
-          store.dispatch(setError(description))
+          store.dispatch(
+            setError(retryHint ? `${description}\n${retryHint}` : description),
+          )
         }
         logger.error('Download failed', raw)
 

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
 import { logger } from '@/shared/lib/logger'
+import { mapBackendError } from '@/shared/lib/mapBackendError'
 import type { Progress } from '@/shared/ui/Progress'
 import { Button } from '@/shared/ui/button'
 import { invoke } from '@tauri-apps/api/core'
@@ -229,6 +230,9 @@ export function PartDownloadProgress({
     (p) => p.stage === 'merge' && !p.isComplete,
   )
 
+  // Why: merge-stage cancellation is disabled because killing ffmpeg mid-merge
+  // races with the final write and produces a contradictory (cancelled-but-
+  // complete) display. Mirrors the canCancel guard in PartStatusRow.tsx.
   const canCancel = (isPending || isDownloading) && !isInMergeStage && onCancel
 
   const handleOpenFile = useCallback(async () => {
@@ -254,6 +258,13 @@ export function PartDownloadProgress({
   ) {
     return null
   }
+
+  // Why: prefer the translated message for known backend codes; otherwise show
+  // the raw error string. When no error is recorded, use the generic label.
+  const mappedErrorKey = errorMessage ? mapBackendError(errorMessage) : null
+  const errorText = mappedErrorKey
+    ? t(mappedErrorKey)
+    : (errorMessage ?? t('video.download_failed_part'))
 
   return (
     <div className="bg-muted/50 mt-2 space-y-2 rounded-md p-2">
@@ -291,7 +302,7 @@ export function PartDownloadProgress({
       {hasError && (
         <div className={`flex ${MIN_HEIGHT} items-center`}>
           <div className="text-destructive flex items-center gap-2 text-sm">
-            <span>{errorMessage || t('video.download_failed_part')}</span>
+            <span>{errorText}</span>
           </div>
         </div>
       )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -235,6 +235,8 @@
     "open_folder": "Open Folder",
     "download_failed_part": "Download failed",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "Copy error message",
+    "retry_hint": "This is likely a temporary issue on Bilibili's side. Please try again in about an hour.",
     "time_remaining": "{{time}} remaining",
     "quality_limited_title": "Quality Limited",
     "quality_limited_description": "If not logged in (no cookies), only 480p or below is available.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -235,6 +235,8 @@
     "open_folder": "Abrir carpeta",
     "download_failed_part": "Descarga fallida",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "Copiar mensaje de error",
+    "retry_hint": "Es probable que sea un problema temporal de Bilibili. Inténtalo de nuevo en aproximadamente una hora.",
     "time_remaining": "{{time}} restante",
     "quality_limited_title": "Calidad Limitada",
     "quality_limited_description": "Si no ha iniciado sesión (sin cookies), solo 480p o inferior está disponible.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -235,6 +235,8 @@
     "open_folder": "Ouvrir le dossier",
     "download_failed_part": "Échec du téléchargement",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "Copier le message d'erreur",
+    "retry_hint": "Il s'agit probablement d'un problème temporaire côté Bilibili. Veuillez réessayer dans environ une heure.",
     "time_remaining": "{{time}} restante",
     "quality_limited_title": "Qualité Limitée",
     "quality_limited_description": "Si non connecté (sans cookies), seule la qualité 480p ou moins est disponible.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -235,6 +235,8 @@
     "open_folder": "フォルダを開く",
     "download_failed_part": "ダウンロードに失敗しました",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "エラーメッセージをコピー",
+    "retry_hint": "Bilibili側の一時的な問題が原因である可能性が高いです。1時間ほど時間をおいてから再試行してください。",
     "time_remaining": "残{{time}}",
     "quality_limited_title": "画質制限あり",
     "quality_limited_description": "未ログイン（Cookieがない）の場合は480p以下の画質のみになります。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -235,6 +235,8 @@
     "open_folder": "폴더 열기",
     "download_failed_part": "다운로드 실패",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "오류 메시지 복사",
+    "retry_hint": "Bilibili 측의 일시적인 문제일 가능성이 높습니다. 약 1시간 후에 다시 시도해 주세요.",
     "time_remaining": "{{time}} 남음",
     "quality_limited_title": "화질 제한됨",
     "quality_limited_description": "미로그인（Cookie 없음）시 480p 이하의 화질만 이용할 수 있습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -235,6 +235,8 @@
     "open_folder": "打开文件夹",
     "download_failed_part": "下载失败",
     "download_failed_part_description": "p{{page}} - {{title}}: {{description}}",
+    "copy_error": "复制错误消息",
+    "retry_hint": "这很可能是Bilibili侧的临时问题。请大约一小时后重试。",
     "time_remaining": "剩余 {{time}}",
     "quality_limited_title": "画质受限",
     "quality_limited_description": "未登录（没有Cookie）的情况下，仅可用480p或以下画质。",

--- a/src/shared/lib/mapBackendError.test.ts
+++ b/src/shared/lib/mapBackendError.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapBackendError } from './mapBackendError'
+
+describe('mapBackendError', () => {
+  it('maps a known video error code to its translation key', () => {
+    expect(mapBackendError('ERR::VIDEO_NOT_FOUND')).toBe(
+      'video.video_not_found',
+    )
+  })
+
+  it('maps ERR::INVALID_MEDIA_RESPONSE to its key', () => {
+    expect(mapBackendError('ERR::INVALID_MEDIA_RESPONSE')).toBe(
+      'video.invalid_media_response',
+    )
+  })
+
+  it('maps ERR::NETWORK:: with a dynamic suffix to the fixed network key', () => {
+    expect(mapBackendError('ERR::NETWORK::2 segment(s) failed')).toBe(
+      'video.network_error',
+    )
+  })
+
+  it('returns null for ERR::UNAUTHORIZED (handled by tauriBaseQuery)', () => {
+    expect(mapBackendError('ERR::UNAUTHORIZED')).toBeNull()
+  })
+
+  it('returns null for unknown ERR:: codes so callers fall back to the raw message', () => {
+    expect(mapBackendError('ERR::SOME_UNKNOWN_CODE')).toBeNull()
+  })
+
+  it('returns null for plain non-ERR messages', () => {
+    expect(mapBackendError('Connection reset by peer')).toBeNull()
+  })
+})

--- a/src/shared/lib/mapBackendError.ts
+++ b/src/shared/lib/mapBackendError.ts
@@ -1,0 +1,68 @@
+import { isUnauthorizedError } from '@/app/lib/invokeErrorHandler'
+
+/**
+ * Maps backend error codes (ERR::*) to i18n translation keys.
+ *
+ * Backend returns error strings containing codes like "ERR::VIDEO_NOT_FOUND".
+ * This maps them to translation keys for localized user-facing messages.
+ * Dynamic parts (e.g., "N segment(s) failed" in ERR::NETWORK::) are discarded;
+ * the fixed message is used instead.
+ *
+ * Extracted from VideoInfoContext.getErrorMessage so queue display paths
+ * (PartStatusRow / PartDownloadProgress) can share the same mapping.
+ */
+const VIDEO_ERROR_MAP: Record<string, string> = {
+  'ERR::VIDEO_NOT_FOUND': 'video.video_not_found',
+  'ERR::COOKIE_MISSING': 'video.cookie_missing',
+  'ERR::API_ERROR': 'video.api_error',
+  'ERR::FILE_EXISTS': 'video.file_exists',
+  'ERR::DISK_FULL': 'video.disk_full',
+  'ERR::MERGE_FAILED': 'video.merge_failed',
+  'ERR::QUALITY_NOT_FOUND': 'video.quality_not_found',
+  'ERR::RATE_LIMITED': 'video.rate_limited',
+  // Bangumi error codes
+  'ERR::BANGUMI_NOT_FOUND': 'video.bangumi_not_found',
+  'ERR::BANGUMI_VIP_ONLY': 'video.bangumi_vip_only',
+  'ERR::BANGUMI_REGION_RESTRICTED': 'video.bangumi_region_restricted',
+  'ERR::BANGUMI_COPYRIGHT_RESTRICTED': 'video.bangumi_copyright_restricted',
+  'ERR::BANGUMI_ACCESS_DENIED': 'video.bangumi_access_denied',
+  'ERR::BANGUMI_NO_DASH': 'video.bangumi_no_dash',
+  'ERR::BANGUMI_DURL_NOT_SUPPORTED': 'video.bangumi_durl_not_supported',
+  // Audio / media download error codes
+  'ERR::INVALID_MEDIA_RESPONSE': 'video.invalid_media_response',
+  'ERR::AUDIO_DOWNLOAD_FAILED': 'video.audio_download_failed',
+  // Why: trailing "::" matches the "ERR::NETWORK::<detail>" shape produced
+  // by retry_download (it appends segment-failure details after the code),
+  // so the dynamic suffix is discarded and the fixed key is returned.
+  'ERR::NETWORK::': 'video.network_error',
+}
+
+/**
+ * Maps a backend error message to a localized translation key.
+ *
+ * The caller is responsible for invoking the i18n `t()` function with the
+ * returned key. Returns `null` when the message should fall back to the
+ * original raw string (unknown code) or is already handled elsewhere
+ * (UNAUTHORIZED).
+ *
+ * @param errorMessage - Raw error string from backend (may contain ERR::* code)
+ * @returns Translation key string if a known ERR::* code is found, otherwise null
+ *
+ * @example
+ * ```ts
+ * mapBackendError('ERR::VIDEO_NOT_FOUND') // => 'video.video_not_found'
+ * mapBackendError('ERR::NETWORK::2 segment(s) failed') // => 'video.network_error'
+ * mapBackendError('ERR::UNAUTHORIZED') // => null (handled by tauriBaseQuery)
+ * mapBackendError('Some raw message') // => null (use original)
+ * ```
+ */
+export function mapBackendError(errorMessage: string): string | null {
+  // ERR::UNAUTHORIZED is handled by tauriBaseQuery/interceptInvokeError.
+  if (isUnauthorizedError(errorMessage)) return null
+
+  for (const [code, key] of Object.entries(VIDEO_ERROR_MAP)) {
+    if (errorMessage.includes(code)) return key
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- **retry_download refetch on retry**: `retry_download` now passes the attempt number to its closure; on attempt > 1 it re-calls the playurl API (`refetch_dash_urls` / `refetch_durl_url`) to refresh signed segment URLs that expire after 120 min (bilibili CDN). Applied to 4 call sites (DASH video, DASH audio primary, regular durl, bangumi durl). The audio fallback loop intentionally does **not** refetch (it already switches CDN edges).
- **SegmentError enum**: replaces the `bool` return in `download_segment_with_speed_check`, surfacing error detail (e.g. \`error decoding response body\`) in segment-failure logs.
- **mapBackendError**: extracts `VIDEO_ERROR_MAP` + `mapBackendError` into \`src/shared/lib/\` and applies it in `PartStatusRow` / `PartDownloadProgress`, so \`ERR::NETWORK\` etc. show localized messages instead of raw codes.
- **Download-failed toast**: adds a copy button (copies the displayed text) and a retry hint for transient Bilibili-side errors (\`NETWORK\` / \`INVALID_MEDIA_RESPONSE\` / \`AUDIO_DOWNLOAD_FAILED\` / \`RATE_LIMITED\`).

## Related Issue

Closes #482

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Test Plan

- [x] \`cargo build\` compiles / \`cargo fmt\`
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm run test\` (169 passed)
- [x] Manual: confirmed \`playurl refetch attempt=2\` in app.log on retry
- [x] Manual: DL succeeded after retry+refetch recovered transient CDN errors
- [x] Manual: \`ERR::NETWORK\` shows localized message in the download status dialog
- [x] i18n key count matches across all 6 locales (677)

## Checklist

- [x] /review-all executed
- [x] Conventional Commits format followed
- [x] Tests added (mapBackendError.test.ts, 6 cases)
- [x] i18n files synced (6 languages)