### PR TITLE
fix(e2e): launch single window in E2E mode to avoid webdriver session break

### DIFF
--- a/e2e-tests/test/app-launch.e2e.ts
+++ b/e2e-tests/test/app-launch.e2e.ts
@@ -57,7 +57,12 @@ describe('bilibili-downloader-gui E2E', () => {
 
   // -- Phase 0: App Launch & Initialization --
 
-  it('should show splash screen on launch', async () => {
+  // NOTE: Skipped because in E2E mode (E2E_TESTING) the app launches directly
+  // into the main window without a standalone splash window. This works around
+  // tauri-plugin-webdriver v0.2 not switching the WebDriver session when the
+  // splash window is closed. The splash UI itself is covered by manual
+  // verification and component-level checks.
+  it.skip('should show splash screen on launch', async () => {
     const container = await browser.$(S.INIT_CONTAINER)
     await container.waitForExist({ timeout: 15_000 })
 

--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -54,6 +54,16 @@ pub struct InitResult {
 /// preserved (login-method branching, ffmpeg install, user fetch).
 #[tauri::command]
 pub async fn initialize(app: AppHandle) -> Result<(), String> {
+    // Idempotency guard: `initialize` may be invoked from both the splash
+    // window (useSplashLifecycle) and the main window (useInit.initApp, used
+    // in E2E mode where there is no splash). The AtomicBool guarantees the
+    // heavy init (cleanup, ffmpeg, session restore, user fetch) runs at most
+    // once per process; the second caller returns immediately.
+    let init_guard = app.state::<std::sync::atomic::AtomicBool>();
+    if init_guard.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        return Ok(());
+    }
+
     // 1. Clean up orphaned temp files from previous sessions.
     emit_step(&app, "init.cleanup_in_progress");
     let _ = cleanup::cleanup_temp_files(&app, None);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -270,10 +270,30 @@ pub fn run() {
                 }
             }
 
-            // Create the splash window first. The main window is created by
-            // finish_splash once initialization completes, so the maximized
-            // restore never races a splash-time geometry lock.
-            window::create_splash_window(app.handle(), window_theme, language)?;
+            // Idempotency flag for the `initialize` command. It can be called
+            // from both the splash window and the main window (E2E mode), so
+            // this guarantees the heavy init runs at most once per process.
+            app.manage(std::sync::atomic::AtomicBool::new(false));
+
+            if crate::handlers::qr_login::is_e2e_testing() {
+                // E2E mode: skip the standalone splash window. tauri-plugin-
+                // webdriver v0.2 pins the WebDriver session to whichever window
+                // exists at session creation and never switches when that
+                // window is later closed, so the 2-window splash→main handoff
+                // (finish_splash closing the splash) leaves the session pointing
+                // at a closed window → "No window could be found" for every
+                // subsequent command. Creating only the main window keeps the
+                // session valid for the whole test suite. Backend init then
+                // runs from the main window via useInit.initApp
+                // (→ invoke('initialize')) instead of from the splash.
+                window::create_main_window(app.handle(), window_theme)?;
+                window::register_main_window_events(app.handle());
+            } else {
+                // Create the splash window first. The main window is created by
+                // finish_splash once initialization completes, so the maximized
+                // restore never races a splash-time geometry lock.
+                window::create_splash_window(app.handle(), window_theme, language)?;
+            }
 
             // Initialize logging plugin with app_data_dir/logs path
             let log_dir = app

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -223,9 +223,11 @@ pub async fn finish_splash(app: AppHandle) -> Result<(), String> {
 }
 
 /// Registers close/resize/move handlers (and opens devtools in debug) on the
-/// main window. Must run AFTER the main window is created (in finish_splash),
-/// since it doesn't exist at setup time anymore (only the splash does).
-fn register_main_window_events(app: &AppHandle) {
+/// main window. Must run AFTER the main window is created. In normal mode this
+/// is called from `finish_splash` (after the splash creates the main window);
+/// in E2E mode it is called directly from `setup` because the splash window is
+/// skipped.
+pub(crate) fn register_main_window_events(app: &AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
     };

--- a/src/features/init/hooks/useInit.tsx
+++ b/src/features/init/hooks/useInit.tsx
@@ -85,6 +85,14 @@ export const useInit = () => {
     // OS detection is fire-and-forget (frontend-only, cheap).
     getOs()
 
+    // Run backend initialization before reading the result. In normal mode the
+    // splash window already ran `initialize`; it is idempotent (AtomicBool
+    // guard in the backend), so this is a no-op then. In E2E mode there is no
+    // splash window, so this is where init actually runs.
+    await invoke('initialize').catch((e) => {
+      logger.error('initApp: initialize failed', e)
+    })
+
     let result: InitResult
     try {
       result = await invoke<InitResult>('get_init_result')


### PR DESCRIPTION
## Summary

Fixes the E2E test regression introduced by the standalone splash window (2-window model, commit `b6fa725`). `tauri-plugin-webdriver` v0.2 pins the WebDriver session to whichever window exists at session creation and never switches when that window is closed, so once `finish_splash` closed the splash window, every subsequent command failed with **"No window could be found"** — 8 of 9 E2E tests failed (only the splash-on-launch test passed, since it ran inside the splash window).

This PR adds an E2E-mode branch that launches a single main window directly (no standalone splash) when `E2E_TESTING` is set, sidestepping the webdriver limitation entirely. Product behavior (the splash 2-window model in normal mode) is unchanged.

Root cause confirmed from the CI logs: after `finish_splash` (`create_main_window` + `splash.close()`), the session kept pointing at the closed splash and never fell back to main. This is a `tauri-plugin-webdriver` v0.2 design limitation (`close_window` does not update `current_window`), not a flaky test.

## Related Issue

N/A (no open issue found)

## Type of Change

- [x] 🐛 Bug fix

## Changes

- **`src-tauri/src/lib.rs`**: `setup` now branches on `is_e2e_testing()` — creates the main window directly (skipping the splash) in E2E mode, keeps the splash-first flow otherwise. Also manages an `AtomicBool` for init idempotency.
- **`src-tauri/src/handlers/init.rs`**: `initialize()` guarded with an `AtomicBool` so it runs at most once (splash and main may both invoke it).
- **`src-tauri/src/window.rs`**: `register_main_window_events` exposed as `pub(crate)` so `setup` can call it directly in E2E mode.
- **`src/features/init/hooks/useInit.tsx`**: `initApp` now invokes `initialize` before `get_init_result`, so backend init runs from the main window when there is no splash (idempotent no-op in normal mode where the splash already ran it).
- **`e2e-tests/test/app-launch.e2e.ts`**: the "should show splash screen on launch" test is skipped (no standalone splash window in E2E mode).

## Test Plan

- [ ] E2E workflow (`.github/workflows/e2e.yml`) passes on this PR
- [ ] Normal mode (`npm run tauri dev`): splash → main flow unchanged (no regression)

## Breaking Changes

None. E2E-mode behavior is gated behind the `E2E_TESTING` env var (CI only); the product's splash 2-window model in normal mode is preserved.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (E2E test adjusted)
- [x] i18n files synced (N/A — no user-facing string changes)