### PR TITLE
feat(download): add H.265 (HEVC) / AV1 codec priority for smaller file sizes

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -34,6 +34,7 @@
 //! - `ERR::API_ERROR` - Generic API request failure
 //! - `ERR::BANGUMI_*` - Bangumi-specific errors (VIP only, region restricted, etc.)
 
+use crate::utils::codec::{select_video_stream, VideoStreamSelection, CODECID_AVC};
 use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 
@@ -85,6 +86,10 @@ pub struct QualityResolvedPayload {
     pub video_quality: i32,
     /// Whether video quality was fallen back from user selection
     pub video_quality_fallback: bool,
+    /// Resolved video codec ID
+    pub video_codecid: i16,
+    /// Whether video codec was fallen back from user selection
+    pub video_codec_fallback: bool,
     /// Resolved audio quality ID (null for durl format)
     pub audio_quality: Option<i32>,
     /// Whether audio quality was fallen back from user selection
@@ -404,6 +409,11 @@ async fn download_bangumi_durl(
             video_quality: resolved_quality,
             video_quality_fallback: options.quality.is_some()
                 && options.quality != Some(resolved_quality),
+            // Constraint: durl format delivers a single muxed stream — Bilibili
+            // fixes the codec (AVC in practice) and exposes no codec choice, so
+            // priority is irrelevant and fallback is always false (issue #460).
+            video_codecid: CODECID_AVC,
+            video_codec_fallback: false,
             audio_quality: None, // durl format has no separate audio
             audio_quality_fallback: false,
             is_preview,
@@ -627,6 +637,12 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                     page,
                     video_quality: resolved_video_quality,
                     video_quality_fallback,
+                    // Constraint: durl format delivers a single muxed stream —
+                    // Bilibili fixes the codec (AVC in practice) and exposes no
+                    // codec choice, so priority is irrelevant and fallback is
+                    // always false (issue #460).
+                    video_codecid: CODECID_AVC,
+                    video_codec_fallback: false,
                     audio_quality: None, // durl format has no separate audio
                     audio_quality_fallback: false,
                     is_preview: None,
@@ -726,22 +742,37 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         dash_data.extra.keys().collect::<Vec<_>>(),
     );
 
+    // Resolve codec priority and filter streams. Falls back to all streams
+    // when the preferred codec is unavailable so the download never fails.
+    let (streams_for_selection, codec_selection) =
+        select_streams_by_codec_priority(app, &dash_data.video).await;
+
     // Fallback if selected quality is unavailable (first = highest quality)
     // None means best available → -1 won't match any real quality ID.
     let requested_quality = options.quality.unwrap_or(-1);
+
     let (video_url, video_backup_urls, raw_video_fallback) =
-        select_stream_url(&dash_data.video, requested_quality)?;
+        select_stream_url(&streams_for_selection, requested_quality)?;
     // Only treat as fallback when the user explicitly selected a quality.
     // When quality is None (accordion never opened), the best-available
     // selection is intentional and should not trigger the warning icon.
     let video_quality_fallback = options.quality.is_some() && raw_video_fallback;
-    // Get the actual resolved video quality ID
-    let resolved_video_quality = dash_data
+    // Get the actual resolved video quality ID and codec ID
+    let (resolved_video_quality, resolved_video_codecid) = dash_data
         .video
         .iter()
         .find(|v| v.base_url == video_url)
-        .map(|v| v.id)
-        .unwrap_or(requested_quality);
+        .map(|v| (v.id, v.codecid))
+        .unwrap_or((requested_quality, CODECID_AVC));
+
+    // True when the preferred codec was unavailable: either a lower-priority
+    // codec was selected (fallback flag), or no priority codec existed at all
+    // (None → fell back to all streams). The latter must also warn so users
+    // notice when e.g. an H.264-only preference silently gets HEVC/AV1.
+    let video_codec_fallback = codec_selection
+        .as_ref()
+        .map(|sel| sel.fallback)
+        .unwrap_or(true);
 
     let audio_quality = options
         .audio_quality
@@ -773,6 +804,8 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             page,
             video_quality: resolved_video_quality,
             video_quality_fallback,
+            video_codecid: resolved_video_codecid,
+            video_codec_fallback,
             audio_quality: resolved_audio_quality,
             audio_quality_fallback,
             is_preview: bangumi_preview_info,
@@ -859,8 +892,10 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                             "[BE] download_video: playurl refetch attempt={} for video",
                             attempt
                         );
-                        match refetch_dash_urls(&cookies, &bvid, v_cid, v_ep_id, v_quality, None)
-                            .await
+                        match refetch_dash_urls(
+                            app, &cookies, &bvid, v_cid, v_ep_id, v_quality, None,
+                        )
+                        .await
                         {
                             Ok(fresh) => (fresh.video_url, fresh.video_backup_urls),
                             Err(e) => {
@@ -1400,7 +1435,7 @@ async fn download_audio_with_fallback(
                     attempt
                 );
                 // video_quality = -1 (best) is unused; only the audio slot matters.
-                match refetch_dash_urls(&cookies, &bvid, a_cid, a_ep_id, -1, a_quality).await {
+                match refetch_dash_urls(app, &cookies, &bvid, a_cid, a_ep_id, -1, a_quality).await {
                     Ok(fresh) => (fresh.audio_url, fresh.audio_backup_urls),
                     Err(e) => {
                         log::warn!("[BE] audio refetch failed, retrying with stale URL: {}", e);
@@ -2278,6 +2313,50 @@ fn select_stream_url(
                 .map(|v| (v.base_url.clone(), v.backup_urls.clone(), true))
         })
         .ok_or_else(|| "ERR::QUALITY_NOT_FOUND".into())
+}
+
+/// Resolves the user's codec priority and filters video streams accordingly.
+///
+/// Reads the codec priority setting once and returns:
+/// - The streams to use for quality selection: filtered by the preferred
+///   codec, or all streams when the preferred codec is unavailable for any
+///   quality (so the download never fails).
+/// - The codec selection result, used by callers to detect codec fallback.
+///   `None` means no priority codec was available at all (caller treats this
+///   as a codec fallback for warning purposes).
+///
+/// Shared by `download_video` and `refetch_dash_urls` to keep the codec
+/// selection logic in a single place.
+async fn select_streams_by_codec_priority(
+    app: &AppHandle,
+    video_streams: &[XPlayerApiResponseVideo],
+) -> (Vec<XPlayerApiResponseVideo>, Option<VideoStreamSelection>) {
+    let codec_priority = settings::get_settings(app)
+        .await
+        .ok()
+        .and_then(|s| s.video_codec_priority)
+        .unwrap_or_default();
+
+    let available_codecs: Vec<i16> = video_streams.iter().map(|v| v.codecid).collect();
+    let codec_selection = select_video_stream(&codec_priority, &available_codecs);
+
+    let filtered: Vec<_> = video_streams
+        .iter()
+        .filter(|v| {
+            codec_selection
+                .as_ref()
+                .map(|sel| v.codecid == sel.codecid)
+                .unwrap_or(true)
+        })
+        .cloned()
+        .collect();
+
+    if filtered.is_empty() {
+        log::info!("[BE] no streams with preferred codec, using all streams");
+        (video_streams.to_vec(), codec_selection)
+    } else {
+        (filtered, codec_selection)
+    }
 }
 
 /// Response from Bilibili watch history API.
@@ -3385,6 +3464,7 @@ struct AudioRefetchCtx {
 /// audio quality). On error, callers fall back to the stale captured URL
 /// (see the retry closures) rather than aborting the retry loop.
 async fn refetch_dash_urls(
+    app: &AppHandle,
     cookies: &[CookieEntry],
     bvid: &str,
     cid: i64,
@@ -3410,7 +3490,12 @@ async fn refetch_dash_urls(
     let dash = data
         .dash
         .ok_or_else(|| "refetch_dash_urls: playurl response has no dash".to_string())?;
-    let (video_url, video_backup_urls, _) = select_stream_url(&dash.video, video_quality)?;
+
+    // Reuse the same codec-aware stream selection as the initial download so
+    // a retry picks the same codec (keeps the merged output consistent).
+    let (streams_for_selection, _) = select_streams_by_codec_priority(app, &dash.video).await;
+    let (video_url, video_backup_urls, _) =
+        select_stream_url(&streams_for_selection, video_quality)?;
     let resolved_audio_quality =
         audio_quality.unwrap_or_else(|| dash.audio.first().map(|a| a.id).unwrap_or(30280));
     let (audio_url, audio_backup_urls, _) = select_stream_url(&dash.audio, resolved_audio_quality)?;

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -1,5 +1,6 @@
 //! Application settings persisted to settings.json
 
+use crate::utils::codec::VideoCodecPriority;
 use serde::{Deserialize, Serialize};
 
 /// Title replacement rule for filename sanitization.
@@ -186,6 +187,13 @@ pub struct Settings {
     /// UI theme preference. Defaults to system preference if not set.
     #[serde(rename = "theme", default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<UiTheme>,
+    /// Video codec priority preference. Defaults to AV1-first if not set.
+    #[serde(
+        rename = "videoCodecPriority",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub video_codec_priority: Option<VideoCodecPriority>,
 }
 
 /// Trim mode for the MP4 trimming feature.

--- a/src-tauri/src/utils/codec.rs
+++ b/src-tauri/src/utils/codec.rs
@@ -1,0 +1,234 @@
+//! Video codec selection utilities.
+//!
+//! This module provides functionality for selecting video streams based on
+//! codec priority preferences. It supports AV1, H.265 (HEVC), and H.264 (AVC)
+//! codecs with configurable fallback behavior.
+
+use serde::{Deserialize, Serialize};
+
+/// Video codec IDs as defined by Bilibili DASH API.
+///
+/// References:
+/// - AVC: https://en.wikipedia.org/wiki/Advanced_Video_Coding
+/// - HEVC: https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding
+/// - AV1: https://en.wikipedia.org/wiki/AV1
+pub const CODECID_AVC: i16 = 7;
+pub const CODECID_HEVC: i16 = 12;
+pub const CODECID_AV1: i16 = 13;
+
+/// Video codec priority preference.
+///
+/// Determines the order of codec selection with automatic fallback to
+/// lower-priority codecs if the preferred codec is not available.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub enum VideoCodecPriority {
+    /// Prefer AV1, fallback to H.265, then H.264 (default).
+    ///
+    /// AV1 provides the best compression efficiency but may not be available
+    /// for all videos. This mode offers the smallest file sizes when AV1 is available.
+    #[default]
+    #[serde(rename = "av1First")]
+    Av1First,
+    /// Prefer H.265 (HEVC), fallback to H.264 only.
+    ///
+    /// H.265 offers better compression than H.264 with broader availability than AV1.
+    /// This mode balances compression efficiency and compatibility.
+    #[serde(rename = "hevcFirst")]
+    HevcFirst,
+    /// Prefer H.264 (AVC) only.
+    ///
+    /// H.264 has the widest device and player compatibility but larger file sizes.
+    /// This mode prioritizes compatibility over compression efficiency.
+    #[serde(rename = "avcOnly")]
+    AvcOnly,
+}
+
+impl VideoCodecPriority {
+    /// Returns codec ID priority list in order of preference.
+    ///
+    /// # Returns
+    ///
+    /// A vector of codec IDs ordered from highest to lowest priority.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bilibili_downloader_gui_lib::utils::codec::{
+    ///     VideoCodecPriority, CODECID_AV1, CODECID_HEVC, CODECID_AVC,
+    /// };
+    /// let priority = VideoCodecPriority::Av1First;
+    /// assert_eq!(priority.codec_ids(), vec![CODECID_AV1, CODECID_HEVC, CODECID_AVC]);
+    /// ```
+    pub fn codec_ids(&self) -> Vec<i16> {
+        // Constraint: fallback is downward-only — the preferred codec is the
+        // ceiling. Each list only includes less-compressed (more compatible)
+        // codecs below the preference, so e.g. HevcFirst never falls back up
+        // to AV1. This bounds file size by the user's stated preference (issue #460).
+        match self {
+            VideoCodecPriority::Av1First => vec![CODECID_AV1, CODECID_HEVC, CODECID_AVC],
+            VideoCodecPriority::HevcFirst => vec![CODECID_HEVC, CODECID_AVC],
+            VideoCodecPriority::AvcOnly => vec![CODECID_AVC],
+        }
+    }
+}
+
+/// Result of video stream selection.
+///
+/// Contains the selected codec ID and whether fallback occurred. The actual
+/// stream URL/quality selection is handled separately by `select_stream_url`;
+/// this only carries the codec decision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoStreamSelection {
+    /// Selected video codec ID.
+    pub codecid: i16,
+    /// Whether fallback occurred (selected codec differs from first preference).
+    pub fallback: bool,
+}
+
+/// Selects the best video codec based on priority and available codecs.
+///
+/// Scans the priority list in order and returns the first codec that is
+/// available. `fallback` is true when the selected codec is not the
+/// top-preference (i.e. a lower-priority codec was used).
+///
+/// # Arguments
+///
+/// * `priority` - Codec priority preference
+/// * `available_codecs` - Available codec IDs from DASH streams
+///
+/// # Returns
+///
+/// `Some(VideoStreamSelection)` when a priority codec is available,
+/// `None` when none of the preferred codecs are available (caller falls
+/// back to all streams).
+///
+/// # Examples
+///
+/// ```
+/// use bilibili_downloader_gui_lib::utils::codec::{
+///     select_video_stream, VideoCodecPriority, CODECID_HEVC, CODECID_AVC,
+/// };
+/// let priority = VideoCodecPriority::Av1First;
+/// let available = vec![CODECID_HEVC, CODECID_AVC];
+/// let selection = select_video_stream(&priority, &available).unwrap();
+/// assert_eq!(selection.codecid, CODECID_HEVC);
+/// assert!(selection.fallback);
+/// ```
+pub fn select_video_stream(
+    priority: &VideoCodecPriority,
+    available_codecs: &[i16],
+) -> Option<VideoStreamSelection> {
+    let priority_list = priority.codec_ids();
+
+    for (index, &codecid) in priority_list.iter().enumerate() {
+        if available_codecs.contains(&codecid) {
+            return Some(VideoStreamSelection {
+                codecid,
+                fallback: index > 0,
+            });
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_codec_constants() {
+        assert_eq!(CODECID_AVC, 7);
+        assert_eq!(CODECID_HEVC, 12);
+        assert_eq!(CODECID_AV1, 13);
+    }
+
+    #[test]
+    fn test_codec_ids() {
+        assert_eq!(
+            VideoCodecPriority::Av1First.codec_ids(),
+            vec![CODECID_AV1, CODECID_HEVC, CODECID_AVC]
+        );
+        assert_eq!(
+            VideoCodecPriority::HevcFirst.codec_ids(),
+            vec![CODECID_HEVC, CODECID_AVC]
+        );
+        assert_eq!(VideoCodecPriority::AvcOnly.codec_ids(), vec![CODECID_AVC]);
+    }
+
+    #[test]
+    fn test_select_video_stream_av1_available() {
+        let priority = VideoCodecPriority::Av1First;
+        let available = vec![CODECID_AV1, CODECID_HEVC, CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_AV1);
+        assert!(!selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_av1_fallback_to_hevc() {
+        let priority = VideoCodecPriority::Av1First;
+        let available = vec![CODECID_HEVC, CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_HEVC);
+        assert!(selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_av1_fallback_to_avc() {
+        let priority = VideoCodecPriority::Av1First;
+        let available = vec![CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_AVC);
+        assert!(selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_hevc_first_no_fallback() {
+        let priority = VideoCodecPriority::HevcFirst;
+        let available = vec![CODECID_HEVC, CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_HEVC);
+        assert!(!selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_hevc_first_fallback_to_avc() {
+        let priority = VideoCodecPriority::HevcFirst;
+        let available = vec![CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_AVC);
+        assert!(selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_avc_only_no_fallback() {
+        let priority = VideoCodecPriority::AvcOnly;
+        let available = vec![CODECID_AVC];
+
+        let selection = select_video_stream(&priority, &available).unwrap();
+        assert_eq!(selection.codecid, CODECID_AVC);
+        assert!(!selection.fallback);
+    }
+
+    #[test]
+    fn test_select_video_stream_no_match() {
+        let priority = VideoCodecPriority::Av1First;
+        let available = vec![999]; // Unknown codec
+
+        let selection = select_video_stream(&priority, &available);
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn test_default_codec_priority() {
+        let default = VideoCodecPriority::default();
+        assert_eq!(default, VideoCodecPriority::Av1First);
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -5,6 +5,7 @@
 //! filename sanitization, error handling, and log cleanup.
 
 pub mod analytics;
+pub mod codec;
 pub mod downloads;
 pub mod error_handler;
 pub mod ffmpeg_probe;

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -730,6 +730,130 @@ function SettingsForm() {
         <Separator />
         <div className="space-y-2">
           <div className="space-y-0.5">
+            <Label>{t('settings.video_codec_priority_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.video_codec_priority_description')}
+            </p>
+          </div>
+          <TooltipProvider>
+            <RadioGroup
+              value={settings.videoCodecPriority ?? 'av1First'}
+              onValueChange={(value) => {
+                saveByForm({
+                  ...settings,
+                  videoCodecPriority: value as
+                    | 'av1First'
+                    | 'hevcFirst'
+                    | 'avcOnly',
+                })
+              }}
+              className="grid grid-cols-3 gap-4"
+            >
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="av1First" id="codec-av1" />
+                <div className="flex-1">
+                  <Label
+                    htmlFor="codec-av1"
+                    className="flex items-center gap-1 whitespace-nowrap"
+                  >
+                    {t('settings.video_codec_av1_first')}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={(e) => e.preventDefault()}
+                          className="text-muted-foreground hover:text-foreground"
+                          aria-label={t(
+                            'settings.video_codec_av1_first_description',
+                          )}
+                        >
+                          <Info className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="max-w-xs">
+                          {t('settings.video_codec_av1_first_description')}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </Label>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {t('settings.video_codec_av1_first_chain')}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="hevcFirst" id="codec-hevc" />
+                <div className="flex-1">
+                  <Label
+                    htmlFor="codec-hevc"
+                    className="flex items-center gap-1 whitespace-nowrap"
+                  >
+                    {t('settings.video_codec_hevc_first')}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={(e) => e.preventDefault()}
+                          className="text-muted-foreground hover:text-foreground"
+                          aria-label={t(
+                            'settings.video_codec_hevc_first_description',
+                          )}
+                        >
+                          <Info className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="max-w-xs">
+                          {t('settings.video_codec_hevc_first_description')}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </Label>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {t('settings.video_codec_hevc_first_chain')}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="avcOnly" id="codec-avc" />
+                <div className="flex-1">
+                  <Label
+                    htmlFor="codec-avc"
+                    className="flex items-center gap-1 whitespace-nowrap"
+                  >
+                    {t('settings.video_codec_avc_only')}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={(e) => e.preventDefault()}
+                          className="text-muted-foreground hover:text-foreground"
+                          aria-label={t(
+                            'settings.video_codec_avc_only_description',
+                          )}
+                        >
+                          <Info className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="max-w-xs">
+                          {t('settings.video_codec_avc_only_description')}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </Label>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {t('settings.video_codec_avc_only_chain')}
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+          </TooltipProvider>
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <div className="space-y-0.5">
             <Label>{t('settings.rotation_mode_label')}</Label>
             <p className="text-muted-foreground text-sm">
               {t('settings.rotation_mode_description')}

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -23,6 +23,7 @@ const initialState: SettingsState = {
   theme: 'light',
   showTaskbarProgress: true,
   flashTaskbarOnComplete: true,
+  videoCodecPriority: 'av1First',
 }
 
 /**

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -115,6 +115,11 @@ export interface Settings {
    * Defaults to true if not specified.
    */
   flashTaskbarOnComplete?: boolean
+  /**
+   * Video codec priority preference.
+   * Defaults to 'av1First' if not specified.
+   */
+  videoCodecPriority?: VideoCodecPriority
 }
 
 /**
@@ -158,6 +163,14 @@ export type RotationAngle = 90 | 180 | 270
  * - reencode: Re-encode with transpose filter, works in all players
  */
 export type RotationMode = 'copy' | 'reencode'
+
+/**
+ * Video codec priority preference.
+ * - av1First: Prefer AV1, fallback to HEVC, then AVC (default - best compression)
+ * - hevcFirst: Prefer HEVC, fallback to AVC (balance)
+ * - avcOnly: Prefer AVC only (best compatibility)
+ */
+export type VideoCodecPriority = 'av1First' | 'hevcFirst' | 'avcOnly'
 
 /**
  * Supported language codes for the application.

--- a/src/features/video/lib/constants.ts
+++ b/src/features/video/lib/constants.ts
@@ -39,3 +39,24 @@ export const AUDIO_QUALITIES_MAP: Record<number, string> = {
 export const AUDIO_QUALITIES_ORDER: number[] = [
   30251, 30250, 30280, 30232, 30216,
 ]
+
+/**
+ * Video codec IDs as defined by Bilibili DASH API.
+ *
+ * References:
+ * - AVC: https://en.wikipedia.org/wiki/Advanced_Video_Coding
+ * - HEVC: https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding
+ * - AV1: https://en.wikipedia.org/wiki/AV1
+ */
+export const CODECID_AVC: number = 7
+export const CODECID_HEVC: number = 12
+export const CODECID_AV1: number = 13
+
+/**
+ * Mapping of video codec IDs to display labels.
+ */
+export const VIDEO_CODEC_MAP: Record<number, string> = {
+  [CODECID_AVC]: 'AVC',
+  [CODECID_HEVC]: 'HEVC',
+  [CODECID_AV1]: 'AV1',
+}

--- a/src/features/video/model/inputSlice.ts
+++ b/src/features/video/model/inputSlice.ts
@@ -340,6 +340,8 @@ export const inputSlice = createSlice({
         page: number
         videoQuality: number
         videoQualityFallback: boolean
+        videoCodecid: number
+        videoCodecFallback: boolean
         audioQuality: number | null
         audioQualityFallback: boolean
         isPreview: boolean | null

--- a/src/features/video/types.ts
+++ b/src/features/video/types.ts
@@ -196,6 +196,10 @@ export type ResolvedQuality = {
   videoQuality: number
   /** Whether video quality was fallen back from user selection */
   videoQualityFallback: boolean
+  /** Resolved video codec ID */
+  videoCodecid: number
+  /** Whether video codec was fallen back from user selection */
+  videoCodecFallback: boolean
   /** Resolved audio quality ID (null for durl format) */
   audioQuality: number | null
   /** Whether audio quality was fallen back from user selection */

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -17,6 +17,7 @@ import { usePartDownloadStatus } from '@/features/video/hooks/usePartDownloadSta
 import {
   AUDIO_QUALITIES_MAP,
   AUDIO_QUALITIES_ORDER,
+  VIDEO_CODEC_MAP,
   VIDEO_QUALITIES_MAP,
 } from '@/features/video/lib/constants'
 import { buildVideoFormSchema2 } from '@/features/video/lib/formSchema'
@@ -234,7 +235,12 @@ const VideoPartCard = memo(function VideoPartCard({
       const videoLabel =
         VIDEO_QUALITIES_MAP[resolvedQuality.videoQuality] ||
         String(resolvedQuality.videoQuality)
-      parts.push(videoLabel)
+      // Append codec in parentheses so the video attributes (quality + codec)
+      // read as a single unit, visually separate from the audio quality.
+      const codecLabel =
+        VIDEO_CODEC_MAP[resolvedQuality.videoCodecid] ||
+        String(resolvedQuality.videoCodecid)
+      parts.push(`${videoLabel}(${codecLabel})`)
 
       if (resolvedQuality.audioQuality !== null) {
         const audioLabel =
@@ -269,6 +275,7 @@ const VideoPartCard = memo(function VideoPartCard({
     if (!resolvedQuality) return false
     return (
       resolvedQuality.videoQualityFallback ||
+      resolvedQuality.videoCodecFallback ||
       resolvedQuality.audioQualityFallback
     )
   }, [resolvedQuality])

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "Taskbar Progress",
     "taskbar_progress_description": "Show download progress on the taskbar.",
     "flash_taskbar_on_complete_label": "Flash Taskbar on Completion",
-    "flash_taskbar_on_complete_description": "Flash the taskbar button when downloads finish."
+    "flash_taskbar_on_complete_description": "Flash the taskbar button when downloads finish.",
+    "video_codec_priority_label": "Video Codec Priority",
+    "video_codec_priority_description": "Choose the preferred video codec for downloads. Higher-priority codecs offer better compression but may not be available for all videos.",
+    "video_codec_av1_first": "AV1 First (High Compression)",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "Prefer AV1 for smallest file sizes, fallback to H.265, then H.264 if unavailable.",
+    "video_codec_hevc_first": "H.265 First (Balance)",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "Prefer H.265 (HEVC) for good compression with broad availability, fallback to H.264 if unavailable.",
+    "video_codec_avc_only": "H.264 Only (Compatibility)",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "Always use H.264 (AVC) for maximum device and player compatibility."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "Progreso en la barra de tareas",
     "taskbar_progress_description": "Muestra el progreso de descarga en la barra de tareas.",
     "flash_taskbar_on_complete_label": "Parpadear barra al completar",
-    "flash_taskbar_on_complete_description": "Hace parpadear el botón de la barra de tareas al terminar."
+    "flash_taskbar_on_complete_description": "Hace parpadear el botón de la barra de tareas al terminar.",
+    "video_codec_priority_label": "Prioridad de códec de video",
+    "video_codec_priority_description": "Elige el códec de video preferido para descargas. Códecs con mayor prioridad ofrecen mejor compresión pero pueden no estar disponibles en todos los videos.",
+    "video_codec_av1_first": "AV1 Primero (Alta Compresión)",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "Prefiere AV1 para los tamaños de archivo más pequeños, retrocede a H.265, luego H.264 si no está disponible.",
+    "video_codec_hevc_first": "H.265 Primero (Equilibrio)",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "Prefiere H.265 (HEVC) para buena compresión con amplia disponibilidad, retrocede a H.264 si no está disponible.",
+    "video_codec_avc_only": "H.264 Solo (Compatibilidad)",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "Siempre usa H.264 (AVC) para máxima compatibilidad de dispositivos y reproductores."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "Progression dans la barre des tâches",
     "taskbar_progress_description": "Affiche la progression du téléchargement dans la barre des tâches.",
     "flash_taskbar_on_complete_label": "Faire clignoter la barre à la fin",
-    "flash_taskbar_on_complete_description": "Fait clignoter le bouton de la barre des tâches à la fin des téléchargements."
+    "flash_taskbar_on_complete_description": "Fait clignoter le bouton de la barre des tâches à la fin des téléchargements.",
+    "video_codec_priority_label": "Priorité du codec vidéo",
+    "video_codec_priority_description": "Choisissez le codec vidéo préféré pour les téléchargements. Les codecs avec une priorité plus élevée offrent une meilleure compression mais peuvent ne pas être disponibles pour toutes les vidéos.",
+    "video_codec_av1_first": "AV1 d'abord (Haute Compression)",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "Préfère AV1 pour les plus petites tailles de fichier, retourne à H.265, puis H.264 si indisponible.",
+    "video_codec_hevc_first": "H.265 d'abord (Équilibre)",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "Préfère H.265 (HEVC) pour une bonne compression avec une large disponibilité, retourne à H.264 si indisponible.",
+    "video_codec_avc_only": "H.264 uniquement (Compatibilité)",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "Utilise toujours H.264 (AVC) pour une compatibilité maximale des appareils et lecteurs."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "タスクバー進捗",
     "taskbar_progress_description": "タスクバーにダウンロード進捗を表示します。",
     "flash_taskbar_on_complete_label": "完了時にタスクバーを点滅",
-    "flash_taskbar_on_complete_description": "ダウンロード完了時にタスクバーボタンを点滅させます。"
+    "flash_taskbar_on_complete_description": "ダウンロード完了時にタスクバーボタンを点滅させます。",
+    "video_codec_priority_label": "ビデオコーデックの優先順位",
+    "video_codec_priority_description": "ダウンロード時に優先するビデオコーデックを選択します。上位のコーデックほど圧縮効率が高いですが、すべての動画で利用できるとは限りません。",
+    "video_codec_av1_first": "AV1優先（高圧縮）",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "AV1を優先して最小ファイルサイズを実現、利用不可の場合はH.265、H.264の順にフォールバック。",
+    "video_codec_hevc_first": "H.265優先（バランス）",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "H.265（HEVC）を優先して高い圧縮率と広い互換性を両立、利用不可の場合はH.264にフォールバック。",
+    "video_codec_avc_only": "H.264のみ（高互換）",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "常にH.264（AVC）を使用して最大限のデバイス/プレイヤー互換性を確保。"
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "작업 표시줄 진행률",
     "taskbar_progress_description": "작업 표시줄에 다운로드 진행률을 표시합니다.",
     "flash_taskbar_on_complete_label": "완료 시 작업 표시줄 깜빡임",
-    "flash_taskbar_on_complete_description": "다운로드 완료 시 작업 표시줄 버튼을 깜빡입니다."
+    "flash_taskbar_on_complete_description": "다운로드 완료 시 작업 표시줄 버튼을 깜빡입니다.",
+    "video_codec_priority_label": "비디오 코덱 우선순위",
+    "video_codec_priority_description": "다운로드 시 선호하는 비디오 코덱을 선택합니다. 우선순위가 높은 코덱은 더 나은 압축을 제공하지만 모든 비디오에서 사용 가능하지는 않습니다.",
+    "video_codec_av1_first": "AV1 우선 (고압축)",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "AV1을 우선하여 최소 파일 크기 실현, 사용 불가능 시 H.265, H.264 순으로 폴백.",
+    "video_codec_hevc_first": "H.265 우선 (균형)",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "H.265(HEVC)를 우선하여 높은 압축률과 광범위한 호환성 균형, 사용 불가능 시 H.264로 폴백.",
+    "video_codec_avc_only": "H.264만 (호환성)",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "항상 H.264(AVC)를 사용하여 최대한의 장치/재생기 호환성 보장."
   },
   "validation": {
     "path": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -451,7 +451,18 @@
     "taskbar_progress_label": "任务栏进度",
     "taskbar_progress_description": "在任务栏显示下载进度。",
     "flash_taskbar_on_complete_label": "完成时闪烁任务栏",
-    "flash_taskbar_on_complete_description": "下载完成时闪烁任务栏按钮。"
+    "flash_taskbar_on_complete_description": "下载完成时闪烁任务栏按钮。",
+    "video_codec_priority_label": "视频编解码器优先级",
+    "video_codec_priority_description": "选择下载时首选的视频编解码器。优先级更高的编解码器提供更好的压缩效果，但并非所有视频都可用。",
+    "video_codec_av1_first": "AV1优先（高压缩）",
+    "video_codec_av1_first_chain": "AV1 → H.265 → H.264",
+    "video_codec_av1_first_description": "优先使用AV1获得最小文件大小，若不可用则降级至H.265，再降级至H.264。",
+    "video_codec_hevc_first": "H.265优先（平衡）",
+    "video_codec_hevc_first_chain": "H.265 → H.264",
+    "video_codec_hevc_first_description": "优先使用H.265（HEVC）在压缩率和可用性间取得平衡，若不可用则降级至H.264。",
+    "video_codec_avc_only": "H.264优先（兼容）",
+    "video_codec_avc_only_chain": "H.264",
+    "video_codec_avc_only_description": "始终使用H.264（AVC）以确保最大的设备和播放器兼容性。"
   },
   "validation": {
     "path": {


### PR DESCRIPTION
## Summary

Add video codec priority selection (AV1-first / HEVC-first / AVC-only) so users can download H.265 (HEVC) and AV1 streams in addition to H.264, cutting file size by 30-50% for the same quality.

- New pure-function module `utils/codec.rs` (`VideoCodecPriority` enum + `select_video_stream`) with 10 unit tests
- Shared `select_streams_by_codec_priority` helper used by both `download_video` and `refetch_dash_urls` for codec consistency on retry
- Fallback is downward-only: the preferred codec is the ceiling (e.g. HevcFirst never falls back up to AV1). DL never fails.
- Settings dialog: vertical RadioGroup with fallback-order display (AV1 → H.265 → H.264)
- `QualityResolvedPayload` reports the resolved codec + codec fallback so the download list shows the actual codec (e.g. \"1080p(AV1)\")
- i18n: `settings.video_codec_*` keys across all 6 languages

## Related Issue

Closes #460

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] \`npm run lint\` / \`npm run typecheck\` pass
- [x] \`cargo build\`, \`cargo fmt --check\`, \`cargo clippy -D warnings\` pass
- [x] \`cargo test codec::\` (10 unit tests) pass
- [x] Manual DL test: downloaded the same video with each codec setting and verified the actual codec via ffprobe (hevc/av1/avc selected correctly)
- [x] Verified existing trim/concat features work on HEVC/AV1 outputs (copy mode preserves codec)

## Breaking Changes

None. Output is still an MP4 container (\`-c:v copy\`); users who need H.264 for an older player can switch to \"H.264 Only\".

## Checklist

- [x] \`/review-all\` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (10 codec unit tests)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)