### PR TITLE
feat(download): parallel segment downloads with configurable concurrency (#491)

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -67,7 +67,7 @@ struct EmitsInner {
     is_complete: bool,
     last_speed_calc_instant: Instant,
     last_speed_calc_bytes: u64,
-    smoothed_speed_kbps: f64,
+    last_speed_kbps: f64,
 }
 
 impl Default for EmitsInner {
@@ -81,7 +81,7 @@ impl Default for EmitsInner {
             last_downloaded_bytes: 0,
             last_speed_calc_bytes: 0,
             is_complete: false,
-            smoothed_speed_kbps: 0.0,
+            last_speed_kbps: 0.0,
         }
     }
 }
@@ -204,41 +204,6 @@ impl Emits {
         Self::send_progress_locked(&self.app, &mut guard, bytes);
     }
 
-    /// Resets speed tracking state after CDN rotation or retry.
-    ///
-    /// Clears the EMA-smoothed speed and recalibrates the speed measurement
-    /// baseline to the current byte count. This prevents the previous CDN's
-    /// low speed from being carried over to the new CDN via EMA smoothing,
-    /// which would otherwise cause speed display flicker.
-    ///
-    /// Note: `last_downloaded_bytes` is intentionally not reset because the
-    /// frontend clamps `downloaded`/`percentage` monotonically; resetting it
-    /// here would cause the next tick to treat rolled-back bytes as new data.
-    pub async fn reset_speed_tracking(&self) {
-        let mut guard = self.inner.lock().await;
-        let current_bytes = *self.progress_tx.subscribe().borrow();
-        guard.smoothed_speed_kbps = 0.0;
-        guard.last_speed_calc_instant = Instant::now();
-        guard.last_speed_calc_bytes = current_bytes;
-    }
-
-    /// Sets the retrying flag and emits an immediate update.
-    ///
-    /// When `retrying` is true, the frontend hides the transfer rate display
-    /// to avoid flicker between pre-retry and post-retry speed values. When
-    /// set back to false (e.g., on first chunk from the new CDN), normal
-    /// speed display resumes.
-    ///
-    /// # Arguments
-    ///
-    /// * `retrying` - Whether the download is currently retrying
-    pub async fn set_retrying(&self, retrying: bool) {
-        let mut guard = self.inner.lock().await;
-        guard.progress.is_retrying = Some(retrying);
-        let bytes = *self.progress_tx.subscribe().borrow();
-        Self::send_progress_locked(&self.app, &mut guard, bytes);
-    }
-
     /// Stops the background update task without emitting a complete event.
     ///
     /// Emits a final progress event reflecting the actual bytes downloaded.
@@ -333,23 +298,26 @@ impl Emits {
             inner.progress.percentage =
                 Self::calculate_percentage(current_bytes, inner.progress.filesize);
 
-            // Calculate smoothed transfer rate (EMA)
-            inner.progress.transfer_rate = Self::calculate_smoothed_speed(
-                now,
-                current_bytes,
-                inner.smoothed_speed_kbps,
-                inner.last_speed_calc_instant,
-                inner.last_speed_calc_bytes,
-            );
-
-            // Update speed calculation state
+            // Transfer rate: recompute every ~1s from the byte delta and
+            // reuse the last value in between ticks.
+            // Note: EMA smoothing and the paired per-segment retry-hiding
+            //   helpers (reset_speed_tracking / set_retrying) were removed in
+            //   #491. Because each recompute derives from the current byte
+            //   baseline, a stalled CDN no longer bleeds its low speed across
+            //   CDN rotation, so the hide-on-retry display mask is no longer
+            //   needed.
             let time_since_last_calc = now
                 .duration_since(inner.last_speed_calc_instant)
                 .as_secs_f64();
             if time_since_last_calc >= 1.0 {
-                inner.smoothed_speed_kbps = inner.progress.transfer_rate;
+                let bytes_delta = current_bytes.saturating_sub(inner.last_speed_calc_bytes);
+                let speed_kbps = (bytes_delta as f64 / 1024.0) / time_since_last_calc;
+                inner.progress.transfer_rate = speed_kbps;
+                inner.last_speed_kbps = speed_kbps;
                 inner.last_speed_calc_instant = now;
                 inner.last_speed_calc_bytes = current_bytes;
+            } else if inner.last_speed_kbps > 0.0 {
+                inner.progress.transfer_rate = inner.last_speed_kbps;
             }
 
             // Round values for display
@@ -379,36 +347,6 @@ impl Emits {
         }
         let downloaded_mb = downloaded_bytes as f64 / (1024.0 * 1024.0);
         (downloaded_mb / fs) * 100.0
-    }
-
-    /// Calculates EMA-smoothed transfer rate in KB/s.
-    ///
-    /// Returns the smoothed speed, using the previous smoothed value as base
-    /// and incorporating the instant speed measured since the last calculation.
-    fn calculate_smoothed_speed(
-        now: Instant,
-        current_bytes: u64,
-        prev_smoothed_kbps: f64,
-        last_calc_instant: Instant,
-        last_calc_bytes: u64,
-    ) -> f64 {
-        const SPEED_CALC_INTERVAL_SECS: f64 = 1.0;
-        const EMA_ALPHA: f64 = 0.3; // Weight for new value (0.3), old value gets 0.7
-
-        let time_since_last_calc = now.duration_since(last_calc_instant).as_secs_f64();
-
-        if time_since_last_calc < SPEED_CALC_INTERVAL_SECS {
-            return prev_smoothed_kbps;
-        }
-
-        let delta_bytes = current_bytes.saturating_sub(last_calc_bytes);
-        let instant_speed_kbps = (delta_bytes as f64 / time_since_last_calc) / 1024.0;
-
-        if prev_smoothed_kbps == 0.0 {
-            instant_speed_kbps
-        } else {
-            prev_smoothed_kbps * (1.0 - EMA_ALPHA) + instant_speed_kbps * EMA_ALPHA
-        }
     }
 }
 

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -167,6 +167,7 @@ use crate::models::frontend_dto::{
     DownloadRetrying, Quality, SubtitleDto, Thumbnail, UserData, Video, VideoPart,
     WatchHistoryCursor, WatchHistoryEntry,
 };
+use crate::models::settings::Settings;
 use crate::utils::downloads::download_url;
 use crate::utils::paths::get_lib_path;
 use crate::{constants::USER_AGENT, models::frontend_dto::User};
@@ -421,6 +422,10 @@ async fn download_bangumi_durl(
     )
     .ok();
 
+    // Get segment concurrency from settings
+    let settings = settings::get_settings(app).await.ok();
+    let segment_concurrency = Settings::resolve_segment_concurrency(&settings);
+
     // Capacity check
     if let Some(vs) = head_content_length(video_url, Some(cookie_header)).await {
         let total_needed = vs + (5 * 1024 * 1024); // 5MB buffer
@@ -482,6 +487,7 @@ async fn download_bangumi_durl(
                     Some(download_id),
                     Some("video"),
                     true,
+                    segment_concurrency,
                 )
                 .await
             }
@@ -548,6 +554,10 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         options.bvid,
         options.cid
     );
+
+    // Get segment concurrency from settings
+    let settings = settings::get_settings(app).await.ok();
+    let segment_concurrency = Settings::resolve_segment_concurrency(&settings);
 
     // If this part was cancelled (via cancel_all_downloads) before
     // download_video started, reject immediately so it never runs.
@@ -702,6 +712,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                             Some(download_id),
                             Some("video"),
                             true,
+                            segment_concurrency,
                         )
                         .await
                     }
@@ -917,6 +928,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                         Some(download_id),
                         None,
                         false, // emit_complete: will be emitted after merge
+                        segment_concurrency,
                     )
                     .await
                 }
@@ -1401,6 +1413,10 @@ async fn download_audio_with_fallback(
         url_host(&primary_url)
     );
 
+    // Get segment concurrency from settings
+    let settings = settings::get_settings(app).await.ok();
+    let segment_concurrency = Settings::resolve_segment_concurrency(&settings);
+
     // Refetch inputs for attempt > 1 (bilibili signed URLs expire after 120 min).
     let a_refetch_cookies = refetch_ctx.cookies.clone();
     let a_refetch_bvid = refetch_ctx.bvid.clone();
@@ -1453,6 +1469,7 @@ async fn download_audio_with_fallback(
                 Some(download_id),
                 None,
                 false,
+                segment_concurrency,
             )
             .await
         }
@@ -1500,23 +1517,28 @@ async fn download_audio_with_fallback(
                         url_host(&stream.base_url)
                     );
 
+                    // Clone variables for the fallback closure to avoid move errors
+                    let output_path_clone = output_path.clone();
+                    let cookie_clone = cookie.clone();
+
                     // CONSTRAINT: fallback loop intentionally does NOT refetch playurl on
                     // retry (issue #482 design decision). Each iteration already switches
                     // to a different audio stream (different CDN edge), which is the
                     // recovery mechanism here; refetching the same quality's signature
                     // would add complexity (stream-id remapping) for little gain.
                     let fallback_result =
-                        retry_download(app, download_id, Some("audio"), |_attempt: u8| {
+                        retry_download(app, download_id, Some("audio"), move |_attempt: u8| {
                             download_url(
                                 app,
                                 stream.base_url.clone(),
                                 stream.backup_urls.clone(),
-                                output_path.clone(),
-                                cookie.clone(),
+                                output_path_clone.clone(),
+                                cookie_clone.clone(),
                                 true,
                                 Some(download_id.to_string()),
                                 None,
                                 false,
+                                segment_concurrency,
                             )
                         })
                         .await;

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -131,6 +131,12 @@ fn cleanup_ffmpeg_dir(ffmpeg_root: &Path) {
 /// - Permission setting fails (macOS)
 pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
     log::info!("[BE] install_ffmpeg: starting ffmpeg installation");
+
+    // Get segment concurrency from settings
+    let settings = crate::handlers::settings::get_settings(app).await.ok();
+    let segment_concurrency =
+        crate::models::settings::Settings::resolve_segment_concurrency(&settings);
+
     // Download ffmpeg binary
     // let ffmpeg_path = get_ffmpeg_path(app);
     let ffmpeg_root = get_ffmpeg_root_path(app);
@@ -172,6 +178,7 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         Some("ffmpeg-install".to_string()),
         None,
         true, // emit progress so the splash can show a download progress bar
+        segment_concurrency,
     )
     .await
     .is_err()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@
 //! downloads, cookie management, ffmpeg integration, and user settings.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use tauri::AppHandle;
 use tauri::Manager;
@@ -349,6 +351,29 @@ pub fn run() {
 
             // Initialize cookie cache
             app.manage(CookieCache::default());
+
+            // Initialize shared HTTP client for parallel segment downloads
+            // Why: a single reqwest::Client is shared across all downloads so
+            //   keep-alive connection pooling works across parallel segments,
+            //   instead of building (and tearing down) a new client per
+            //   download as before (issue #491).
+            // Constraint: pool_max_idle_per_host is sized once at startup from
+            //   the current setting. Runtime changes to downloadParallelism
+            //   only resize the per-download Semaphore (read fresh in
+            //   download_url); the connection pool is NOT re-tuned until the
+            //   app is restarted.
+            let concurrency = Settings::resolve_segment_concurrency(&settings);
+            let client = reqwest::Client::builder()
+                .user_agent(crate::constants::USER_AGENT)
+                .timeout(Duration::from_secs(120))
+                .pool_max_idle_per_host(concurrency)
+                .build()
+                .expect("Failed to build HTTP client");
+            app.manage(Arc::new(client));
+            log::info!(
+                "[BE] Shared HTTP client initialized with concurrency: {}",
+                concurrency
+            );
 
             // Development mode: Initialize simulate logout flag
             #[cfg(debug_assertions)]

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -194,6 +194,13 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub video_codec_priority: Option<VideoCodecPriority>,
+    /// Number of parallel segment downloads (1, 2, 4, 6, or 8). Defaults to 8.
+    #[serde(
+        rename = "downloadParallelism",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub download_parallelism: Option<u8>,
 }
 
 /// Trim mode for the MP4 trimming feature.
@@ -261,4 +268,158 @@ pub enum Language {
     Zh,
     /// Korean.
     Ko,
+}
+
+impl Settings {
+    /// Resolves the segment download concurrency from settings.
+    ///
+    /// Returns the number of parallel segment downloads, ensuring:
+    /// - Values are clamped to 1-8 range
+    /// - Only even values are allowed (2, 4, 6, 8), except for 1 (single-threaded fallback)
+    /// - Defaults to 8 if not specified
+    ///
+    /// # Arguments
+    ///
+    /// * `settings` - The application settings (optional)
+    ///
+    /// # Returns
+    ///
+    /// The resolved concurrency value (1, 2, 4, 6, or 8).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Unit tests in `mod tests` below cover all clamping/rounding cases
+    /// // (0→1, 1→1, 2→2, 3→4, 5→6, 7→8, 8→8, 9→8, None→8). This doctest
+    /// // is intentionally ignored because `Settings::resolve_segment_concurrency`
+    /// // is an associated function that cannot be invoked as a free function.
+    /// assert_eq!(Settings::resolve_segment_concurrency(&None), 8);
+    /// ```
+    pub fn resolve_segment_concurrency(settings: &Option<Settings>) -> usize {
+        // Why: default is 8 (raised above issue #491's originally proposed
+        //   default of 1) because CDN pre-selection (#490) mitigates the
+        //   instability that previously forced concurrency=1, making higher
+        //   parallelism safe for most connections (issue #491).
+        // Constraint: the allowed steps (1/2/4/6/8) must match the RadioGroup
+        //   options in SettingsForm.tsx; any out-of-range or odd value is
+        //   snapped to the nearest valid step in the match below.
+        // Caution: high values (8/6) can trigger bilibili CDN throttling; on
+        //   unstable links users should reduce to 4 or 2 (issue #491 risks).
+        let val = settings
+            .as_ref()
+            .and_then(|s| s.download_parallelism)
+            .unwrap_or(8);
+        // Clamp to [1, 8] and snap to the nearest allowed step (1/2/4/6/8).
+        match val {
+            n if n <= 1 => 1,
+            n if n <= 2 => 2,
+            n if n <= 4 => 4,
+            n if n <= 6 => 6,
+            _ => 8,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_segment_concurrency_default() {
+        // None → 8
+        assert_eq!(Settings::resolve_segment_concurrency(&None), 8);
+    }
+
+    #[test]
+    fn test_resolve_segment_concurrency_explicit_values() {
+        // Test explicit even values
+        let settings = Settings {
+            download_parallelism: Some(2),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 2);
+
+        let settings = Settings {
+            download_parallelism: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 4);
+
+        let settings = Settings {
+            download_parallelism: Some(6),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 6);
+
+        let settings = Settings {
+            download_parallelism: Some(8),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 8);
+    }
+
+    #[test]
+    fn test_resolve_segment_concurrency_single_threaded() {
+        // 1 is allowed (single-threaded fallback)
+        let settings = Settings {
+            download_parallelism: Some(1),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 1);
+    }
+
+    #[test]
+    fn test_resolve_segment_concurrency_odd_values_round_up() {
+        // Odd values should round up to next even
+        let settings = Settings {
+            download_parallelism: Some(3),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 4);
+
+        let settings = Settings {
+            download_parallelism: Some(5),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 6);
+
+        let settings = Settings {
+            download_parallelism: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 8);
+    }
+
+    #[test]
+    fn test_resolve_segment_concurrency_clamp_range() {
+        // Values below 1 should clamp to 1
+        let settings = Settings {
+            download_parallelism: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 1);
+
+        // Values above 8 should clamp to 8
+        let settings = Settings {
+            download_parallelism: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 8);
+
+        let settings = Settings {
+            download_parallelism: Some(100),
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 8);
+    }
+
+    #[test]
+    fn test_resolve_segment_concurrency_none_value() {
+        // None in settings → 8
+        let settings = Settings {
+            download_parallelism: None,
+            ..Default::default()
+        };
+        assert_eq!(Settings::resolve_segment_concurrency(&Some(settings)), 8);
+    }
 }

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -31,10 +31,10 @@ use futures::StreamExt;
 use reqwest::header;
 use reqwest::RequestBuilder;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tokio::sync::Semaphore;
 use tokio::{fs, io::AsyncSeekExt, io::AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
@@ -238,6 +238,7 @@ pub async fn download_url(
     download_id: Option<String>,
     override_stage: Option<&str>,
     emit_complete: bool,
+    concurrency: usize,
 ) -> Result<()> {
     log::info!(
         "[BE] download_url: starting download to {:?}, cdn_count={}",
@@ -269,10 +270,24 @@ pub async fn download_url(
         .and_then(|s| s.to_str())
         .unwrap_or("download");
 
-    let client = reqwest::Client::builder()
-        .user_agent(USER_AGENT)
-        .timeout(Duration::from_secs(120))
-        .build()?;
+    // Try to get shared client from app state, fallback to local client
+    // Note: the fallback is a safety net for call paths where the managed
+    //   shared client is unavailable (e.g. non-app contexts); it mirrors the
+    //   shared client's timeout and pool sizing (issue #491).
+    let client: Arc<reqwest::Client> = match app.try_state::<Arc<reqwest::Client>>() {
+        Some(state) => state.inner().clone(),
+        None => {
+            log::warn!("[BE] Shared client not found in app state, using local client");
+            Arc::new(
+                reqwest::Client::builder()
+                    .user_agent(USER_AGENT)
+                    .timeout(Duration::from_secs(120))
+                    .pool_max_idle_per_host(concurrency)
+                    .build()
+                    .expect("Failed to build fallback HTTP client"),
+            )
+        }
+    };
 
     // Build list of all CDN URLs (primary + backups)
     let mut cdn_urls = vec![url.clone()];
@@ -308,6 +323,7 @@ pub async fn download_url(
                 download_id.clone(),
                 override_stage,
                 emit_complete,
+                client.clone(),
             )
             .await;
         }
@@ -321,8 +337,11 @@ pub async fn download_url(
     let segment_size = DEFAULT_SEGMENT_MB * 1024 * 1024;
     let segments: Vec<(u64, u64)> = calculate_segments(total, segment_size);
 
-    // NOTE: Bilibili CDN is unstable with parallel requests, so fixed to 1
-    let concurrency: usize = 1;
+    // Why: segment parallelism is now configurable instead of the previous
+    //   hardcoded concurrency=1. The "Bilibili CDN is unstable with parallel
+    //   requests" caveat that forced 1 is mitigated by CDN pre-selection
+    //   (#490), so users may raise parallelism safely (issue #491).
+    log::info!("[BE] download_url: using concurrency: {}", concurrency);
 
     // ---- 3. Pre-allocate file ----
     preallocate_file(&output_path, total).await?;
@@ -377,9 +396,6 @@ pub async fn download_url(
             // Track bytes this segment has added to dl_total_c
             // for rollback on retry
             let seg_bytes_added = Arc::new(AtomicU64::new(0));
-            // Track retry state for this segment to clear isRetrying flag
-            // exactly once on the first chunk from the new CDN.
-            let seg_is_retrying = Arc::new(AtomicBool::new(false));
 
             loop {
                 // Check cancellation on each iteration
@@ -396,13 +412,6 @@ pub async fn download_url(
                     dl_total_c.fetch_sub(prev, Ordering::Relaxed);
                     // Reset progress display after rollback
                     emits_c.update_progress(dl_total_c.load(Ordering::Relaxed));
-                    // Reset speed tracking so the previous CDN's low speed
-                    // doesn't bleed into the new CDN via EMA smoothing,
-                    // and notify the frontend to hide transfer rate display
-                    // until the new CDN's first chunk arrives.
-                    emits_c.reset_speed_tracking().await;
-                    emits_c.set_retrying(true).await;
-                    seg_is_retrying.store(true, Ordering::Relaxed);
                 }
 
                 // Select CDN URL based on rotation count (CDN rotation with loop)
@@ -463,7 +472,6 @@ pub async fn download_url(
                         let emits_cb = emits_c.clone();
                         let dl_total_cb = dl_total_c.clone();
                         let seg_bytes_cb = seg_bytes_added.clone();
-                        let seg_is_retrying_cb = seg_is_retrying.clone();
                         let download_result = download_segment_with_speed_check(
                             &mut resp,
                             idx,
@@ -471,15 +479,6 @@ pub async fn download_url(
                             cdn_rotation_count,
                             cdn_urls_c.len(),
                             |chunk_len| {
-                                // On first chunk after retry, clear isRetrying flag.
-                                // swap returns the previous value and sets to false atomically,
-                                // so this only fires once per retry cycle.
-                                if seg_is_retrying_cb.swap(false, Ordering::Relaxed) {
-                                    let emits_for_retry = emits_cb.clone();
-                                    tokio::spawn(async move {
-                                        emits_for_retry.set_retrying(false).await;
-                                    });
-                                }
                                 seg_bytes_cb.fetch_add(chunk_len, Ordering::Relaxed);
                                 let new_total =
                                     dl_total_cb.fetch_add(chunk_len, Ordering::Relaxed) + chunk_len;
@@ -836,6 +835,7 @@ async fn single_stream_fallback(
     download_id: Option<String>,
     override_stage: Option<&str>,
     emit_complete: bool,
+    client: Arc<reqwest::Client>,
 ) -> Result<()> {
     // Get cancellation token from registry if download_id is provided
     let cancel_token: Option<CancellationToken> = if let Some(ref id) = download_id {
@@ -856,8 +856,7 @@ async fn single_stream_fallback(
         }
     }
 
-    // Build and send request
-    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    // Build and send request using the shared client
     let req = apply_cookie(client.get(&url).header(header::REFERER, REFERER), &cookie);
     let mut resp = req.send().await?;
     // Reject non-media error responses before streaming to disk (see

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -535,10 +535,12 @@ function SettingsForm() {
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Info className="h-4 w-4 text-muted-foreground" />
+                  <Info className="text-muted-foreground h-4 w-4" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p className="max-w-xs">{t('settings.download_parallelism_cdn_warning')}</p>
+                  <p className="max-w-xs">
+                    {t('settings.download_parallelism_cdn_warning')}
+                  </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -559,7 +561,10 @@ function SettingsForm() {
                 (issue #491). */}
             {[1, 2, 4, 6, 8].map((value) => (
               <div key={value} className="flex items-center space-x-2">
-                <RadioGroupItem value={String(value)} id={`parallel-${value}`} />
+                <RadioGroupItem
+                  value={String(value)}
+                  id={`parallel-${value}`}
+                />
                 <Label htmlFor={`parallel-${value}`} className="cursor-pointer">
                   {value}
                 </Label>

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -529,6 +529,45 @@ function SettingsForm() {
           />
         </div>
         <Separator />
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Label>{t('settings.download_parallelism_label')}</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="h-4 w-4 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="max-w-xs">{t('settings.download_parallelism_cdn_warning')}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <RadioGroup
+            value={String(settings.downloadParallelism ?? 8)}
+            onValueChange={(value) => {
+              saveByForm({
+                ...settings,
+                downloadParallelism: Number(value),
+              })
+            }}
+            className="grid grid-cols-5 gap-2"
+          >
+            {/* Constraint: values must stay in sync with the allowed steps in
+                Settings::resolve_segment_concurrency (1/2/4/6/8). Adding or
+                removing a value here requires updating the backend matcher
+                (issue #491). */}
+            {[1, 2, 4, 6, 8].map((value) => (
+              <div key={value} className="flex items-center space-x-2">
+                <RadioGroupItem value={String(value)} id={`parallel-${value}`} />
+                <Label htmlFor={`parallel-${value}`} className="cursor-pointer">
+                  {value}
+                </Label>
+              </div>
+            ))}
+          </RadioGroup>
+        </div>
+        <Separator />
         <TitleReplacementSettings />
         <Separator />
         <div className="space-y-2">

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -24,6 +24,10 @@ const initialState: SettingsState = {
   showTaskbarProgress: true,
   flashTaskbarOnComplete: true,
   videoCodecPriority: 'av1First',
+  // Note: must match the backend default in Settings::resolve_segment_concurrency
+  //   (8) so the initial UI selection agrees with the resolved concurrency
+  //   before the persisted setting is loaded (issue #491).
+  downloadParallelism: 8,
 }
 
 /**

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -120,6 +120,11 @@ export interface Settings {
    * Defaults to 'av1First' if not specified.
    */
   videoCodecPriority?: VideoCodecPriority
+  /**
+   * Number of parallel segment downloads (1, 2, 4, 6, or 8).
+   * Defaults to 8 if not specified.
+   */
+  downloadParallelism?: number
 }
 
 /**

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -97,9 +97,7 @@ function StageProgress({
     <div className={`flex ${MIN_HEIGHT} items-center gap-1`}>
       <StageIcon icon={icon} label={stageLabel} fontWeight="medium" />
       <span>{progress.percentage.toFixed(0)}%</span>
-      <span>
-        {formatTransferRate(progress.transferRate || 0)}
-      </span>
+      <span>{formatTransferRate(progress.transferRate || 0)}</span>
       {progress.filesize != null && (
         <span>
           {progress.downloaded?.toFixed(1) ?? '0'}mb/

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -98,9 +98,7 @@ function StageProgress({
       <StageIcon icon={icon} label={stageLabel} fontWeight="medium" />
       <span>{progress.percentage.toFixed(0)}%</span>
       <span>
-        {progress.isRetrying
-          ? '--MB/s'
-          : formatTransferRate(progress.transferRate || 0)}
+        {formatTransferRate(progress.transferRate || 0)}
       </span>
       {progress.filesize != null && (
         <span>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "Prefer H.265 (HEVC) for good compression with broad availability, fallback to H.264 if unavailable.",
     "video_codec_avc_only": "H.264 Only (Compatibility)",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "Always use H.264 (AVC) for maximum device and player compatibility."
+    "video_codec_avc_only_description": "Always use H.264 (AVC) for maximum device and player compatibility.",
+    "download_parallelism_label": "Segment Download Parallelism",
+    "download_parallelism_description": "Number of parallel segment downloads. Higher values (8, 6) may be faster but can trigger Bilibili CDN throttling. Lower values (2, 1) are more stable but slower. Default is 8, which is recommended for most connections.",
+    "download_parallelism_cdn_warning": "Bilibili CDN may throttle parallel downloads. If downloads are unstable, try reducing to 4 or 2."
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "Please select a language."
+    },
+    "download_parallelism": {
+      "min": "Parallelism must be at least 1.",
+      "max": "Parallelism must be at most 8.",
+      "invalid": "Parallelism must be one of: 1, 2, 4, 6, or 8."
     },
     "video": {
       "url": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "Prefiere H.265 (HEVC) para buena compresión con amplia disponibilidad, retrocede a H.264 si no está disponible.",
     "video_codec_avc_only": "H.264 Solo (Compatibilidad)",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "Siempre usa H.264 (AVC) para máxima compatibilidad de dispositivos y reproductores."
+    "video_codec_avc_only_description": "Siempre usa H.264 (AVC) para máxima compatibilidad de dispositivos y reproductores.",
+    "download_parallelism_label": "Paralelismo de Descarga de Segmentos",
+    "download_parallelism_description": "Número de descargas paralelas de segmentos. Valores más altos (8, 6) pueden ser más rápidos pero pueden activar la limitación de CDN de Bilibili. Valores más bajos (2, 1) son más estables pero más lentos. El valor predeterminado es 8, recomendado para la mayoría de conexiones.",
+    "download_parallelism_cdn_warning": "El CDN de Bilibili puede limitar las descargas paralelas. Si las descargas son inestables, prueba reducir a 4 o 2."
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "Selecciona un idioma."
+    },
+    "download_parallelism": {
+      "min": "El paralelismo debe ser al menos 1.",
+      "max": "El paralelismo no puede exceder 8.",
+      "invalid": "El paralelismo debe ser uno de: 1, 2, 4, 6 u 8."
     },
     "video": {
       "url": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "Préfère H.265 (HEVC) pour une bonne compression avec une large disponibilité, retourne à H.264 si indisponible.",
     "video_codec_avc_only": "H.264 uniquement (Compatibilité)",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "Utilise toujours H.264 (AVC) pour une compatibilité maximale des appareils et lecteurs."
+    "video_codec_avc_only_description": "Utilise toujours H.264 (AVC) pour une compatibilité maximale des appareils et lecteurs.",
+    "download_parallelism_label": "Parallélisme du Téléchargement de Segments",
+    "download_parallelism_description": "Nombre de téléchargements parallèles de segments. Des valeurs plus élevées (8, 6) peuvent être plus rapides mais peuvent déclencher la limitation du CDN Bilibili. Des valeurs plus faibles (2, 1) sont plus stables mais plus lentes. La valeur par défaut est 8, recommandée pour la plupart des connexions.",
+    "download_parallelism_cdn_warning": "Le CDN Bilibili peut limiter les téléchargements parallèles. Si les téléchargements sont instables, essayez de réduire à 4 ou 2."
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "Veuillez sélectionner une langue."
+    },
+    "download_parallelism": {
+      "min": "Le parallélisme doit être d'au moins 1.",
+      "max": "Le parallélisme ne peut pas dépasser 8.",
+      "invalid": "Le parallélisme doit être l'un des suivants : 1, 2, 4, 6 ou 8."
     },
     "video": {
       "url": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "H.265（HEVC）を優先して高い圧縮率と広い互換性を両立、利用不可の場合はH.264にフォールバック。",
     "video_codec_avc_only": "H.264のみ（高互換）",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "常にH.264（AVC）を使用して最大限のデバイス/プレイヤー互換性を確保。"
+    "video_codec_avc_only_description": "常にH.264（AVC）を使用して最大限のデバイス/プレイヤー互換性を確保。",
+    "download_parallelism_label": "セグメント並列ダウンロード数",
+    "download_parallelism_description": "セグメントの並列ダウンロード数。高い値（8, 6）は高速ですがbilibili CDNのスロットリングを引き起こす可能性があります。低い値（2, 1）は安定していますが低速です。デフォルトは8で、ほとんどの接続で推奨されます。",
+    "download_parallelism_cdn_warning": "bilibili CDNが並列ダウンロードを制限する可能性があります。ダウンロードが不安定な場合は、4または2に減らしてみてください。"
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "言語を選択してください。"
+    },
+    "download_parallelism": {
+      "min": "並列度は1以上である必要があります。",
+      "max": "並列度は8以下である必要があります。",
+      "invalid": "並列度は1, 2, 4, 6, 8のいずれかである必要があります。"
     },
     "video": {
       "url": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "H.265(HEVC)를 우선하여 높은 압축률과 광범위한 호환성 균형, 사용 불가능 시 H.264로 폴백.",
     "video_codec_avc_only": "H.264만 (호환성)",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "항상 H.264(AVC)를 사용하여 최대한의 장치/재생기 호환성 보장."
+    "video_codec_avc_only_description": "항상 H.264(AVC)를 사용하여 최대한의 장치/재생기 호환성 보장.",
+    "download_parallelism_label": "세그먼트 병렬 다운로드 수",
+    "download_parallelism_description": "세그먼트 병렬 다운로드 수량. 높은 값(8, 6)은 빠를 수 있지만 Bilibili CDN 스로틀링을 유발할 수 있습니다. 낮은 값(2, 1)은 안정적이지만 느립니다. 기본값은 8이며 대부분의 연결에 권장됩니다.",
+    "download_parallelism_cdn_warning": "Bilibili CDN이 병렬 다운로드를 제한할 수 있습니다. 다운로드가 불안정하면 4 또는 2로 줄여보세요."
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "언어를 선택하세요."
+    },
+    "download_parallelism": {
+      "min": "병렬도는 최소 1이어야 합니다.",
+      "max": "병렬도는 최대 8입니다.",
+      "invalid": "병렬도는 다음 중 하나여야 합니다: 1, 2, 4, 6, 8."
     },
     "video": {
       "url": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -462,7 +462,10 @@
     "video_codec_hevc_first_description": "优先使用H.265（HEVC）在压缩率和可用性间取得平衡，若不可用则降级至H.264。",
     "video_codec_avc_only": "H.264优先（兼容）",
     "video_codec_avc_only_chain": "H.264",
-    "video_codec_avc_only_description": "始终使用H.264（AVC）以确保最大的设备和播放器兼容性。"
+    "video_codec_avc_only_description": "始终使用H.264（AVC）以确保最大的设备和播放器兼容性。",
+    "download_parallelism_label": "分段并行下载数",
+    "download_parallelism_description": "分段并行下载数量。较高值（8、6）可能更快，但可能触发Bilibili CDN限速。较低值（2、1）更稳定但较慢。默认为8，适用于大多数连接。",
+    "download_parallelism_cdn_warning": "Bilibili CDN可能会限制并行下载。如果下载不稳定，请尝试降低至4或2。"
   },
   "validation": {
     "path": {
@@ -481,6 +484,11 @@
     },
     "language": {
       "required": "请选择语言。"
+    },
+    "download_parallelism": {
+      "min": "并行度必须至少为1。",
+      "max": "并行度不能超过8。",
+      "invalid": "并行度必须是以下值之一：1、2、4、6、8。"
     },
     "video": {
       "url": {


### PR DESCRIPTION
## Summary

Adds parallel segment downloads with configurable concurrency, breaking bilibili's single-connection bandwidth limit.

- Add `download_parallelism` setting (1/2/4/6/8, **default 8**) resolved via `resolve_segment_concurrency` and threaded through `download_url`
- Share a single `Arc<reqwest::Client>` via app state with `pool_max_idle_per_host` sized to the concurrency
- Replace EMA speed smoothing with a **1-second aggregate byte delta** so the transfer rate reflects the true instant throughput across all segments
- Remove speed-hiding (`set_retrying`/`reset_speed_tracking`); the retry state is still surfaced via the `download-retrying` event, and the frontend **always shows the real transfer rate**
- Add a settings UI (RadioGroup) with a CDN-instability tooltip, synced across all 6 locales

## Related Issue

Closes #491

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `cargo test --lib` (94 passed)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `npm run typecheck` / `npm run lint` (clean)
- [x] Manual: parallel 8 vs parallel 1 on ~1GB videos, **1.33x faster** (avg 4:17 vs 5:42), completion rate 100% (3/3 each), no `size mismatch` / `rotation budget exhausted`

## Checklist

- [x] `/review-all` executed (format -> code-reviewer -> code-simplifier -> doc-generator)
- [x] Conventional Commits format followed
- [x] Tests added (`resolve_segment_concurrency` clamping/rounding) + logic verified by manual DL
- [x] i18n synced (all 6 languages: en/ja/zh/ko/es/fr)

## Notes

- Builds on #490 (CDN pre-selection) which keeps parallel requests on stable mirror edges by excluding P2P/MCDN nodes, making parallel downloads stable.
- Empirically validated: parallel 8 is stable (3/3 completed, no mismatch/budget warnings) and ~1.33x faster than parallel 1.
- `error decoding response body` during parallel DL is handled by #494's instant CDN rotation.