### PR TITLE
feat(merge): stream-copy audio instead of re-encoding for faster merges

### DIFF
--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -548,17 +548,171 @@ pub async fn merge_av(
     .await
 }
 
+/// Audio codec strategy used when merging.
+///
+/// `Copy` is tried first (`-c:a copy`) for a fast, lossless mux; `Aac`
+/// (`-c:a aac`) is the fallback re-encode used only when stream copy fails —
+/// e.g. a future non-AAC source that cannot live in an MP4 container. bilibili's
+/// standard DASH audio is always AAC today, so copy succeeds in practice.
+enum AudioCodec {
+    Copy,
+    Aac,
+}
+
+impl AudioCodec {
+    /// Returns the ffmpeg codec name passed after `-c:a`.
+    fn as_str(&self) -> &'static str {
+        match self {
+            AudioCodec::Copy => "copy",
+            AudioCodec::Aac => "aac",
+        }
+    }
+}
+
+/// Builds ffmpeg merge arguments for the given subtitle mode and audio codec.
+///
+/// The audio codec is parameterized so a single builder serves both the
+/// stream-copy attempt and the AAC re-encode fallback — only the `-c:a` value
+/// differs; everything else (inputs, mappings, metadata, video codec) is
+/// identical for a given [`MergeMode`].
+fn build_merge_args(
+    video_path: &str,
+    audio_path: &str,
+    output_path: &str,
+    subtitle_mode: &MergeMode,
+    audio_codec: AudioCodec,
+) -> Result<Vec<String>, String> {
+    let to_str_err = || "Invalid path".to_string();
+    let audio = audio_codec.as_str();
+
+    let mut args = Vec::new();
+
+    match subtitle_mode {
+        MergeMode::None => {
+            args.extend(
+                [
+                    "-i",
+                    video_path,
+                    "-i",
+                    audio_path,
+                    "-c:v",
+                    "copy",
+                    "-c:a",
+                    audio,
+                    "-progress",
+                    "pipe:1",
+                    "-y",
+                    output_path,
+                ]
+                .iter()
+                .map(|s| s.to_string()),
+            );
+        }
+        MergeMode::SoftSub(subtitles) => {
+            let mut input_args: Vec<String> = vec![
+                "-i".to_string(),
+                video_path.to_string(),
+                "-i".to_string(),
+                audio_path.to_string(),
+            ];
+
+            for sub in subtitles {
+                let sub_str = sub.path.to_str().ok_or_else(to_str_err)?;
+                input_args.push("-i".to_string());
+                input_args.push(sub_str.to_string());
+            }
+
+            let mut map_args: Vec<String> = vec![
+                "-map".to_string(),
+                "0:v".to_string(),
+                "-map".to_string(),
+                "1:a".to_string(),
+            ];
+
+            for i in 0..subtitles.len() {
+                map_args.push("-map".to_string());
+                map_args.push(format!("{}:0", i + 2));
+            }
+
+            let mut metadata_args: Vec<String> = Vec::new();
+            for (i, sub) in subtitles.iter().enumerate() {
+                metadata_args.push(format!("-metadata:s:s:{}", i));
+                metadata_args.push(format!("language={}", sub.language));
+                metadata_args.push(format!("-metadata:s:s:{}", i));
+                metadata_args.push(format!("title={}", sub.title));
+            }
+
+            let codec_args: Vec<String> = vec![
+                "-c:v".to_string(),
+                "copy".to_string(),
+                "-c:a".to_string(),
+                audio.to_string(),
+                "-c:s".to_string(),
+                "mov_text".to_string(),
+            ];
+
+            args.extend(input_args);
+            args.extend(map_args);
+            args.extend(metadata_args);
+            args.extend(codec_args);
+            args.extend(
+                ["-progress", "pipe:1", "-y", output_path]
+                    .iter()
+                    .map(|s| s.to_string()),
+            );
+        }
+        MergeMode::HardSub(subtitle) => {
+            let sub_str = subtitle.path.to_str().ok_or_else(to_str_err)?;
+
+            let escaped_sub = sub_str
+                .replace('\\', "\\\\")
+                .replace(':', "\\:")
+                .replace('\'', "'\\''");
+
+            let filter = format!("subtitles='{}'", escaped_sub);
+
+            args.extend(
+                [
+                    "-i",
+                    video_path,
+                    "-i",
+                    audio_path,
+                    "-vf",
+                    &filter,
+                    "-c:v",
+                    "libx264",
+                    "-preset",
+                    "fast",
+                    "-c:a",
+                    audio,
+                    "-progress",
+                    "pipe:1",
+                    "-y",
+                    output_path,
+                ]
+                .iter()
+                .map(|s| s.to_string()),
+            );
+        }
+    }
+
+    Ok(args)
+}
+
 /// Merges video, audio, and optional subtitles into a single MP4 file.
 ///
 /// This is an extended version of [`merge_av`] that supports subtitle handling
 /// based on the specified [`MergeMode`]:
 ///
 /// - **None**: Merges video and audio only (identical to [`merge_av`]).
-///   Video stream is copied without re-encoding; audio is re-encoded to AAC.
+///   Video stream is copied without re-encoding; audio is first tried with
+///   stream copy, falling back to AAC re-encoding if needed.
 /// - **SoftSub**: Embeds subtitle tracks into the container (`mov_text` codec).
 ///   Viewers can toggle subtitles on/off during playback. Supports multiple tracks.
+///   Audio uses copy-first with AAC fallback.
 /// - **HardSub**: Burns subtitles into the video frame using the `subtitles` filter.
-///   Requires re-encoding via `libx264` with `fast` preset.
+///   Requires re-encoding via `libx264` with `fast` preset. Audio uses copy-first
+///   with AAC fallback.
 ///
 /// Progress events are emitted to the frontend during the merge process.
 ///
@@ -582,7 +736,7 @@ pub async fn merge_av(
 /// - File paths contain invalid UTF-8
 /// - Subtitle file paths are invalid (when using SoftSub or HardSub mode)
 /// - ffmpeg execution fails
-/// - ffmpeg returns a non-zero exit code
+/// - ffmpeg returns a non-zero exit code for both copy and re-encode attempts
 #[allow(clippy::too_many_arguments)]
 pub async fn merge_avs(
     app: &AppHandle,
@@ -607,7 +761,7 @@ pub async fn merge_avs(
 
     let emits = Emits::new(
         app.clone(),
-        download_id.unwrap_or(filename.to_string()),
+        download_id.clone().unwrap_or(filename.to_string()),
         Some(100 * 1024 * 1024),
     );
     let _ = emits.set_stage("merge").await;
@@ -619,106 +773,87 @@ pub async fn merge_avs(
     let audio_str = audio_path.to_str().ok_or_else(to_str_err)?;
     let output_str = output_path.to_str().ok_or_else(to_str_err)?;
 
-    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    // Try audio stream copy first; fall back to AAC re-encoding on failure.
+    let copy_args = build_merge_args(
+        video_str,
+        audio_str,
+        output_str,
+        &subtitle_mode,
+        AudioCodec::Copy,
+    )?;
+    let copy_result = run_merge_ffmpeg(
+        &ffmpeg_path,
+        &copy_args,
+        output_path,
+        duration_ms,
+        &emits,
+        &cancel_token,
+    )
+    .await;
 
-    match &subtitle_mode {
-        MergeMode::None => {
-            cmd.args([
-                "-i",
-                video_str,
-                "-i",
-                audio_str,
-                "-c:v",
-                "copy",
-                "-c:a",
-                "aac",
-                "-progress",
-                "pipe:1",
-                "-y",
-                output_str,
-            ]);
-        }
-        MergeMode::SoftSub(subtitles) => {
-            let mut input_args: Vec<String> = vec![
-                "-i".to_string(),
-                video_str.to_string(),
-                "-i".to_string(),
-                audio_str.to_string(),
-            ];
-
-            for sub in subtitles {
-                let sub_str = sub.path.to_str().ok_or_else(to_str_err)?;
-                input_args.push("-i".to_string());
-                input_args.push(sub_str.to_string());
-            }
-
-            let sub_count = subtitles.len();
-
-            let mut map_args: Vec<String> = vec![
-                "-map".to_string(),
-                "0:v".to_string(),
-                "-map".to_string(),
-                "1:a".to_string(),
-            ];
-
-            for i in 0..sub_count {
-                map_args.push("-map".to_string());
-                map_args.push(format!("{}:0", i + 2));
-            }
-
-            let mut metadata_args: Vec<String> = Vec::new();
-            for (i, sub) in subtitles.iter().enumerate() {
-                metadata_args.push(format!("-metadata:s:s:{}", i));
-                metadata_args.push(format!("language={}", sub.language));
-                metadata_args.push(format!("-metadata:s:s:{}", i));
-                metadata_args.push(format!("title={}", sub.title));
-            }
-
-            let codec_args: Vec<String> = vec![
-                "-c:v".to_string(),
-                "copy".to_string(),
-                "-c:a".to_string(),
-                "aac".to_string(),
-                "-c:s".to_string(),
-                "mov_text".to_string(),
-            ];
-
-            cmd.args(&input_args)
-                .args(&map_args)
-                .args(&metadata_args)
-                .args(&codec_args)
-                .args(["-progress", "pipe:1", "-y", output_str]);
-        }
-        MergeMode::HardSub(subtitle) => {
-            let sub_str = subtitle.path.to_str().ok_or_else(to_str_err)?;
-
-            let escaped_sub = sub_str
-                .replace('\\', "\\\\")
-                .replace(':', "\\:")
-                .replace('\'', "'\\''");
-
-            let filter = format!("subtitles='{}'", escaped_sub);
-
-            cmd.args([
-                "-i",
-                video_str,
-                "-i",
-                audio_str,
-                "-vf",
-                &filter,
-                "-c:v",
-                "libx264",
-                "-preset",
-                "fast",
-                "-c:a",
-                "aac",
-                "-progress",
-                "pipe:1",
-                "-y",
-                output_str,
-            ]);
-        }
+    if copy_result.is_ok() {
+        log::info!("[BE] merge_avs: audio copy succeeded");
+        let _ = emits.set_stage("complete").await;
+        emits.complete().await;
+        return Ok(());
     }
+
+    // Cancellation must propagate immediately — it is a user action, not a
+    // transcode failure, and must NOT trigger the AAC re-encode fallback.
+    if matches!(
+        copy_result.as_ref().err().map(String::as_str),
+        Some("ERR::CANCELLED")
+    ) {
+        return Err(copy_result.unwrap_err());
+    }
+
+    // Audio copy failed (non-cancel): reset the progress baseline so the
+    // frontend's monotonic clamp tracks the re-encode from 0% instead of
+    // sitting at the copy attempt's peak, then fall back to AAC re-encoding.
+    log::info!("[BE] merge_avs: audio copy failed, falling back to AAC re-encoding");
+    emits.update_progress(0);
+    let _ = emits.set_stage("merge-fallback").await;
+
+    let reencode_args = build_merge_args(
+        video_str,
+        audio_str,
+        output_str,
+        &subtitle_mode,
+        AudioCodec::Aac,
+    )?;
+    match run_merge_ffmpeg(
+        &ffmpeg_path,
+        &reencode_args,
+        output_path,
+        duration_ms,
+        &emits,
+        &cancel_token,
+    )
+    .await
+    {
+        Ok(()) => {
+            log::info!("[BE] merge_avs: AAC re-encoding succeeded");
+            let _ = emits.set_stage("complete").await;
+            emits.complete().await;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Runs ffmpeg with the given args for merge operations.
+///
+/// Handles progress parsing, cancellation, and stderr collection.
+async fn run_merge_ffmpeg(
+    ffmpeg_path: &Path,
+    args: &[String],
+    output_path: &Path,
+    duration_ms: Option<u64>,
+    emits: &Emits,
+    cancel_token: &Option<CancellationToken>,
+) -> Result<(), String> {
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
+    cmd.args(args);
 
     #[cfg(target_os = "windows")]
     {
@@ -754,7 +889,7 @@ pub async fn merge_avs(
         // Cancel check (inline; check_cancelled is private + anyhow-typed).
         // On cancel: kill ffmpeg, remove partial output, stop the progress
         // emitter (prevents progress ghost), reap stderr task, then return.
-        if let Some(t) = &cancel_token {
+        if let Some(t) = cancel_token {
             if t.is_cancelled() {
                 // Kill ffmpeg; its stderr closes and the stderr_task winds down
                 // on its own (avoid moving stderr_task so the post-loop await
@@ -798,7 +933,7 @@ pub async fn merge_avs(
     if !status.success() {
         // ffmpeg didn't finish cleanly. If a cancel was requested, report it
         // as cancelled and remove the partial output.
-        if let Some(t) = &cancel_token {
+        if let Some(t) = cancel_token {
             if t.is_cancelled() {
                 let _ = tokio::fs::remove_file(output_path).await;
                 let _ = emits.stop().await;
@@ -812,11 +947,130 @@ pub async fn merge_avs(
         ));
     }
 
-    // ffmpeg finished successfully. Treat as complete even if a cancel
-    // arrived in the brief window after progress=end; don't discard a
-    // finished file.
-    let _ = emits.set_stage("complete").await;
-    emits.complete().await;
-
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts the arg list contains `-c:a <expected>` as an adjacent pair.
+    ///
+    /// A plain `.contains("copy")` check would also pass for `-c:v copy`, so we
+    /// verify positional pairing to catch a real codec swap regression.
+    fn assert_audio_codec_pair(args: &[String], expected: &str) {
+        let i = args
+            .iter()
+            .position(|a| a == "-c:a")
+            .expect("-c:a flag must be present in merge args");
+        assert_eq!(
+            args.get(i + 1).map(String::as_str),
+            Some(expected),
+            "audio codec after -c:a"
+        );
+    }
+
+    #[test]
+    fn none_mode_copy_uses_audio_copy() {
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::None,
+            AudioCodec::Copy,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "copy");
+    }
+
+    #[test]
+    fn none_mode_aac_uses_audio_aac() {
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::None,
+            AudioCodec::Aac,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "aac");
+    }
+
+    #[test]
+    fn softsub_mode_copy_uses_audio_copy() {
+        let subtitles = vec![SubtitleMergeOptions {
+            path: std::path::PathBuf::from("subtitle1.srt"),
+            language: "eng".to_string(),
+            title: "English".to_string(),
+        }];
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::SoftSub(subtitles),
+            AudioCodec::Copy,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "copy");
+        // Subtitle-specific flags must still be emitted alongside the audio codec.
+        assert!(args.contains(&"-c:s".to_string()));
+        assert!(args.contains(&"mov_text".to_string()));
+    }
+
+    #[test]
+    fn softsub_mode_aac_uses_audio_aac() {
+        let subtitles = vec![SubtitleMergeOptions {
+            path: std::path::PathBuf::from("subtitle1.srt"),
+            language: "eng".to_string(),
+            title: "English".to_string(),
+        }];
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::SoftSub(subtitles),
+            AudioCodec::Aac,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "aac");
+    }
+
+    #[test]
+    fn hardsub_mode_copy_uses_audio_copy() {
+        let subtitle = SubtitleMergeOptions {
+            path: std::path::PathBuf::from("subtitle.srt"),
+            language: "eng".to_string(),
+            title: "English".to_string(),
+        };
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::HardSub(subtitle),
+            AudioCodec::Copy,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "copy");
+        // HardSub always re-encodes video to burn subtitles in; that is unaffected.
+        assert!(args.contains(&"-vf".to_string()));
+        assert!(args.contains(&"libx264".to_string()));
+    }
+
+    #[test]
+    fn hardsub_mode_aac_uses_audio_aac() {
+        let subtitle = SubtitleMergeOptions {
+            path: std::path::PathBuf::from("subtitle.srt"),
+            language: "eng".to_string(),
+            title: "English".to_string(),
+        };
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::HardSub(subtitle),
+            AudioCodec::Aac,
+        )
+        .unwrap();
+        assert_audio_codec_pair(&args, "aac");
+    }
 }

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -114,6 +114,23 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
           store.dispatch(updateQueueStatus({ downloadId, status: 'running' }))
         }
 
+        // Why: the backend emits the `merge-fallback` stage (Emits::set_stage
+        //   in merge_avs, src-tauri/src/handlers/ffmpeg.rs) only when the
+        //   fast/lossless `-c:a copy` path fails and it falls back to AAC
+        //   re-encoding. Surfacing it as a toast keeps the user informed that
+        //   this merge will run slower than the usual stream-copy fast path
+        //   (Issue #492).
+        // Note: this is the merge *codec* fallback, distinct from the *quality*
+        //   fallback handled below (warn-*-quality-fallback), which is about
+        //   the CDN serving a lower-than-requested quality. Keep this stage
+        //   string in sync with the Rust emitter if it is renamed.
+        // Show toast for audio fallback during merge
+        if (stage === 'merge-fallback') {
+          toast.info(i18n.t('video.audio_merge_fallback'), {
+            duration: 6000,
+          })
+        }
+
         // Show toast for quality fallback warnings
         const isFallbackWarning =
           stage === 'warn-video-quality-fallback' ||

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -206,6 +206,7 @@
     "rate_limited": "Too many requests. Please wait a moment and try again.",
     "video_quality_fallback": "Selected video quality ({{from}}) unavailable. Using {{to}}.",
     "audio_quality_fallback": "Selected audio quality ({{from}}) unavailable. Using {{to}}.",
+    "audio_merge_fallback": "Audio stream copy failed. Using AAC re-encoding instead.",
     "invalid_media_response": "Invalid media response from server (received error page instead of media).",
     "audio_download_failed": "Failed to download audio after trying all available streams.",
     "queue_waiting_prefix": "Queued:",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -206,6 +206,7 @@
     "rate_limited": "Demasiadas solicitudes. Por favor, espere un momento e inténtelo de nuevo.",
     "video_quality_fallback": "La calidad de video seleccionada ({{from}}) no está disponible. Usando {{to}}.",
     "audio_quality_fallback": "La calidad de audio seleccionada ({{from}}) no está disponible. Usando {{to}}.",
+    "audio_merge_fallback": "La copia del flujo de audio falló. Usando recodificación AAC en su lugar.",
     "invalid_media_response": "Respuesta de medios no válida del servidor (se recibió página de error).",
     "audio_download_failed": "Error al descargar audio después de intentar todas las transmisiones disponibles.",
     "queue_waiting_prefix": "En cola:",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -206,6 +206,7 @@
     "rate_limited": "Trop de requêtes. Veuillez patienter un instant et réessayer.",
     "video_quality_fallback": "La qualité vidéo sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
     "audio_quality_fallback": "La qualité audio sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
+    "audio_merge_fallback": "La copie du flux audio a échoué. Utilisation du réencodage AAC à la place.",
     "invalid_media_response": "Réponse média non valide du serveur (page d'erreur reçue).",
     "audio_download_failed": "Échec du téléchargement audio après avoir essayé tous les flux disponibles.",
     "queue_waiting_prefix": "En file d'attente:",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -206,6 +206,7 @@
     "rate_limited": "リクエストが多すぎます。しばらく待ってから再試行してください。",
     "video_quality_fallback": "選択した画質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
     "audio_quality_fallback": "選択した音質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
+    "audio_merge_fallback": "音声ストリームコピーに失敗しました。AAC再エンコードを使用します。",
     "invalid_media_response": "サーバーから無効なメディア応答がありました（エラーページを受信）。",
     "audio_download_failed": "すべての利用可能なストリームを試しましたが、音声のダウンロードに失敗しました。",
     "queue_waiting_prefix": "キュー待ち:",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -206,6 +206,7 @@
     "rate_limited": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
     "video_quality_fallback": "선택한 화질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
     "audio_quality_fallback": "선택한 음질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
+    "audio_merge_fallback": "오디오 스트림 복사에 실패했습니다. AAC 재인코딩을 사용합니다.",
     "invalid_media_response": "서버에서 잘못된 미디어 응답을 받았습니다(오류 페이지 수신).",
     "audio_download_failed": "사용 가능한 모든 스트림을 시도했으나 오디오 다운로드에 실패했습니다.",
     "queue_waiting_prefix": "대기 중:",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -207,6 +207,7 @@
     "rate_limited": "请求过于频繁，请稍后再试。",
     "video_quality_fallback": "选定的视频清晰度 ({{from}}) 不可用，已使用 {{to}}。",
     "audio_quality_fallback": "选定的音频音质 ({{from}}) 不可用，已使用 {{to}}。",
+    "audio_merge_fallback": "音频流复制失败，正在使用 AAC 重新编码。",
     "invalid_media_response": "服务器返回了无效的媒体响应（接收到错误页面而非媒体）。",
     "audio_download_failed": "尝试了所有可用流后，音频下载失败。",
     "queue_waiting_prefix": "排队中:",


### PR DESCRIPTION
## Summary

Switches the audio merge codec from `-c:a aac` (re-encode) to `-c:a copy` (stream copy), so merges finish in seconds instead of scaling with video length — with **zero quality loss**.

Closes #492

## Problem / Motivation

The merge step already copied video (`-c:v copy`) but re-encoded audio (`-c:a aac`). That audio re-encode was the only thing left dominating merge time: it scaled with video length, delayed the "complete" state after the download finished, and held the global download semaphore (`VIDEO_SEMAPHORE`) for the whole duration — throttling queued downloads too.

## Changes

- **`src-tauri/src/handlers/ffmpeg.rs`**:
  - `build_merge_args` + `AudioCodec` enum (`Copy`/`Aac`) — a single arg builder parameterized by audio codec, replacing two near-duplicate functions
  - `run_merge_ffmpeg` helper extracted (spawn / progress / cancel / stderr)
  - copy-first / AAC-fallback flow in `merge_avs`: try `-c:a copy`; on a **non-cancel** failure, retry with `-c:a aac` (mirrors `concat.rs`)
  - Cancellation propagates immediately — it never triggers the AAC fallback
  - Progress baseline reset (`update_progress(0)`) before the fallback so the frontend's monotonic clamp tracks the re-encode from 0%
  - Positional unit tests covering copy/aac × None/SoftSub/HardSub
- **`src/app/providers/ListenerContext.tsx`**: `merge-fallback` stage → toast (consistent with the existing `warn-*-quality-fallback` pattern)
- **`src/i18n/locales/*.json`** (6 langs): `video.audio_merge_fallback`

Applied to all three `MergeMode` variants (None/SoftSub/HardSub).

## Safety

bilibili's standard DASH audio is always AAC (`mp4a.40.2` / `mp4a.40.5`), which is native to the MP4 container — so `-c:a copy` is safe in practice. VIP-only Dolby (E-AC-3) and Hi-Res FLAC are intentionally excluded from stream selection (`models/bilibili_api.rs`, per the #467 investigation), so they never reach the merge. The AAC fallback is a safety net for a hypothetical future non-AAC source.

## Performance impact

| Mode | Before | After |
|------|--------|-------|
| None / SoftSub | audio re-encode (scales w/ length) | stream copy (seconds) |
| HardSub | video re-encode (`libx264`) — unchanged | audio copied (minor) |

## Verification

- ✅ `cargo build` / `cargo clippy -- -D warnings`
- ✅ `cargo test --lib`: 100 passed (6 new tests included)
- ✅ `npm run lint` / `format:check` / `build`
- ✅ Manual: download → merge → playback confirmed; cancel aborts immediately (no fallback)