### PR TITLE
perf(download): tune shared HTTP client pool and timeouts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,6 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tauri::AppHandle;
 use tauri::Manager;
@@ -357,23 +356,11 @@ pub fn run() {
             //   keep-alive connection pooling works across parallel segments,
             //   instead of building (and tearing down) a new client per
             //   download as before (issue #491).
-            // Constraint: pool_max_idle_per_host is sized once at startup from
-            //   the current setting. Runtime changes to downloadParallelism
-            //   only resize the per-download Semaphore (read fresh in
-            //   download_url); the connection pool is NOT re-tuned until the
-            //   app is restarted.
-            let concurrency = Settings::resolve_segment_concurrency(&settings);
-            let client = reqwest::Client::builder()
-                .user_agent(crate::constants::USER_AGENT)
-                .timeout(Duration::from_secs(120))
-                .pool_max_idle_per_host(concurrency)
-                .build()
-                .expect("Failed to build HTTP client");
+            // Connection pool is tuned in build_download_client() (fixed at max
+            //   segment concurrency, see WHY docs there).
+            let client = crate::utils::downloads::build_download_client();
             app.manage(Arc::new(client));
-            log::info!(
-                "[BE] Shared HTTP client initialized with concurrency: {}",
-                concurrency
-            );
+            log::info!("[BE] Shared HTTP client initialized");
 
             // Development mode: Initialize simulate logout flag
             #[cfg(debug_assertions)]

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -25,6 +25,7 @@ enum SegmentError {
     /// (triggers CDN rotation via caller's loop)
     Reconnect,
 }
+
 use anyhow::Result;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -38,6 +39,41 @@ use tauri::{AppHandle, Manager};
 use tokio::sync::Semaphore;
 use tokio::{fs, io::AsyncSeekExt, io::AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
+
+/// Builds the shared reqwest::Client for downloads with connection pooling
+/// tuned for parallel segment fetches (see inline comments for each option).
+/// Centralized here so the shared client (lib.rs) and the fallback client
+/// (download_url) stay identical without manual mirroring.
+pub fn build_download_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        // Overall request timeout. CDN rotation handles truly stuck
+        // transfers.
+        .timeout(Duration::from_secs(120))
+        // Separate handshake timeout so a hung connect fails fast (10s) and
+        // rotates to the next CDN, instead of burning the full 120s budget.
+        .connect_timeout(Duration::from_secs(10))
+        // Fixed at the max segment concurrency (8). The pool is just a
+        // cache; sizing to the max means runtime changes to
+        // downloadParallelism take effect immediately without rebuilding
+        // the client or restarting the app.
+        // Constraint: the literal 8 is maintenance-coupled to the max clamp
+        //   in Settings::resolve_segment_concurrency
+        //   (src/models/settings.rs: both the `unwrap_or(8)` default and the
+        //   `_ => 8` match arm). There is no shared named constant, so if the
+        //   allowed max step ever changes, bump this in lockstep or the pool
+        //   will under-provision at peak parallelism.
+        .pool_max_idle_per_host(8)
+        // Keep idle connections alive longer than reqwest's 90s default so
+        // they're reused across gaps between segment fetches. Safe to
+        // extend because tcp_keepalive evicts dead peers.
+        .pool_idle_timeout(Duration::from_secs(120))
+        // Probe idle connections so half-open/dead CDN sockets are
+        // detected and reused connections don't fail mid-request.
+        .tcp_keepalive(Duration::from_secs(60))
+        .build()
+        .expect("Failed to build HTTP client")
+}
 
 /// Sets the download stage based on filename pattern.
 ///
@@ -278,14 +314,7 @@ pub async fn download_url(
         Some(state) => state.inner().clone(),
         None => {
             log::warn!("[BE] Shared client not found in app state, using local client");
-            Arc::new(
-                reqwest::Client::builder()
-                    .user_agent(USER_AGENT)
-                    .timeout(Duration::from_secs(120))
-                    .pool_max_idle_per_host(concurrency)
-                    .build()
-                    .expect("Failed to build fallback HTTP client"),
-            )
+            Arc::new(build_download_client())
         }
     };
 


### PR DESCRIPTION
## Summary

Optimizes the shared `reqwest::Client` connection pool and timeout configuration for parallel segment downloads, and centralizes client construction in a single helper.

- **New `build_download_client()` helper** (`downloads.rs`): consolidates the client builder so the shared client (`lib.rs`) and the fallback client (`download_url`) share one source of truth — removes the manual mirror that had to be kept in sync by hand.
- **`pool_max_idle_per_host(8)` fixed** (previously pinned at startup to the current `downloadParallelism`): runtime changes to `downloadParallelism` now take effect immediately without rebuilding the client or restarting the app. The pool is a cache sized to the max; the per-download Semaphore controls effective concurrency. The literal `8` is maintenance-coupled to `Settings::resolve_segment_concurrency`'s max clamp (documented inline via a `Constraint:` tag).
- **`tcp_keepalive(60s)` + `pool_idle_timeout(120s)`**: stabilize idle connection reuse across gaps between segment fetches; dead peers are evicted by keepalive probes.
- **`connect_timeout(10s)`**: a hung TCP/TLS handshake now fails fast and rotates to the next CDN instead of burning the full 120s budget.

Values follow reqwest's documented best practices (verified via Context7).

## Related Issue

No direct issue. Follow-up optimization to the parallel segment download work (#491 / #490).

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] 🔧 Chore

Performance tuning of connection pool / timeouts (no new user-facing feature).

## Test Plan

- [x] `cargo build` compiles
- [x] `cargo clippy --all-targets` passes
- [x] Manual download test (video + audio) completed during verification

## Breaking Changes

None. Connection pool/timeout tuning only; no API or user-visible behavior change.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (config tuning, no new logic paths)
- [x] i18n files synced — N/A (no user-facing text changed)