### PR TITLE
fix(tooltip): forward side prop to Radix Content for correct placement

### DIFF
--- a/src/shared/animate-ui/radix/tooltip.tsx
+++ b/src/shared/animate-ui/radix/tooltip.tsx
@@ -106,6 +106,12 @@ function TooltipContent({
         <TooltipPrimitive.Portal forceMount data-slot="tooltip-portal">
           <TooltipPrimitive.Content
             forceMount
+            // Why: forward `side` to Radix so placement matches the motion direction.
+            //      `side` is destructured above and consumed only by getInitialPosition
+            //      for the enter/exit offset, so it never reaches Content via {...props}.
+            // Caution: Radix may flip the side on collision; the motion offset is fixed
+            //          from the requested `side` and won't track that flip.
+            side={side}
             sideOffset={sideOffset}
             className="z-50"
             {...props}


### PR DESCRIPTION
## Summary

`TooltipContent` destructured the `side` prop but never forwarded it to the underlying Radix `<TooltipPrimitive.Content>`. As a result, `side="right"` (and any non-`top` value) was silently ignored — Radix always placed the tooltip at its default `top` side, while the motion animation used the requested `side`. This caused sidebar menu tooltips to appear **above** items instead of **to the right** when the sidebar was collapsed.

The fix is a one-line change: pass `side={side}` to `TooltipPrimitive.Content` so the actual placement matches the motion direction.

## Related Issue

No related issue found.

## Type of Change

- [x] 🐛 Bug fix

## Root Cause

`side` was destructured (default `'top'`) and consumed only by `getInitialPosition(side)` for the motion enter/exit offset. Being destructured, it never reached Radix via `{...props}` either, so Radix fell back to its built-in default (`top`) — confirmed via [Radix docs](https://www.radix-ui.com/primitives/docs/components/tooltip#content).

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Collapse the sidebar (click the toggle button)
- [ ] Hover over each menu item (Home / Trim / Concat / Audio / etc.)
- [ ] Verify the tooltip appears to the **right** of the icon (not above)
- [ ] Expand the sidebar and confirm tooltips still hide as before

## Impact (all intended — these callers already specified `side="right"`)

- Sidebar menu items (`SidebarMenuButton`) — the main goal
- Sidebar collapse/expand toggle (`EnhancedSidebarTrigger`)
- VideoPartCard audio quality / subtitle info tooltips

`side="top"` (explicit) and unspecified callers are unchanged.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (1-line shared-component fix, no new logic to test)
- [x] i18n files synced — N/A (no user-facing text changed)