### PR TITLE
fix(download-status): left-align part title tooltip and arrow

### DIFF
--- a/src/features/download-status/ui/PartStatusRow.tsx
+++ b/src/features/download-status/ui/PartStatusRow.tsx
@@ -136,7 +136,17 @@ export function PartStatusRow({
             {rawName}
           </span>
         </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-lg break-all">
+        <TooltipContent
+          side="top"
+          align="start"
+          // CAUTION: align="start" moves the tooltip to the trigger's left edge,
+          // but Radix keeps the arrow pointing at the trigger center (see the
+          // inline `left` on its arrow-wrapper span). Pin the arrow to the
+          // content's left edge so it points at the title's start, not its
+          // middle. `[&>span]` targets that Radix arrow wrapper; the `!` is
+          // required to override the inline `left`.
+          className="max-w-lg break-all [&>span]:!left-3"
+        >
           {tooltipName}
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## Summary

Left-align the part title tooltip and its arrow in the download status dialog. Previously the tooltip was horizontally centered and its arrow pointed at the trigger center, which looked misaligned under the truncated title.

- `align="start"` — the tooltip's left edge now matches the title's left edge.
- `[&>span]:!left-3` — pins the Radix arrow to the content's left edge. Radix otherwise keeps the arrow pointing at the trigger center even with `align="start"`, so the `!` is required to override the inline `left` it sets on the arrow-wrapper span.

## Related Issue

None (direct user request).

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Start a download to open the download status dialog
- [ ] Hover a part title
- [ ] Verify the tooltip's left edge aligns with the title's left edge and the arrow points at the title's start

## Breaking Changes

None.

## Checklist

- [x] \`/review-all\` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (N/A — UI-only positioning tweak, no logic change)
- [x] i18n files synced (N/A — no translation key changes)