### PR TITLE
feat(video): debounce title validation for real-time feedback

### DIFF
--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -293,6 +293,31 @@ const VideoPartCard = memo(function VideoPartCard({
   useEffect(() => {
     mountedRef.current = true
   }, [])
+
+  // Debounce timer for deferred title validation. Holds the pending
+  // timeout so it can be cancelled on blur or unmount.
+  const titleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cancel any pending debounced validation. Used on blur (so the
+  // form-level onBlur flushes the save once) and on unmount (to avoid
+  // updating form state after the component is gone). The null guard
+  // also narrows the ref type for clearTimeout.
+  const cancelPendingTitleValidation = useCallback(() => {
+    if (titleDebounceRef.current) {
+      clearTimeout(titleDebounceRef.current)
+      titleDebounceRef.current = null
+    }
+  }, [])
+
+  // Constraint: Relies on `cancelPendingTitleValidation` staying referentially
+  // stable (its useCallback above uses `[]` deps) so cleanup fires only on
+  // unmount. Adding deps to that useCallback would re-run this effect on every
+  // render, clearing the in-flight timer each keystroke and silently disabling
+  // the debounced validation.
+  useEffect(() => {
+    return cancelPendingTitleValidation
+  }, [cancelPendingTitleValidation])
+
   /**
    * Transition override applied only on initial mount when the accordion is
    * already open (e.g. restored from Redux state). Prevents the animated
@@ -661,7 +686,32 @@ const VideoPartCard = memo(function VideoPartCard({
                             placeholder={t('video.title_placeholder')}
                             className="min-h-[52px] resize-none"
                             rows={3}
-                            {...field}
+                            value={field.value}
+                            onChange={(e) => {
+                              field.onChange(e.target.value)
+
+                              // Debounce validation so it only fires after
+                              // the user pauses typing, avoiding noisy
+                              // per-keystroke error flashes. When valid, also
+                              // flush the auto-save so the download-ready
+                              // state updates without requiring blur.
+                              cancelPendingTitleValidation()
+                              titleDebounceRef.current = setTimeout(() => {
+                                void form.trigger('title').then((isValid) => {
+                                  if (isValid) {
+                                    void form.handleSubmit(onSubmit)()
+                                  }
+                                })
+                              }, 500)
+                            }}
+                            onBlur={() => {
+                              // Cancel any not-yet-fired debounce timer so the
+                              // form-level onBlur flushes the save once. If the
+                              // timer already fired, the extra dispatch is
+                              // idempotent (same title value).
+                              cancelPendingTitleValidation()
+                              field.onBlur()
+                            }}
                           />
                         </FormControl>
                         {selected && <FormMessage />}


### PR DESCRIPTION
## Summary

The title input on the video part card (Step 2) required **blur** before the validation result and the download-ready state would update. After entering an invalid filename character (e.g. `/`, `:`, `*`) and correcting it, the error stayed visible and the part was not marked valid until the field lost focus.

## Changes

- Add debounced validation to the title `Textarea` in `VideoPartCard`
- `onChange` updates the value immediately, then after **500ms** of inactivity runs `form.trigger('title')` and, if valid, flushes the auto-save (`form.handleSubmit(onSubmit)()`) so the download-ready state updates without requiring blur
- The existing form-level `onBlur={form.handleSubmit(onSubmit)}` is kept as a fallback; the Textarea `onBlur` cancels any pending debounce timer to avoid a duplicate save
- Extracted a `cancelPendingTitleValidation` helper to share the clear-and-null sequence across unmount / re-schedule / blur

## Why debounce (not per-keystroke)

Per-keystroke validation (`mode: 'onChange'`) would flash the "invalid filename characters" error on every keystroke while typing. Debouncing validates only after the user pauses typing (500ms), keeping the signal clean.

## Verification

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Human verification

### Manual checklist

1. Typing in the title does not show errors on every keystroke (500ms debounce)
2. After pausing ~500ms, the part is validated and — if valid — the download-ready state updates **without blur**
3. Entering `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|` (Windows) and pausing shows the error
4. Correcting an invalid title and pausing clears the error and updates the ok state without blur
5. Blur still saves immediately (fallback behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)