### PR TITLE
fix(download-status): prevent part row left-edge clipping in dialog

### DIFF
--- a/src/features/download-status/ui/DownloadStatusDialog.tsx
+++ b/src/features/download-status/ui/DownloadStatusDialog.tsx
@@ -32,6 +32,17 @@ import { PartStatusRow } from './PartStatusRow'
  * スクロール領域は ScrollArea ではなく overflow-y-auto の div を使い、
  * 内容の max-content に水平に広がらないようにする。
  * TooltipProvider は PartStatusRow の Tooltip 表示に必要。
+ *
+ * @why overflow-x-clip + px-1: `overflow-y-auto` promotes the computed
+ *   `overflow-x` from `visible` to `auto` (CSS Overflow spec: a `visible`
+ *   axis is forced to `auto` when the other axis is non-`visible`), which
+ *   clips a child's box-shadow at the container edge. Each PartStatusRow's
+ *   `ring-1` sits 1px outside its border box flush against this container's
+ *   left edge, so without `px-1` the left ring — and the row's left rounded
+ *   corner — gets clipped (visible as the "left edge cut off"). `px-1`
+ *   reserves a gutter so the ring renders; `overflow-x-clip` also suppresses
+ *   any implicit horizontal scrollbar, honoring the "don't expand
+ *   horizontally" intent above.
  */
 export function DownloadStatusDialog() {
   const { t } = useTranslation()
@@ -56,7 +67,7 @@ export function DownloadStatusDialog() {
           {rows.length > 0 && <OverallProgressBar />}
           <div
             className={cn(
-              'max-h-[80vh] min-h-[22rem] overflow-y-auto pr-1',
+              'max-h-[80vh] min-h-[22rem] overflow-x-clip overflow-y-auto px-1',
               rows.length === 0 && 'flex items-center justify-center',
             )}
           >


### PR DESCRIPTION
## Summary

Fix a visual bug in the download status dialog where the left edge of each part row (the rounded corner + the `ring-1`) appeared clipped / cut off.

The scroll container used `overflow-y-auto`, which per the CSS Overflow spec forces the computed `overflow-x` from `visible` to `auto`. That clipped each `PartStatusRow`'s `ring-1` (box-shadow) flush at the container's left edge — the right side was fine because of the existing `pr-1` gutter, but the left had no gutter.

Fix: replace `pr-1` with `px-1` (a symmetrical 4px gutter so the 1px ring renders) and add `overflow-x-clip` (suppress any implicit horizontal scrollbar that the forced `overflow-x: auto` would otherwise enable). The non-obvious CSS behavior is documented in a `@why` JSDoc tag.

## Related Issue

None (no matching open issue found).

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] Open the download status dialog (auto-opens on download start, or reopen from the sidebar)
- [x] Verify the left edge of downloading part rows (`ring-1` + rounded corner) renders fully — no clipping
- [x] Verify narrow window widths also render the left edge correctly
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

## Screenshots / Videos (Optional)

N/A (verified visually by the user).

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (CSS-class-only change)
- [x] i18n files synced (all 6 languages) — N/A (no i18n keys changed)