### PR TITLE
feat(font): apply Noto Sans JP and preload during splash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bilibili Downloader</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <!-- Caution: crossorigin is required on THIS preconnect only. Font files
+         from fonts.gstatic.com are fetched via an anonymous CORS request, so
+         without crossorigin the preopened connection is not reused and the
+         browser opens a second one, defeating the preconnect. The
+         googleapis.com preconnect above intentionally omits it because the
+         stylesheet response is not a CORS request. (web.dev/preconnect) -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
     <script>
       ;(function () {
         var t = localStorage.getItem('ui-theme') || 'system'

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "macOSPrivateApi": true,
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' http: https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; img-src 'self' http: https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"
     }
   },
   "plugins": {

--- a/src/features/splash/hooks/useSplashLifecycle.ts
+++ b/src/features/splash/hooks/useSplashLifecycle.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { sleep } from '@/shared/lib/utils'
 
-import { MIN_DISPLAY_MS } from '../lib/constants'
+import { FONT_LOAD_TIMEOUT_MS, MIN_DISPLAY_MS } from '../lib/constants'
 
 /** Represents the current visual state of the splash screen. */
 type SplashPhase = 'active' | 'fading' | 'done'
@@ -60,10 +60,20 @@ export function useSplashLifecycle(): SplashLifecycle {
       if (disposedRef.current) return
       setSkipMode(skip)
 
-      // Run backend initialization. Phase B-1: skeleton returns immediately.
-      // Phase B-2 will port the ffmpeg/cookie/user steps here and emit
-      // init_step / init_progress events that the splash UI renders.
-      await invoke('initialize').catch(() => {})
+      // Run backend initialization in parallel with the web font preload.
+      // Loading Noto Sans JP during splash lets the main window (a separate
+      // webview sharing this Tauri process's HTTP cache) render the same font
+      // without FOUT. Skip mode bypasses the font wait for fastest startup,
+      // symmetric with the MIN_DISPLAY_MS skip below. The timeout guards
+      // against slow networks; on expiry the font-family fallback still applies.
+      const fontReady = skip
+        ? Promise.resolve()
+        : Promise.race([
+            document.fonts.load('400 16px "Noto Sans JP"'),
+            sleep(FONT_LOAD_TIMEOUT_MS),
+          ]).catch(() => {})
+
+      await Promise.all([invoke('initialize').catch(() => {}), fontReady])
 
       if (!skip) {
         await sleep(MIN_DISPLAY_MS)

--- a/src/features/splash/lib/constants.ts
+++ b/src/features/splash/lib/constants.ts
@@ -2,6 +2,12 @@
 export const MIN_DISPLAY_MS = 2_000
 /** Duration (ms) of the CSS opacity fade-out transition. */
 export const FADE_DURATION_MS = 700
+/**
+ * Maximum time (ms) to wait for the web font to finish loading during the
+ * splash phase before proceeding. Guards against slow networks stalling
+ * startup; the font-family fallback chain still applies on timeout.
+ */
+export const FONT_LOAD_TIMEOUT_MS = 4_000
 
 /** Number of floating particles in the 3D scene. */
 export const PARTICLE_COUNT = 150

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
   font-weight: 400;
@@ -52,6 +52,11 @@
 }
 
 @theme inline {
+  /* Caution: In Tailwind v4 this token drives the `font-sans` utility and
+     theme font defaults. It must stay in sync with the :root font-family
+     above so utility-driven elements pick up Noto Sans JP too; updating only
+     one leaves Tailwind-styled components on the fallback stack. */
+  --font-sans: 'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);


### PR DESCRIPTION
## Summary

Apply **Noto Sans JP** (Google Fonts CDN, variable weight `wght@100..900`) as the preferred font across all 6 languages. The font is preloaded during the splash screen so the main window — a separate webview sharing the Tauri process's HTTP cache — renders without FOUT (Flash of Unstyled Text).

### Changes
- **index.html**: add Google Fonts `preconnect` + `stylesheet` links (variable font, `display=swap`)
- **tauri.conf.json**: allow `fonts.googleapis.com` (`style-src`) and `fonts.gstatic.com` (`font-src`) in the CSP — required, since `default-src 'self'` would otherwise block the external font
- **index.css**: prepend `'Noto Sans JP'` to `:root` font-family, and add `@theme inline --font-sans` so Tailwind's `font-sans` utility stays in sync (previously it fell back to Tailwind's default stack)
- **useSplashLifecycle.ts**: run `initialize()` in parallel with `document.fonts.load()`; skip-mode bypasses the font wait for fastest startup; `FONT_LOAD_TIMEOUT_MS` guards against slow networks
- **constants.ts**: add `FONT_LOAD_TIMEOUT_MS` (4s)

### Why a variable font
A single variable font file covers all weights used across the UI (extralight–semibold), which is smaller than loading multiple static weights. Splash-phase preload warms the shared HTTP cache so the main window hits cache.

## Related Issue

N/A (no related open issue found)

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Run `npm run tauri dev` and verify:
  - [ ] Splash → main window transitions normally
  - [ ] Font is Noto Sans JP (DevTools → Computed → font-family)
  - [ ] No CSP violations in DevTools Console (`fonts.googleapis.com` / `fonts.gstatic.com` not blocked)
  - [ ] No FOUT when the main window appears
  - [ ] `skipSplashAnimation` setting still launches normally

## Breaking Changes

None. Offline / timed-out requests fall back to `system-ui` via the font-family stack.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated — N/A (font asset / config change; no logic requiring new tests)
- [x] i18n files synced — N/A (no user-facing text keys added)