### PR TITLE
feat(subtitle): show download progress and add HTTP timeout

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -956,7 +956,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         // Subtitle processing
         let (subtitle_mode, subtitle_language_labels, subtitle_failed_labels) =
             prepare_subtitle_mode(
-                &app,
+                app,
                 &options.subtitle,
                 &cookies,
                 &options.bvid,

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -956,6 +956,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         // Subtitle processing
         let (subtitle_mode, subtitle_language_labels, subtitle_failed_labels) =
             prepare_subtitle_mode(
+                &app,
                 &options.subtitle,
                 &cookies,
                 &options.bvid,
@@ -2912,6 +2913,14 @@ pub async fn fetch_part_qualities(
     Err("ERR::NO_STREAM".to_string())
 }
 
+/// Timeout (seconds) for a single subtitle download request.
+///
+/// Subtitle payloads are small, but Bilibili's CDN occasionally stalls and
+/// holds the connection open. Without a cap the request hangs indefinitely,
+/// which surfaces to the user as a frozen download. The retry layer
+/// (`download_subtitle_with_retry`) still handles transient failures.
+const SUBTITLE_DOWNLOAD_TIMEOUT_SECS: u64 = 30;
+
 /// Downloads a subtitle and saves it in SRT format.
 ///
 /// Fetches BCC format JSON subtitle from Bilibili, converts to SRT format,
@@ -2951,6 +2960,7 @@ pub async fn download_subtitle(
 
     let response = client
         .get(&url)
+        .timeout(Duration::from_secs(SUBTITLE_DOWNLOAD_TIMEOUT_SECS))
         .send()
         .await
         .map_err(|e| format!("Failed to download subtitle: {}", e))?;
@@ -3079,6 +3089,7 @@ async fn download_subtitle_with_retry(
 ///
 /// Returns an error if the HTTP client cannot be constructed.
 async fn prepare_subtitle_mode(
+    app: &AppHandle,
     subtitle_opts: &Option<SubtitleOptions>,
     cookies: &[CookieEntry],
     bvid: &str,
@@ -3095,6 +3106,25 @@ async fn prepare_subtitle_mode(
     };
 
     let client = build_client()?;
+
+    // Emit a "subtitle" progress stage so the frontend can surface that the
+    // subtitle download is running. Without this, the UI stays frozen at
+    // audio/video 100% for the whole fetch + retry loop and looks hung.
+    // Why a single emit with no periodic updates: subtitle payloads are small
+    // and fetched in parallel per language, so there is no meaningful
+    // byte-level progress to stream — the frontend renders this as an
+    // indeterminate "downloading..." state.
+    // Why after build_client: on client construction failure we return early
+    // without emitting, so no orphan "subtitle" entry is left in the
+    // frontend's progress slice bound to this download_id.
+    let _ = app.emit(
+        "progress",
+        crate::emits::Progress {
+            stage: Some("subtitle".to_string()),
+            download_id: download_id.to_string(),
+            ..Default::default()
+        },
+    );
 
     // Initial subtitles from frontend or API
     let initial_subs: Vec<SubtitleDto> = if !sub_opts.subtitles.is_empty() {

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -105,7 +105,7 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
         // Update queue status based on progress stage
         const isDownloadStage =
-          stage && ['audio', 'video', 'merge'].includes(stage)
+          stage && ['audio', 'video', 'merge', 'subtitle'].includes(stage)
         if (stage === 'complete') {
           // Mark as done - keep in queue so completion actions remain visible
           store.dispatch(updateQueueStatus({ downloadId, status: 'done' }))

--- a/src/features/download-status/model/selectors.ts
+++ b/src/features/download-status/model/selectors.ts
@@ -88,6 +88,7 @@ function pickStageData(entries: Progress[]): {
   const audio = byStage('audio')
   const video = byStage('video')
   const merge = byStage('merge')
+  const subtitle = byStage('subtitle')
   const audioPct = audio?.percentage ?? (merge ? 100 : 0)
   const videoPct = video?.percentage ?? (merge ? 100 : 0)
   const mergePct = merge?.percentage ?? 0
@@ -106,7 +107,12 @@ function pickStageData(entries: Progress[]): {
       (audio?.isRetrying ?? false) ||
       (video?.isRetrying ?? false) ||
       (merge?.isRetrying ?? false),
-    stage: merge ? 'merge' : 'download',
+    // @why: merge takes precedence over subtitle. The subtitle entry lingers
+    //   in state after the subtitle download finishes (it is never re-emitted
+    //   or cleared), so if subtitle won, the merge stage would be skipped and
+    //   the row would jump straight from "subtitle downloading" to "complete".
+    //   Prioritizing merge lets the merge stage render once ffmpeg starts.
+    stage: merge ? 'merge' : subtitle ? 'subtitle' : 'download',
     isComplete: false,
   }
 }

--- a/src/features/download-status/ui/PartStatusRow.tsx
+++ b/src/features/download-status/ui/PartStatusRow.tsx
@@ -65,6 +65,30 @@ function StageMini({
   )
 }
 
+/** Compact inline subtitle stage: icon + indeterminate bar (no %, no speed).
+ *
+ * Subtitle download has no byte-level progress (small JSON payload, parallel
+ * per-language fetch), so we show a pulsing bar to signal "working" rather
+ * than a misleading percentage. Keeps the same h-1.5 w-16 bar shape as
+ * StageMini so the row stays visually aligned. */
+function SubtitleStageMini({ tooltipLabel }: { tooltipLabel: string }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default text-xs">💬</span>
+          </TooltipTrigger>
+          <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <div className="bg-primary/20 relative h-1.5 w-16 overflow-hidden rounded-full">
+        <div className="bg-primary h-full w-full animate-pulse rounded-full" />
+      </div>
+    </div>
+  )
+}
+
 /**
  * ダイアログ内の1パート分の行（1行、横並び）。
  *
@@ -150,7 +174,9 @@ export function PartStatusRow({
           {tooltipName}
         </TooltipContent>
       </Tooltip>
-      {/* DL中: audio + video inline */}
+      {/* DL中: audio + video inline (download + subtitle stages).
+          During the subtitle stage audio/video are already at 100%, so we keep
+          them visible and append an indeterminate subtitle indicator. */}
       {isDownloading && part.stage !== 'merge' && (
         <>
           <StageMini
@@ -165,6 +191,11 @@ export function PartStatusRow({
             stage={part.video}
             showSpeed
           />
+          {part.stage === 'subtitle' && (
+            <SubtitleStageMini
+              tooltipLabel={t('downloadStatus.stage_subtitle')}
+            />
+          )}
         </>
       )}
       {/* マージ中: merge bar only */}

--- a/src/features/video/ui/PartDownloadProgress.tsx
+++ b/src/features/video/ui/PartDownloadProgress.tsx
@@ -200,6 +200,34 @@ function MergeStageProgress({ progressEntries, t }: MergeStageProgressProps) {
   return null
 }
 
+type SubtitleStageProgressProps = {
+  t: (key: string) => string
+}
+
+/**
+ * Renders the subtitle download stage in the merge column.
+ *
+ * Shown while subtitles are fetching (after audio/video reach 100%, before
+ * merge starts) so the card doesn't appear frozen. Indeterminate — no
+ * percentage — because subtitle payloads are small and fetched in parallel
+ * per language, so there is no meaningful byte-level progress to show.
+ */
+function SubtitleStageProgress({ t }: SubtitleStageProgressProps) {
+  const label = t('video.stage_subtitle')
+  return (
+    <div
+      className={`flex ${MIN_HEIGHT} items-center gap-1`}
+      aria-label={`${label}: ${t('video.stage_subtitle_downloading')}`}
+    >
+      <StageIcon icon="💬" label={label} fontWeight="medium" />
+      <span className="font-medium">
+        {' '}
+        {t('video.stage_subtitle_downloading')}
+      </span>
+    </div>
+  )
+}
+
 type Props = {
   status: PartDownloadStatus
   isWaitingForTurn?: boolean
@@ -256,6 +284,11 @@ export function PartDownloadProgress({
   const isInMergeStage = progressEntries.some(
     (p) => p.stage === 'merge' && !p.isComplete,
   )
+
+  // @why: subtitle stage runs after audio/video reach 100% and before merge.
+  //   Detected separately so the merge column can swap to an indeterminate
+  //   "subtitle downloading" state instead of freezing at 100%.
+  const hasSubtitleStage = progressEntries.some((p) => p.stage === 'subtitle')
 
   // Why: merge-stage cancellation is disabled because killing ffmpeg mid-merge
   // races with the final write and produces a contradictory (cancelled-but-
@@ -364,7 +397,11 @@ export function PartDownloadProgress({
               />
             </div>
             <div className="flex-1">
-              <MergeStageProgress progressEntries={progressEntries} t={t} />
+              {hasSubtitleStage ? (
+                <SubtitleStageProgress t={t} />
+              ) : (
+                <MergeStageProgress progressEntries={progressEntries} t={t} />
+              )}
             </div>
           </div>
           {/* Video-only stage: visible when hasEmbeddedAudio and not fading */}
@@ -380,7 +417,9 @@ export function PartDownloadProgress({
                 />
               </div>
               <div className="flex-1" />
-              <div className="flex-1" />
+              <div className="flex-1">
+                {hasSubtitleStage && <SubtitleStageProgress t={t} />}
+              </div>
             </>
           )}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -246,6 +246,8 @@
     "stage_merge": "Merge",
     "stage_waiting": "Waiting...",
     "stage_merging": "Processing...",
+    "stage_subtitle": "Subtitles",
+    "stage_subtitle_downloading": "Downloading subtitles...",
     "merging": "Merging...",
     "download_complete": "Complete",
     "open_file": "Open File",
@@ -689,7 +691,8 @@
     "status_merging": "Merging",
     "stage_audio": "Audio",
     "stage_video": "Video",
-    "stage_merge": "Merge"
+    "stage_merge": "Merge",
+    "stage_subtitle": "Subtitles"
   },
   "audio": {
     "title": "Audio Extraction",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -246,6 +246,8 @@
     "stage_merge": "Fusionar",
     "stage_waiting": "Esperando...",
     "stage_merging": "Procesando...",
+    "stage_subtitle": "Subtítulos",
+    "stage_subtitle_downloading": "Descargando subtítulos...",
     "merging": "Fusionando...",
     "download_complete": "Completo",
     "open_file": "Abrir archivo",
@@ -689,7 +691,8 @@
     "status_merging": "Combinando",
     "stage_audio": "Audio",
     "stage_video": "Video",
-    "stage_merge": "Combinar"
+    "stage_merge": "Combinar",
+    "stage_subtitle": "Subtítulos"
   },
   "audio": {
     "title": "Extracción de audio",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -246,6 +246,8 @@
     "stage_merge": "Fusion",
     "stage_waiting": "En attente...",
     "stage_merging": "Traitement...",
+    "stage_subtitle": "Sous-titres",
+    "stage_subtitle_downloading": "Téléchargement des sous-titres...",
     "merging": "Fusion...",
     "download_complete": "Terminé",
     "open_file": "Ouvrir le fichier",
@@ -689,7 +691,8 @@
     "status_merging": "Fusion",
     "stage_audio": "Audio",
     "stage_video": "Vidéo",
-    "stage_merge": "Fusion"
+    "stage_merge": "Fusion",
+    "stage_subtitle": "Sous-titres"
   },
   "audio": {
     "title": "Extraction audio",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -246,6 +246,8 @@
     "stage_merge": "マージ",
     "stage_waiting": "待機中...",
     "stage_merging": "実行中...",
+    "stage_subtitle": "字幕",
+    "stage_subtitle_downloading": "字幕をダウンロード中...",
     "merging": "マージ中...",
     "download_complete": "完了",
     "open_file": "ファイルを開く",
@@ -689,7 +691,8 @@
     "status_merging": "マージ中",
     "stage_audio": "音声",
     "stage_video": "動画",
-    "stage_merge": "マージ"
+    "stage_merge": "マージ",
+    "stage_subtitle": "字幕"
   },
   "audio": {
     "title": "音声抽出",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -246,6 +246,8 @@
     "stage_merge": "병합",
     "stage_waiting": "대기 중...",
     "stage_merging": "처리 중...",
+    "stage_subtitle": "자막",
+    "stage_subtitle_downloading": "자막 다운로드 중...",
     "merging": "병합 중...",
     "download_complete": "완료",
     "open_file": "파일 열기",
@@ -689,7 +691,8 @@
     "status_merging": "병합 중",
     "stage_audio": "오디오",
     "stage_video": "비디오",
-    "stage_merge": "병합"
+    "stage_merge": "병합",
+    "stage_subtitle": "자막"
   },
   "audio": {
     "title": "오디오 추출",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -246,6 +246,8 @@
     "stage_merge": "合并",
     "stage_waiting": "等待中...",
     "stage_merging": "处理中...",
+    "stage_subtitle": "字幕",
+    "stage_subtitle_downloading": "正在下载字幕...",
     "merging": "合并中...",
     "download_complete": "完成",
     "open_file": "打开文件",
@@ -689,7 +691,8 @@
     "status_merging": "合并中",
     "stage_audio": "音频",
     "stage_video": "视频",
-    "stage_merge": "合并"
+    "stage_merge": "合并",
+    "stage_subtitle": "字幕"
   },
   "audio": {
     "title": "音频提取",


### PR DESCRIPTION
## Summary

Subtitles download after audio/video reach 100% and before merge, but the UI froze at 100% during the subtitle fetch (no progress event was emitted), and the subtitle HTTP request had no timeout — so a stalled CDN connection could hang indefinitely and look like a frozen download.

This change:
- Emits a `stage="subtitle"` progress event once when the subtitle download starts. The frontend renders an indeterminate 💬 indicator in the merge column (download-status dialog row and home card) instead of freezing at 100%.
- Adds a 30s timeout to the subtitle HTTP request. `build_client` is intentionally untouched since it is shared with large video/audio downloads.
- In `selectors`, `merge` takes precedence over `subtitle` because the subtitle entry lingers in Redux state after the fetch completes (otherwise the merge stage is skipped and the row jumps straight to "complete").

## Related Issue

None (no matching open issue found).

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Test Plan

- [x] `npm run lint` / `npm run typecheck` clean
- [x] `cargo build` clean
- [ ] Download a video with subtitles (soft/hard) and verify 💬 shows after audio/video hit 100%, then switches to 🔄 merging, then ✅ complete
- [ ] Verify no 💬 indicator when subtitles are off

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed
- [x] Conventional Commits format followed
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)
- [ ] Tests added/updated — N/A (no existing tests for these components; selectors precedence verified in review)