### PR TITLE
fix(video): select only the targeted bangumi episode on URL input

### DIFF
--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -10,6 +10,7 @@ import {
   buildVideoFormSchema1,
   buildVideoFormSchema2,
 } from '@/features/video/lib/formSchema'
+import { shouldSelectPart } from '@/features/video/lib/partSelection'
 import { extractContentId } from '@/features/video/lib/utils'
 import {
   clearPendingDownload,
@@ -156,21 +157,17 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
   /**
    * Initializes part input fields based on video metadata.
    *
-   * When a pending download exists (from history/favorites), only the
-   * target part is marked as selected. This prevents a race condition
-   * where all parts would briefly be selected, triggering duplicate
-   * title detection before the selection effect could run.
+   * Selection of each part is delegated to {@link shouldSelectPart},
+   * which selects only the targeted episode for a bangumi URL, only the
+   * requested part for a `?p=N` URL or history/favorites navigation,
+   * and otherwise only the first page.
    *
    * @param v - Video object
    */
   const initInputsForVideo = useCallback((v: Video) => {
     const pending = processingPendingRef.current
 
-    const isSelected = (p: (typeof v.parts)[0]) =>
-      !pending ||
-      (pending.cid !== null ? p.cid === pending.cid : p.page === pending.page)
-
-    const partInputs = v.parts.map((p) => ({
+    const partInputs = v.parts.map((p, index) => ({
       cid: p.cid,
       page: p.page,
       title:
@@ -179,7 +176,11 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
           : `${v.title} ${p.sanitizedPart ?? p.part}`,
       videoQuality: '',
       audioQuality: '',
-      selected: isSelected(p),
+      selected: shouldSelectPart(p, index, {
+        contentType: v.contentType,
+        videoEpId: v.epId,
+        pending,
+      }),
       duration: p.duration,
       thumbnailUrl: p.thumbnail.url,
       qualitiesLoading: false,

--- a/src/features/video/index.ts
+++ b/src/features/video/index.ts
@@ -59,6 +59,7 @@ export { normalizeFilename } from './lib/utils'
 export {
   AUDIO_QUALITIES_MAP,
   AUDIO_QUALITIES_ORDER,
+  PARTS_PER_PAGE,
   VIDEO_QUALITIES_MAP,
 } from './lib/constants'
 

--- a/src/features/video/lib/constants.ts
+++ b/src/features/video/lib/constants.ts
@@ -60,3 +60,12 @@ export const VIDEO_CODEC_MAP: Record<number, string> = {
   [CODECID_HEVC]: 'HEVC',
   [CODECID_AV1]: 'AV1',
 }
+
+/**
+ * Number of parts displayed per page in the paginated part list.
+ *
+ * Also bounds the default selection when a URL does not identify a
+ * specific part/episode: only the first page is selected by default
+ * to avoid silently queuing every part of a large series.
+ */
+export const PARTS_PER_PAGE: number = 10

--- a/src/features/video/lib/partSelection.test.ts
+++ b/src/features/video/lib/partSelection.test.ts
@@ -1,0 +1,83 @@
+import { shouldSelectPart } from '@/features/video/lib/partSelection'
+import type { VideoPart } from '@/features/video/types'
+import { describe, expect, it } from 'vitest'
+
+/** Minimal VideoPart factory for tests. */
+const makePart = (overrides: Partial<VideoPart> = {}): VideoPart => ({
+  part: 'Part',
+  page: 1,
+  cid: 100,
+  duration: 60,
+  videoQualities: [],
+  audioQualities: [],
+  thumbnail: { url: '' },
+  subtitles: [],
+  ...overrides,
+})
+
+describe('shouldSelectPart', () => {
+  describe('bangumi with a requested epId', () => {
+    const ctx = {
+      contentType: 'bangumi' as const,
+      videoEpId: 825757,
+      pending: null,
+    }
+
+    it('selects only the part whose epId matches', () => {
+      expect(shouldSelectPart(makePart({ epId: 825757 }), 0, ctx)).toBe(true)
+      expect(shouldSelectPart(makePart({ epId: 999999 }), 1, ctx)).toBe(false)
+    })
+
+    it('does not fall back to first-page selection when epId is set', () => {
+      // Even at index 0 (< PARTS_PER_PAGE), a non-matching epId is not selected
+      expect(shouldSelectPart(makePart({ epId: 1 }), 0, ctx)).toBe(false)
+    })
+  })
+
+  describe('video with a pending download', () => {
+    it('selects by cid when pending.cid is provided', () => {
+      const ctx = {
+        contentType: 'video' as const,
+        pending: { bvid: 'BV1xx', cid: 200, page: 1 },
+      }
+      expect(shouldSelectPart(makePart({ cid: 200 }), 5, ctx)).toBe(true)
+      expect(shouldSelectPart(makePart({ cid: 999 }), 0, ctx)).toBe(false)
+    })
+
+    it('selects by page when pending.cid is null', () => {
+      const ctx = {
+        contentType: 'video' as const,
+        pending: { bvid: 'BV1xx', cid: null, page: 3 },
+      }
+      expect(shouldSelectPart(makePart({ page: 3 }), 2, ctx)).toBe(true)
+      expect(shouldSelectPart(makePart({ page: 1 }), 0, ctx)).toBe(false)
+    })
+  })
+
+  describe('default (no specific target)', () => {
+    const ctx = {
+      contentType: 'video' as const,
+      pending: null,
+    }
+
+    it('selects only the first page', () => {
+      expect(shouldSelectPart(makePart(), 0, ctx)).toBe(true)
+      expect(shouldSelectPart(makePart(), 9, ctx)).toBe(true)
+    })
+
+    it('does not select parts beyond the first page', () => {
+      expect(shouldSelectPart(makePart(), 10, ctx)).toBe(false)
+      expect(shouldSelectPart(makePart(), 83, ctx)).toBe(false)
+    })
+
+    it('falls back to first-page selection for bangumi without epId', () => {
+      const bangumiCtx = {
+        contentType: 'bangumi' as const,
+        videoEpId: undefined,
+        pending: null,
+      }
+      expect(shouldSelectPart(makePart(), 0, bangumiCtx)).toBe(true)
+      expect(shouldSelectPart(makePart(), 10, bangumiCtx)).toBe(false)
+    })
+  })
+})

--- a/src/features/video/lib/partSelection.ts
+++ b/src/features/video/lib/partSelection.ts
@@ -1,0 +1,59 @@
+import type { ContentType, VideoPart } from '../types'
+import { PARTS_PER_PAGE } from './constants'
+
+/**
+ * Context used to decide the initial selection state of a part.
+ */
+export type SelectionContext = {
+  /** Content type of the fetched video ("video" or "bangumi"). */
+  contentType: ContentType
+  /**
+   * Episode ID requested via the bangumi URL (e.g. ep825757).
+   *
+   * Populated by the backend on the top-level `Video.epId` field for
+   * bangumi content. Undefined for regular videos.
+   */
+  videoEpId?: number
+  /**
+   * Pending download from history/favorites, or a video `?p=N` URL.
+   *
+   * Null when the URL does not identify a specific part (e.g. a plain
+   * video URL without `?p`, or a bangumi URL — bangumi is handled via
+   * `videoEpId` instead).
+   */
+  pending: { bvid: string; cid: number | null; page: number } | null
+}
+
+/**
+ * Determines whether a part should be initially selected after fetching.
+ *
+ * Selection priority:
+ * 1. Bangumi with a requested `videoEpId` → only the matching episode.
+ *    A bangumi URL always targets one episode (via epId), so selecting
+ *    only that episode prevents silently queuing an entire season.
+ * 2. Pending download (cid/page) → the specific part from a `?p=N` URL
+ *    or from history/favorites navigation.
+ * 3. Otherwise → only the first page (`index < PARTS_PER_PAGE`). This
+ *    avoids queuing every part of a large multi-part video when the URL
+ *    does not name a specific part.
+ *
+ * @param part - The video part to evaluate.
+ * @param index - Zero-based index of the part within `video.parts`.
+ * @param ctx - Selection context describing how the fetch was initiated.
+ * @returns True if the part should be selected by default.
+ */
+export const shouldSelectPart = (
+  part: VideoPart,
+  index: number,
+  ctx: SelectionContext,
+): boolean => {
+  if (ctx.contentType === 'bangumi' && ctx.videoEpId !== undefined) {
+    return part.epId === ctx.videoEpId
+  }
+  if (ctx.pending) {
+    return ctx.pending.cid !== null
+      ? part.cid === ctx.pending.cid
+      : part.page === ctx.pending.page
+  }
+  return index < PARTS_PER_PAGE
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -8,6 +8,7 @@ import {
   deselectAll,
   deselectPageAll,
   DownloadButton,
+  PARTS_PER_PAGE,
   selectHasSelectedParts,
   selectPageAll,
   setHomePage,
@@ -107,9 +108,6 @@ function TooltipButton({
     </TooltipProvider>
   )
 }
-
-/** Number of parts per page in pagination. */
-const PARTS_PER_PAGE = 10
 
 /** Props for the PaginatedPartList component. */
 type PaginatedPartListProps = {
@@ -417,6 +415,15 @@ function HomeContentInner() {
       page = parseInt(browserPage, 10)
     } else if (browserP) {
       page = Math.ceil(parseInt(browserP, 10) / PARTS_PER_PAGE)
+      // Why: A bangumi season spans many pages, so a deep-link to one episode
+      // (Video.epId, populated by the backend from the ep-id URL) must open on
+      // that episode's page. Otherwise the user lands on page 1 and the single
+      // auto-selected episode stays off-screen (selection logic lives in
+      // lib/partSelection shouldSelectPart).
+    } else if (video.contentType === 'bangumi' && video.epId !== undefined) {
+      // Bangumi URL: jump to the page containing the requested episode
+      const idx = video.parts.findIndex((p) => p.epId === video.epId)
+      if (idx >= 0) page = Math.floor(idx / PARTS_PER_PAGE) + 1
     } else if (input.pendingDownload) {
       page = Math.ceil(input.pendingDownload.page / PARTS_PER_PAGE)
     } else if (input.url) {
@@ -431,7 +438,16 @@ function HomeContentInner() {
     }
 
     return Math.max(1, Math.min(page, totalPages || 1))
-  }, [browserPage, browserP, input.pendingDownload, input.url, totalPages])
+  }, [
+    browserPage,
+    browserP,
+    video.contentType,
+    video.epId,
+    video.parts,
+    input.pendingDownload,
+    input.url,
+    totalPages,
+  ])
 
   // Track scroll request timestamp to ensure each navigation triggers scroll
   const [scrollRequestId, setScrollRequestId] = useState(0)
@@ -455,6 +471,13 @@ function HomeContentInner() {
 
     if (browserP) {
       targetIndex = parseInt(browserP, 10) - 1
+      // Why: Scrolls the targeted episode (Video.epId) into view to match the
+      // page-jump and single-episode selection above, so the user immediately
+      // sees the one part that was auto-selected.
+    } else if (video.contentType === 'bangumi' && video.epId !== undefined) {
+      // Bangumi URL: scroll to the requested episode
+      const idx = video.parts.findIndex((p) => p.epId === video.epId)
+      targetIndex = idx >= 0 ? idx : null
     } else if (input.url) {
       try {
         const pParam = new URL(input.url).searchParams.get('p')
@@ -470,7 +493,14 @@ function HomeContentInner() {
     if (targetIndex !== null) {
       setScrollRequestId((prev) => prev + 1)
     }
-  }, [browserP, input.url, video.parts.length, isFetching])
+  }, [
+    browserP,
+    video.contentType,
+    video.epId,
+    video.parts,
+    input.url,
+    isFetching,
+  ])
 
   // Trigger scroll after pendingDownload is cleared (video info fetch complete)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Entering a bangumi episode URL (e.g. `ep825757`) previously selected **every episode of the season** (e.g. all 84) for download. The initial selection logic marked all parts as selected when no specific target was set, and bangumi URLs never populated the `pending` ref (only video `?p=N` URLs did).

Extracted the initial selection into a pure `shouldSelectPart` function:
- **bangumi**: select only the targeted episode (via backend-populated `Video.epId`)
- **video `?p=N` / history / favorites**: select the requested part (unchanged)
- **otherwise**: select only the first page instead of every part

Also jumps the paginated view to the page containing the targeted bangumi episode and scrolls to it, so the single auto-selected part is visible.

## Related Issue

N/A (no matching open issue found)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] Unit tests for `shouldSelectPart` (all branches + boundaries)
- [x] `npm run typecheck`, `npm run lint`, `npm run test` — all green
- [x] Manual: `ep825757` selects only Episode 1 (previously all 84)
- [x] Manual: `ep825764` selects only Episode 8 and scrolls to it

## Breaking Changes

Minor behavior change: a multi-part **video** (`BV...`) URL without `?p` now selects only the first page (max 10) by default instead of every part, consistent with the new "first page default" policy. Users can still select across pages manually via the checkboxes.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated
- [x] i18n files synced — N/A (no user-facing text changed)