### PR TITLE
fix(subtitle): clamp overshooting timestamps and harden subtitle fetch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "tauri-plugin-webdriver",
  "tokio",
  "tokio-util",
+ "url",
  "xz2",
  "zip 2.4.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1.0.98"
 reqwest = { version = "0.12.24", features = ["json", "stream", "blocking", "gzip", "brotli"] }
+# Direct dependency for pre-parsing subtitle URLs so a malformed URL fails
+# with a precise error instead of an opaque reqwest "builder error". Already
+# present transitively via reqwest; pinning here makes the usage explicit.
+url = "2"
 tokio = { version = "1.47.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 octocrab = "0.42"

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -173,7 +173,7 @@ use crate::utils::paths::get_lib_path;
 use crate::{constants::USER_AGENT, models::frontend_dto::User};
 use reqwest::header;
 use reqwest::Client;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
@@ -963,6 +963,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 options.cid,
                 &options.download_id,
                 &lib_path,
+                Some(options.duration_seconds as f64),
             )
             .await?;
 
@@ -2625,7 +2626,10 @@ pub async fn fetch_watch_history(
 ///
 /// # Notes
 ///
-/// - Uses `/x/player/v2` with Cookie authentication (per API docs, WBI signature is optional)
+/// - Uses `/x/player/wbi/v2` with WBI signature + Cookie authentication.
+///   The unsigned `/x/player/v2` endpoint returns stale CDN cache with a
+///   partial AI subtitle set; the signed endpoint returns the full set
+///   in one request.
 /// - Requires login (SESSDATA cookie) to retrieve subtitle data
 /// - Determines if subtitle is AI-generated via the URL path containing `/ai_subtitle/`
 pub async fn fetch_subtitles(
@@ -2649,11 +2653,36 @@ pub async fn fetch_subtitles(
         return Vec::new();
     }
 
+    // WBI-signed access. The unsigned `/x/player/v2` endpoint is
+    // unreliable: Bilibili's CDN returns stale cached responses that
+    // contain only a partial AI subtitle set. The signed `/wbi/v2`
+    // endpoint returns the full set in a single request.
+    let mixin_key = match crate::utils::wbi::fetch_mixin_key(client, Some(&cookie_header)).await {
+        Ok(k) => k,
+        Err(e) => {
+            log::error!("[BE] fetch_subtitles: failed to fetch WBI mixin key: {}", e);
+            return Vec::new();
+        }
+    };
+
+    let mut params = BTreeMap::from([
+        ("bvid".to_string(), bvid.to_string()),
+        ("cid".to_string(), cid.to_string()),
+    ]);
+    let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
+
+    let mut query: Vec<(&str, String)> = params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect();
+    query.push(("w_rid", signature.w_rid));
+    query.push(("wts", signature.wts));
+
     let response = match client
-        .get("https://api.bilibili.com/x/player/v2")
+        .get("https://api.bilibili.com/x/player/wbi/v2")
         .header(header::COOKIE, &cookie_header)
         .header(header::REFERER, "https://www.bilibili.com")
-        .query(&[("bvid", bvid), ("cid", &cid.to_string())])
+        .query(&query)
         .send()
         .await
     {
@@ -2736,7 +2765,8 @@ pub async fn fetch_subtitles(
 /// Returns a list of available subtitles with language info and URLs.
 /// Returns an empty vector if no subtitles are available or on error.
 ///
-/// Stale CDN mitigation is handled by [`fetch_subtitles_parallel`].
+/// Uses the WBI-signed [`fetch_subtitles`], which returns the full
+/// subtitle set in a single request.
 pub async fn fetch_subtitles_for_part(
     app: &AppHandle,
     bvid: &str,
@@ -2750,101 +2780,13 @@ pub async fn fetch_subtitles_for_part(
     );
     let cookies = read_cookie(app)?.unwrap_or_default();
     let client = build_client()?;
-    let subtitles = fetch_subtitles_parallel(&client, &cookies, bvid, cid).await;
+    let subtitles = fetch_subtitles(&client, &cookies, bvid, cid).await;
 
     log::info!(
         "[BE] fetch_subtitles_for_part: received {} subtitles",
         subtitles.len()
     );
     Ok(subtitles)
-}
-
-/// Merges multiple subtitle lists, deduplicating by `lan` (language code).
-///
-/// When the same `lan` appears in multiple results, the first occurrence
-/// is kept. This ensures each language appears at most once, which is
-/// required because the downstream download pipeline selects subtitles
-/// by `lan` alone and cannot handle duplicates.
-fn merge_subtitles(results: Vec<Vec<SubtitleDto>>) -> Vec<SubtitleDto> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut merged: Vec<SubtitleDto> = Vec::new();
-
-    for subtitles in results {
-        for sub in subtitles {
-            if seen.insert(sub.lan.clone()) {
-                merged.push(sub);
-            }
-        }
-    }
-
-    merged
-}
-
-/// Fetches subtitles via parallel requests to mitigate stale CDN cache.
-///
-/// Bilibili's CDN may return stale cached responses that contain only a single
-/// AI subtitle (`ai_type: 0`) instead of the full set of AI-translated
-/// subtitles (`ai_type: 1`). Rather than retrying sequentially, this function
-/// issues [`PARALLEL_COUNT`] concurrent requests with small inter-request
-/// jitter, increasing the probability of hitting a fresh CDN node.
-/// All results are merged and deduplicated via [`merge_subtitles`].
-///
-/// # Arguments
-///
-/// * `client` - HTTP client used for API requests
-/// * `cookies` - Cookie entries for authentication
-/// * `bvid` - Bilibili video ID (BV identifier)
-/// * `cid` - Content ID for the specific video part
-///
-/// # Returns
-///
-/// Returns the merged and deduplicated subtitle list from all parallel
-/// attempts. Returns an empty vector if all requests fail.
-async fn fetch_subtitles_parallel(
-    client: &Client,
-    cookies: &[CookieEntry],
-    bvid: &str,
-    cid: i64,
-) -> Vec<SubtitleDto> {
-    const PARALLEL_COUNT: usize = 3;
-    const JITTER_STEP_MS: u64 = 1000;
-
-    let futures: Vec<_> = (0..PARALLEL_COUNT)
-        .map(|i| {
-            let jitter_ms = (i as u64) * JITTER_STEP_MS;
-            async move {
-                if jitter_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
-                }
-                fetch_subtitles(client, cookies, bvid, cid).await
-            }
-        })
-        .collect();
-
-    let results = futures::future::join_all(futures).await;
-
-    for (i, subs) in results.iter().enumerate() {
-        log::info!(
-            "[BE] fetch_subtitles_parallel: request {} returned \
-             {} subtitles for bvid={}, cid={}",
-            i,
-            subs.len(),
-            bvid,
-            cid,
-        );
-    }
-
-    let merged = merge_subtitles(results);
-
-    log::info!(
-        "[BE] fetch_subtitles_parallel: merged into {} unique \
-         subtitles for bvid={}, cid={}",
-        merged.len(),
-        bvid,
-        cid,
-    );
-
-    merged
 }
 
 /// Fetches available video and audio qualities for a specific part.
@@ -2939,10 +2881,13 @@ const SUBTITLE_DOWNLOAD_TIMEOUT_SECS: u64 = 30;
 /// * `client` - HTTP client for requests
 /// * `subtitle_url` - BCC subtitle JSON URL (may start with "//")
 /// * `output_path` - Path to save the SRT file
+/// * `max_duration_secs` - Optional video duration cap (seconds). Cues whose
+///   `to` exceeds this are clamped during SRT conversion (see [`bcc_to_srt`]).
 ///
 /// # Errors
 ///
 /// Returns errors in the following cases:
+/// - URL parse failure (malformed subtitle URL)
 /// - Download failure
 /// - Non-success HTTP response
 /// - JSON parse failure
@@ -2951,6 +2896,7 @@ pub async fn download_subtitle(
     client: &Client,
     subtitle_url: &str,
     output_path: &std::path::Path,
+    max_duration_secs: Option<f64>,
 ) -> Result<(), String> {
     let url = if subtitle_url.starts_with("//") {
         format!("https:{}", subtitle_url)
@@ -2958,15 +2904,28 @@ pub async fn download_subtitle(
         subtitle_url.to_string()
     };
 
+    // Pre-parse with the url crate so a malformed subtitle URL fails here
+    // with a precise error (raw URL + parser reason) instead of an opaque
+    // reqwest "builder error" at send() time. Passing the parsed `Url`
+    // also skips reqwest's own equivalent parse step.
+    let parsed_url = url::Url::parse(&url).map_err(|e| {
+        log::warn!(
+            "[BE] download_subtitle: URL parse failed for '{}': {}",
+            url,
+            e
+        );
+        format!("Failed to parse subtitle URL '{}': {}", url, e)
+    })?;
+
     let response = client
-        .get(&url)
+        .get(parsed_url)
         .timeout(Duration::from_secs(SUBTITLE_DOWNLOAD_TIMEOUT_SECS))
         .send()
         .await
-        .map_err(|e| format!("Failed to download subtitle: {}", e))?;
+        .map_err(|e| format!("Failed to download subtitle '{}': {}", url, e))?;
 
     if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
+        return Err(format!("HTTP error {} for '{}'", response.status(), url));
     }
 
     let bcc: crate::models::bilibili_api::BccSubtitle = response
@@ -2974,7 +2933,7 @@ pub async fn download_subtitle(
         .await
         .map_err(|e| format!("Failed to parse subtitle JSON: {}", e))?;
 
-    let srt_content = crate::utils::subtitle::bcc_to_srt(&bcc);
+    let srt_content = crate::utils::subtitle::bcc_to_srt(&bcc, max_duration_secs);
 
     tokio::fs::write(output_path, srt_content)
         .await
@@ -2995,6 +2954,8 @@ pub async fn download_subtitle(
 /// * `client` - HTTP client used for the request
 /// * `subtitle_url` - BCC subtitle JSON URL (may start with `//`)
 /// * `output_path` - Output path for the converted SRT file
+/// * `max_duration_secs` - Optional video duration cap forwarded to
+///   [`download_subtitle`] for SRT clamping.
 ///
 /// # Returns
 ///
@@ -3008,12 +2969,13 @@ async fn download_subtitle_with_retry(
     client: &Client,
     subtitle_url: &str,
     output_path: &std::path::Path,
+    max_duration_secs: Option<f64>,
 ) -> Result<(), String> {
     const MAX_RETRIES: usize = 3;
     const BASE_DELAY_SECS: u64 = 2;
 
     for attempt in 0..MAX_RETRIES {
-        match download_subtitle(client, subtitle_url, output_path).await {
+        match download_subtitle(client, subtitle_url, output_path, max_duration_secs).await {
             Ok(()) => return Ok(()),
             Err(e) => {
                 let _ = tokio::fs::remove_file(output_path).await;
@@ -3075,6 +3037,8 @@ async fn download_subtitle_with_retry(
 /// * `cid` - Content ID
 /// * `download_id` - Unique identifier used for temporary file names
 /// * `lib_path` - Output directory for temporary subtitle files
+/// * `duration_secs` - Optional video duration (seconds) used to clamp
+///   out-of-range subtitle timestamps during SRT conversion.
 ///
 /// # Returns
 ///
@@ -3088,6 +3052,7 @@ async fn download_subtitle_with_retry(
 /// # Errors
 ///
 /// Returns an error if the HTTP client cannot be constructed.
+#[allow(clippy::too_many_arguments)]
 async fn prepare_subtitle_mode(
     app: &AppHandle,
     subtitle_opts: &Option<SubtitleOptions>,
@@ -3096,6 +3061,7 @@ async fn prepare_subtitle_mode(
     cid: i64,
     download_id: &str,
     lib_path: &Path,
+    duration_secs: Option<f64>,
 ) -> Result<(crate::handlers::ffmpeg::MergeMode, Vec<String>, Vec<String>), String> {
     use crate::handlers::ffmpeg::{MergeMode, SubtitleMergeOptions};
     use crate::utils::subtitle::lan_to_iso639;
@@ -3144,7 +3110,7 @@ async fn prepare_subtitle_mode(
             })
             .collect()
     } else {
-        let subs = fetch_subtitles_parallel(&client, cookies, bvid, cid).await;
+        let subs = fetch_subtitles(&client, cookies, bvid, cid).await;
         log::info!(
             "[BE] prepare_subtitle_mode: fetched {} subtitles from API",
             subs.len()
@@ -3177,7 +3143,7 @@ async fn prepare_subtitle_mode(
                 MAX_OUTER_ATTEMPTS,
                 remaining_lans.len(),
             );
-            let fresh = fetch_subtitles_parallel(&client, cookies, bvid, cid).await;
+            let fresh = fetch_subtitles(&client, cookies, bvid, cid).await;
             fresh
                 .into_iter()
                 .filter(|s| remaining_lans.contains(&s.lan))
@@ -3199,8 +3165,13 @@ async fn prepare_subtitle_mode(
                 let srt_path = lib_path.join(format!("temp_sub_{download_id}_{}.srt", sub.lan));
                 let client = client.clone();
                 async move {
-                    let result =
-                        download_subtitle_with_retry(&client, &sub.subtitle_url, &srt_path).await;
+                    let result = download_subtitle_with_retry(
+                        &client,
+                        &sub.subtitle_url,
+                        &srt_path,
+                        duration_secs,
+                    )
+                    .await;
                     (sub.lan, sub.lan_doc, srt_path, result)
                 }
             })

--- a/src-tauri/src/utils/subtitle.rs
+++ b/src-tauri/src/utils/subtitle.rs
@@ -10,17 +10,48 @@ use crate::models::bilibili_api::BccSubtitle;
 /// BCC format uses `from`/`to` fields in seconds, while SRT uses
 /// `HH:MM:SS,mmm --> HH:MM:SS,mmm` timestamp format.
 ///
+/// When `max_duration_secs` is `Some(d)` with `d > 0.0`, out-of-range
+/// timestamps are clamped to the video duration: cues that start at or
+/// after `d` are dropped, and cues that end after `d` are truncated to
+/// `d`. Pass `None` to preserve timestamps as-is (e.g. for standalone
+/// SRT export without a known video duration).
+///
 /// The output includes a UTF-8 BOM prefix to ensure correct encoding
 /// detection by ffmpeg on Windows.
-pub fn bcc_to_srt(bcc: &BccSubtitle) -> String {
+pub fn bcc_to_srt(bcc: &BccSubtitle, max_duration_secs: Option<f64>) -> String {
     let srt_content = bcc
         .body
         .iter()
+        // Clamp out-of-range timestamps. Bilibili AI subtitles may carry
+        // cues whose `to` far exceeds the video duration (observed 35x
+        // overshoot). Without clamping, these cues inflate the muxed
+        // subtitle stream duration and stretch the container runtime.
+        .filter_map(|entry| {
+            let (from, mut to) = (entry.from, entry.to);
+            // Note: The `m > 0.0` guard treats 0.0 as "unknown duration" and
+            // disables clamping. `duration_seconds` is an i64 on DownloadOptions
+            // cast to f64 at the download_video call site (handlers/bilibili.rs);
+            // when it is unset (0), Some(0.0) would otherwise make `from >= max`
+            // true for every cue (including from == 0.0) and drop all subtitles.
+            if let Some(max) = max_duration_secs.filter(|&m| m > 0.0) {
+                if from >= max {
+                    // Cue starts after the video ends; drop entirely.
+                    return None;
+                }
+                if to > max {
+                    // Cue ends after the video ends; clamp to the end.
+                    to = max;
+                }
+            }
+            Some((
+                format_srt_time(from),
+                format_srt_time(to),
+                entry.content.as_str(),
+            ))
+        })
         .enumerate()
-        .map(|(i, entry)| {
-            let start = format_srt_time(entry.from);
-            let end = format_srt_time(entry.to);
-            format!("{}\n{} --> {}\n{}\n", i + 1, start, end, entry.content)
+        .map(|(i, (start, end, content))| {
+            format!("{}\n{} --> {}\n{}\n", i + 1, start, end, content)
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -152,7 +183,7 @@ mod tests {
             }],
         };
 
-        let srt = bcc_to_srt(&bcc);
+        let srt = bcc_to_srt(&bcc, None);
         let expected = "\u{FEFF}1\n00:00:00,000 --> 00:00:02,500\nHello world\n";
         assert_eq!(srt, expected);
     }
@@ -181,7 +212,7 @@ mod tests {
             ],
         };
 
-        let srt = bcc_to_srt(&bcc);
+        let srt = bcc_to_srt(&bcc, None);
         assert!(srt.contains("1\n00:00:00,000 --> 00:00:02,500\nFirst line"));
         assert!(srt.contains("2\n00:00:03,000 --> 00:00:05,500\nSecond line"));
     }
@@ -197,7 +228,66 @@ mod tests {
             body: vec![],
         };
 
-        let srt = bcc_to_srt(&bcc);
+        let srt = bcc_to_srt(&bcc, None);
         assert_eq!(srt, "\u{FEFF}");
+    }
+
+    #[test]
+    fn test_bcc_to_srt_clamps_to_max_duration() {
+        let bcc = BccSubtitle {
+            font_size: 0.4,
+            font_color: "0xFFFFFF".to_string(),
+            background_alpha: 0.5,
+            background_color: "0x000000".to_string(),
+            stroke: "none".to_string(),
+            body: vec![
+                BccSubtitleBody {
+                    from: 0.0,
+                    to: 2.5,
+                    location: 0,
+                    content: "inside".to_string(),
+                },
+                BccSubtitleBody {
+                    from: 8.0,
+                    to: 100.0, // overshoots the 10s cap -> clamped
+                    location: 0,
+                    content: "straddles end".to_string(),
+                },
+                BccSubtitleBody {
+                    from: 12.0, // starts after the 10s cap -> dropped
+                    to: 15.0,
+                    location: 0,
+                    content: "after end".to_string(),
+                },
+            ],
+        };
+
+        let srt = bcc_to_srt(&bcc, Some(10.0));
+        // First cue untouched, second clamped to 10s, third dropped.
+        assert!(srt.contains("1\n00:00:00,000 --> 00:00:02,500\ninside"));
+        assert!(srt.contains("2\n00:00:08,000 --> 00:00:10,000\nstraddles end"));
+        assert!(!srt.contains("after end"));
+    }
+
+    #[test]
+    fn test_bcc_to_srt_none_disables_clamp() {
+        let bcc = BccSubtitle {
+            font_size: 0.4,
+            font_color: "0xFFFFFF".to_string(),
+            background_alpha: 0.5,
+            background_color: "0x000000".to_string(),
+            stroke: "none".to_string(),
+            body: vec![BccSubtitleBody {
+                from: 0.0,
+                to: 10000.0, // would be dropped if clamped
+                location: 0,
+                content: "far".to_string(),
+            }],
+        };
+
+        // None preserves the original (oversized) timestamp.
+        let srt = bcc_to_srt(&bcc, None);
+        assert!(srt.contains("00:00:00,000 --> 02:46:40,000"));
+        assert!(srt.contains("\nfar"));
     }
 }


### PR DESCRIPTION
## Problem

Soft-subtitle downloads produced output with an inflated duration. Bilibili AI subtitles can carry cues whose `to` timestamp far exceeds the video length (observed 35x overshoot on a 4:47 video → 2h48m output). The muxed subtitle stream stretched the container duration and players reported an inflated runtime, leaving black screen / silence after the video ended.

Root cause (confirmed via `ffprobe`): the AI subtitle stream duration was 10108s while video/audio were 287s.

## Changes

**B: Clamp overshooting timestamps in BCC→SRT conversion**
- `bcc_to_srt` now takes `Option<f64>` video duration. Cues starting at/after the end are dropped; cues ending past it are truncated.
- `duration_seconds` is propagated through `prepare_subtitle_mode` → `download_subtitle_with_retry` → `download_subtitle` → `bcc_to_srt`.

**C: Harden subtitle fetch / download**
- `fetch_subtitles`: switch from unsigned `/x/player/v2` to WBI-signed `/x/player/wbi/v2` (reuses existing `wbi.rs`). The unsigned endpoint returned stale CDN cache with partial AI subtitle sets.
- Drop `fetch_subtitles_parallel` / `merge_subtitles` (3-request merge hack); the signed endpoint returns the full set in one request.
- `download_subtitle`: pre-parse URL with `url::Url::parse` to surface precise errors instead of an opaque reqwest "builder error".
- Add `url = "2"` direct dependency (already transitive via reqwest).

## What was tried and reverted

`ffmpeg -shortest` was initially added (plan A) to truncate at the shortest stream, but it had a side effect: when a subtitle stream was *shorter* than the video (e.g. incomplete fallback data at 211s vs 287s video), `-shortest` truncated the video itself. Removed; the B clamp alone is sufficient because ffmpeg already bases container duration on the longest stream, which is the video.

## Verification

- `cargo build`, `cargo clippy -D warnings`, `cargo test --lib` (104 passed, incl. 2 new clamp tests), `npm run lint` — all green
- Manual: re-downloading the repro video (BV1WHfLB8Esn) with 6 soft-sub languages now yields a 4:47 output instead of 2h48m