### PR TITLE
fix(toast): scale padding and status icon with user font size

### DIFF
--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -29,6 +29,14 @@ type ToasterProps = {
  *   max-w-[480px] on toastClassName caps long errors from stretching
  *   too wide.
  *
+ * @why: --toastify-toast-padding (rem) and --toastify-toast-min-height
+ *   (auto) override react-toastify's defaults (14px / 64px) so the toast
+ *   hugs its content instead of leaving a large fixed margin around
+ *   single-line messages. The padding is rem-based to scale with the
+ *   user's fontSize setting (applied on <html>), keeping the toast
+ *   visually consistent across font sizes; min-height: auto drops the
+ *   64px floor so the content height alone decides the toast height.
+ *
  * @why: Radix Dialog (modal) sets pointer-events: none on body siblings
  *   while open, which would disable react-toastify's portal. Force auto
  *   so drag/swipe-to-dismiss and the Copy button stay clickable above
@@ -55,6 +63,8 @@ const Toaster = ({ theme, richColors }: ToasterProps) => {
       style={
         {
           '--toastify-toast-width': 'fit-content',
+          '--toastify-toast-padding': '0.5rem',
+          '--toastify-toast-min-height': 'auto',
           zIndex: 9999,
           pointerEvents: 'auto',
         } as CSSProperties

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -136,3 +136,16 @@
     @apply bg-background text-foreground;
   }
 }
+
+/*
+ * react-toastify hardcodes the status icon at width: 22px with a 10px
+ * trailing margin, neither of which scales with the user's fontSize
+ * setting. Re-declare both in rem so the icon tracks <html> font-size
+ * the same way the toast text and padding do. The doubled-class selector
+ * raises specificity above the library's `.Toastify__toast-icon` rule so
+ * the override wins regardless of CSS bundle order.
+ */
+.Toastify__toast .Toastify__toast-icon {
+  width: 1.125rem;
+  margin-inline-end: 0.625rem;
+}


### PR DESCRIPTION
## Summary

Make react-toastify toasts scale with the user's fontSize setting. Previously the toast padding (`14px`), min-height (`64px`), and status icon width (`22px`) were hardcoded px values that ignored the fontSize setting, leaving oversized padding around single-line toasts and a non-scaling status icon.

Changes:
- `src/shared/ui/sonner.tsx`: override `--toastify-toast-padding` (`0.5rem`) and `--toastify-toast-min-height` (`auto`) so the toast hugs its content and the padding scales with the font size.
- `src/styles/index.css`: re-declare `.Toastify__toast-icon` width (`1.125rem`) and margin (`0.625rem`) in rem via a specificity-raised selector (`.Toastify__toast .Toastify__toast-icon`) so the status icon tracks the font size too.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [ ] Run `npm run tauri dev`
- [ ] Trigger a toast (success / error / info / warning)
- [ ] Verify the toast padding fits the content (no oversized margins around single-line toasts)
- [ ] Open Settings, change the fontSize, and confirm the toast padding and status icon scale together

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A — CSS variable adjustment, no logic change)
- [x] i18n files synced (N/A — no user-facing text changed)