### PR TITLE
🚀 Release v1.48.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release **v1.48.0** — bumps the app version from `v1.47.0` to `v1.48.0` (minor).

This release bundles 15 commits since v1.47.0: 6 new features (`feat`), 7 bug fixes (`fix`), and 2 style changes.

### Notable changes
- **feat(toast)**: migrate sonner to react-toastify with copy button
- **feat(about)**: add About dialog with environment info and macOS app menu
- **feat(about)**: unify About with in-app dialog and fix Window menu build
- **feat(subtitle)**: show download progress and add HTTP timeout
- **feat(font)**: apply Noto Sans JP and preload during splash
- **feat(video)**: debounce title validation for real-time feedback
- **fix(subtitle)**: clamp overshooting timestamps and harden subtitle fetch
- **fix(toast)**: scale padding and status icon with user font size
- **fix(video)**: select only the targeted bangumi episode on URL input
- **fix(video)**: stabilize progress numbers and trim `.0` from file sizes
- **fix(download-status)**: prevent part row left-edge clipping in dialog

## Related Issue

N/A (version bump release)

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [ ] Verify the app version reports `1.48.0` after build
- [ ] Confirm `ci-status` passes on this branch

## Breaking Changes

None.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A for release chore)
- [x] i18n files synced (N/A — version bump only)

---

> ⚠️ GitHub Release creation and tag push are handled by the CI/CD pipeline after merge. No manual `gh release create` / `git tag` is required.