### PR TITLE
fix(cancel): make download cancellation idempotent to prevent duplicate toast

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -495,8 +495,17 @@ async fn download_bangumi_durl(
     )
     .await;
 
-    // Always remove the cancellation token (success or error).
+    // Always clean up the registry (success or error): remove the token AND
+    // clear the pre-cancel flag. Mirrors the regular durl and DASH cleanup
+    // paths (remove + clear_cancelled). clear_cancelled matters here because
+    // cancel() records the id in cancelled_ids for the get_token-None
+    // fallback; without this, a cancelled bangumi-durl id would linger and
+    // could falsely trip download_video's start-up is_cancelled check on id
+    // reuse, and accumulate over long-running sessions.
     DOWNLOAD_CANCEL_REGISTRY.remove(&options.download_id).await;
+    DOWNLOAD_CANCEL_REGISTRY
+        .clear_cancelled(&options.download_id)
+        .await;
 
     match result {
         Ok(()) => {

--- a/src-tauri/src/handlers/concurrency.rs
+++ b/src-tauri/src/handlers/concurrency.rs
@@ -107,9 +107,16 @@ impl DownloadCancelRegistry {
         token
     }
 
-    /// Signals cancellation for a specific download.
+    /// Signals cancellation for a specific download and removes its token
+    /// from the registry.
     ///
-    /// Returns `true` if the download was found and cancelled, `false` otherwise.
+    /// Removing the token makes `cancel()` idempotent: a second call for the
+    /// same id (e.g. a double-clicked cancel button) returns `false`, so
+    /// `cancel_download` does not emit a duplicate `download_cancelled`
+    /// event (which would surface a second "cancelled" toast). The id is
+    /// also recorded in `cancelled_ids` so paths that re-fetch the token via
+    /// `get_token` (retry backoff, playurl fetch, bangumi-durl) can still
+    /// detect the cancel via `is_cancelled` instead of running to completion.
     ///
     /// # Arguments
     ///
@@ -117,12 +124,24 @@ impl DownloadCancelRegistry {
     ///
     /// # Returns
     ///
-    /// `true` if cancellation was signaled, `false` if download not found
+    /// `true` if the token existed and was cancelled (and removed), `false`
+    /// if the download was not found (never started, already completed, or
+    /// already cancelled by a previous call)
     pub async fn cancel(&self, download_id: &str) -> bool {
-        let tokens = self.tokens.lock().await;
-        if let Some(token) = tokens.get(download_id) {
+        // Remove the token (not just flag it) so a duplicate cancel_download
+        // returns false. Hold the tokens lock only for the Map mutation and
+        // release it before locking cancelled_ids. Holding two mutexes at
+        // once is a deadlock hazard in general, so we keep each guard in its
+        // own scope even though no current caller nests them.
+        let token_opt = {
+            let mut tokens = self.tokens.lock().await;
+            tokens.remove(download_id)
+        };
+        if let Some(token) = token_opt {
             token.cancel();
             log::info!("[BE] download cancelled: id={}", download_id);
+            let mut ids = self.cancelled_ids.lock().await;
+            ids.insert(download_id.to_string());
             true
         } else {
             log::warn!(
@@ -133,19 +152,35 @@ impl DownloadCancelRegistry {
         }
     }
 
-    /// Signals cancellation for all registered downloads.
+    /// Signals cancellation for all registered downloads and clears the
+    /// registry.
     ///
-    /// Returns the number of downloads that were cancelled.
+    /// Clearing mirrors `cancel()`'s removal semantics: subsequent per-id
+    /// `cancel_download` calls for these ids return `false`, avoiding
+    /// duplicate `download_cancelled` events when cancel-all and per-part
+    /// cancel race on the same id.
     ///
     /// # Returns
     ///
-    /// Number of downloads cancelled
+    /// Number of downloads cancelled (the count captured before clearing)
     pub async fn cancel_all(&self) -> usize {
-        let tokens = self.tokens.lock().await;
+        let mut tokens = self.tokens.lock().await;
         let count = tokens.len();
         for token in tokens.values() {
             token.cancel();
         }
+        // Constraint: unlike cancel(), this path does NOT record ids in
+        // cancelled_ids — clearing tokens alone satisfies the idempotency
+        // goal (a later per-id cancel returns false). The get_token-None
+        // fallback in download_url/single_stream_fallback reads
+        // cancelled_ids, so mid-retry cancel detection here depends on the
+        // caller having pre-marked the ids. The sole production caller
+        // (cancel_all_downloads in lib.rs) does this via mark_cancelled_many
+        // before invoking cancel_all.
+        // Caution: any future direct caller of cancel_all() must pre-mark the
+        // ids, otherwise a download sitting in retry backoff would lose its
+        // token here yet read is_cancelled=false and run to completion.
+        tokens.clear();
         count
     }
 
@@ -228,5 +263,79 @@ impl DownloadCancelRegistry {
     pub async fn clear_cancelled(&self, download_id: &str) {
         let mut ids = self.cancelled_ids.lock().await;
         ids.remove(download_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The core fix: a second cancel for the same id must return false so
+    /// cancel_download does not emit a duplicate `download_cancelled` event
+    /// (the "cancelled" toast showing twice on double-click).
+    #[tokio::test]
+    async fn cancel_is_idempotent_on_second_call() {
+        let registry = DownloadCancelRegistry::new();
+        let id = "test-id-idempotent";
+
+        registry.register(id).await;
+        assert!(registry.cancel(id).await, "first cancel should return true");
+        assert!(
+            !registry.cancel(id).await,
+            "second cancel should return false (idempotent — token was removed)"
+        );
+    }
+
+    /// cancel() must record the id in cancelled_ids so download_url's
+    /// get_token-None fallback (retry backoff, playurl fetch, bangumi-durl)
+    /// can still detect the cancel via is_cancelled.
+    #[tokio::test]
+    async fn cancel_records_id_in_cancelled_ids_for_fallback() {
+        let registry = DownloadCancelRegistry::new();
+        let id = "test-id-fallback";
+
+        registry.register(id).await;
+        assert!(
+            !registry.is_cancelled(id).await,
+            "freshly registered id should not be cancelled"
+        );
+
+        registry.cancel(id).await;
+        assert!(
+            registry.is_cancelled(id).await,
+            "cancel() should record the id so the get_token-None fallback can detect it"
+        );
+    }
+
+    /// Guards against cancel-all × per-part cancel duplicate emit: once
+    /// cancel_all has cleared the tokens, a per-id cancel must return false.
+    #[tokio::test]
+    async fn cancel_after_cancel_all_returns_false() {
+        let registry = DownloadCancelRegistry::new();
+        let id = "test-id-cancel-all";
+
+        registry.register(id).await;
+        registry.cancel_all().await;
+        assert!(
+            !registry.cancel(id).await,
+            "per-id cancel after cancel_all should return false (no duplicate emit)"
+        );
+    }
+
+    /// Prerequisite for the get_token-None fallback path: cancel() must
+    /// remove the token so get_token returns None for in-flight callers.
+    #[tokio::test]
+    async fn cancel_removes_token_so_get_token_returns_none() {
+        let registry = DownloadCancelRegistry::new();
+        let id = "test-id-get-token";
+
+        registry.register(id).await;
+        assert!(registry.get_token(id).await.is_some());
+
+        registry.cancel(id).await;
+        assert!(
+            registry.get_token(id).await.is_none(),
+            "cancel() should remove the token so get_token returns None"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -645,7 +645,8 @@ async fn download_video(
 /// # Returns
 ///
 /// Returns `Ok(true)` if the download was found and cancelled,
-/// `Ok(false)` if the download was not found (may have already completed).
+/// `Ok(false)` if the download was not found (may have already completed
+/// or already been cancelled by a previous call).
 ///
 /// # Example
 ///
@@ -667,13 +668,17 @@ async fn cancel_download(app: AppHandle, download_id: String) -> Result<bool, St
             serde_json::json!({ "downloadId": download_id }),
         );
     } else {
-        // No token: either a pre-enqueued pending child (download_video not
-        // started yet) or a finished download whose token was already
-        // removed. Mark it pre-cancelled so download_video rejects it on
-        // start, mirroring cancel_all_downloads. We deliberately do NOT emit
-        // download_cancelled here: that event triggers clearQueueItem on the
-        // frontend, which would drop the row. A cancelled pending part must
-        // stay visible (greyed dot + strikethrough) instead of vanishing.
+        // No token: a pre-enqueued pending child (download_video not started
+        // yet), a finished download whose token was already removed, or a
+        // running download already cancelled by a previous cancel_download
+        // call (cancel() removes the token to stay idempotent). Mark it
+        // pre-cancelled so download_video rejects it on start, mirroring
+        // cancel_all_downloads. We deliberately do NOT emit
+        // download_cancelled here: for an already-cancelled running download
+        // the first cancel already emitted it (a duplicate would show a
+        // second toast), and for a pending child the frontend's pending
+        // reducer has already finalized the row to 'cancelled' — so an emit
+        // here is redundant in every case.
         DOWNLOAD_CANCEL_REGISTRY.mark_cancelled(&download_id).await;
     }
 

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -284,7 +284,26 @@ pub async fn download_url(
 
     // Get cancellation token from registry
     let cancel_token: Option<CancellationToken> = if let Some(ref id) = download_id {
-        DOWNLOAD_CANCEL_REGISTRY.get_token(id).await
+        match DOWNLOAD_CANCEL_REGISTRY.get_token(id).await {
+            Some(t) => Some(t),
+            None => {
+                // Token was removed by a prior cancel() (the registry drops
+                // tokens on cancel to stay idempotent). A download can still
+                // reach this point after the user cancelled — e.g. a retry
+                // attempt that started during a backoff sleep, or a playurl
+                // fetch that was in flight when cancel arrived. Consult the
+                // pre-cancel flag so we detect it here instead of running the
+                // download to completion.
+                if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(id).await {
+                    log::info!(
+                        "[BE] download_url: token absent but pre-cancelled: id={}",
+                        id
+                    );
+                    return Err(anyhow::anyhow!("ERR::CANCELLED"));
+                }
+                None
+            }
+        }
     } else {
         None
     };
@@ -868,7 +887,23 @@ async fn single_stream_fallback(
 ) -> Result<()> {
     // Get cancellation token from registry if download_id is provided
     let cancel_token: Option<CancellationToken> = if let Some(ref id) = download_id {
-        DOWNLOAD_CANCEL_REGISTRY.get_token(id).await
+        match DOWNLOAD_CANCEL_REGISTRY.get_token(id).await {
+            Some(t) => Some(t),
+            None => {
+                // Token removed by a prior cancel(); fall back to the
+                // pre-cancel flag so a mid-flight cancel is detected here
+                // rather than after streaming the whole file. See
+                // download_url for the full rationale.
+                if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(id).await {
+                    log::info!(
+                        "[BE] single_stream_fallback: token absent but pre-cancelled: id={}",
+                        id
+                    );
+                    return Err(anyhow::anyhow!("ERR::CANCELLED"));
+                }
+                None
+            }
+        }
     } else {
         None
     };


### PR DESCRIPTION
## Summary

The "cancelled" toast occasionally showed twice when a download was cancelled right after starting (reproduces in production). This makes download cancellation idempotent at the backend so a duplicate `cancel_download` no longer emits a second `download_cancelled` event.

## Related Issue

No open issue found via search; reported directly during development.

## Type of Change

- [x] 🐛 Bug fix

## Root cause

`cancel()` signalled the CancellationToken but did not remove it from the registry. A second `cancel_download` for the same id (e.g. a double-clicked cancel button) returned `was_found=true` and emitted a duplicate `download_cancelled` event, and the frontend listener (no `toastId`) showed two toasts.

## Fix (backend-only, frontend untouched)

- `cancel()`/`cancel_all()` now **remove** tokens, making the 2nd call return `false` → no duplicate `download_cancelled` event. Also resolves the cancel-all × per-part cancel race on the same id.
- `cancel()` records the id in `cancelled_ids` so in-flight callers that re-fetch the token via `get_token` (retry backoff, playurl fetch, bangumi-durl) can still detect the cancel via `is_cancelled`.
- `download_url`/`single_stream_fallback` fall back to `is_cancelled` when `get_token` returns `None`, preventing "cancelled yet file saved" — critical for the bangumi-durl path which bypasses `download_video`'s post-download safety net.
- bangumi-durl cleanup now also clears `cancelled_ids`, matching the regular durl and DASH paths (prevents id residue / false cancel on reuse).
- Unit tests cover the idempotency contract.

## Test Plan

- [x] `cargo build` succeeds
- [x] `cargo test concurrency` — 4 new tests + 6 existing, all pass
- [x] `npm run lint` clean
- [x] Manual: cancel right after start → single toast
- [x] Manual: double-click cancel → single toast
- [x] Manual: cancel-all + per-part cancel → no duplicate
- [x] Manual: bangumi cancel → no file saved

## Breaking Changes

None. Backend-only; the frontend `download_cancelled` listener is unchanged.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (4 unit tests for the idempotency contract)
- [x] i18n files synced (N/A — no user-facing text changed)

## Review

A 4-expert panel (Rust concurrency, Tauri events, cancel-flow, regression) reviewed both the plan and the implementation; the bangumi-durl `clear_cancelled` gap and the missing idempotency tests were addressed per their consensus before opening this PR.

Known non-blocking follow-ups (out of scope): retry backoff sleep is not interruptible (≤1.5s delay, no runaway download); `cancel-all` × per-id register window is a pre-existing race (bounded by serial-download assumption).