### PR TITLE
feat(download): per-download host health with netloc substitution

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -175,6 +175,7 @@ use reqwest::header;
 use reqwest::Client;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
 
@@ -359,6 +360,7 @@ async fn download_bangumi_durl(
     cookie_header: &str,
     cookies: &[CookieEntry],
     player_result: BangumiPlayerResult,
+    host_health: Arc<crate::utils::cdn_selector::HostHealth>,
 ) -> Result<String, String> {
     use crate::handlers::concurrency::DOWNLOAD_CANCEL_REGISTRY;
 
@@ -442,6 +444,7 @@ async fn download_bangumi_durl(
     let bd_output_path = output_path.to_path_buf();
     let bd_cookie_header = cookie_header.to_string();
     let bd_download_id = options.download_id.clone();
+    let bd_host_health = host_health.clone();
     // Download directly. Capture the result so we always remove the token
     // (success or error) to avoid a registry leak on the early-return path.
     let result = retry_download(
@@ -458,6 +461,7 @@ async fn download_bangumi_durl(
             let output_path = bd_output_path.clone();
             let cookie_header = bd_cookie_header.clone();
             let download_id = bd_download_id.clone();
+            let host_health = bd_host_health.clone();
             async move {
                 let (url, backups) = if attempt == 1 {
                     (video_url.clone(), backup_urls.clone())
@@ -488,6 +492,7 @@ async fn download_bangumi_durl(
                     Some("video"),
                     true,
                     segment_concurrency,
+                    host_health.clone(),
                 )
                 .await
             }
@@ -585,6 +590,11 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         .register(&options.download_id)
         .await;
 
+    // Per-download CDN host health, shared by the video stream, audio
+    // stream(s), every retry attempt, and their segment tasks. Dropping the
+    // last Arc when this download ends clears the state (issue #527).
+    let host_health = Arc::new(crate::utils::cdn_selector::HostHealth::new());
+
     // 1. Determine output file path + auto-rename
     let output_path = auto_rename(&build_output_path(app, &options.filename).await?);
 
@@ -609,6 +619,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 &cookie_header,
                 &cookies,
                 player_result,
+                host_health,
             )
             .await;
         }
@@ -701,6 +712,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                     let output_path = d_output_path.to_path_buf();
                     let cookie_header = cookie_header.to_string();
                     let download_id = options.download_id.clone();
+                    let host_health = host_health.clone();
                     async move {
                         let (url, backups) = if attempt == 1 {
                             (video_url.clone(), backup_urls.clone())
@@ -731,6 +743,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                             Some("video"),
                             true,
                             segment_concurrency,
+                            host_health.clone(),
                         )
                         .await
                     }
@@ -759,6 +772,21 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     }
 
     let dash_data = data.dash.unwrap();
+
+    // Seed the shared mirror pool from the whole DASH manifest (video +
+    // audio streams, base + backup URLs) so the video pre-selection already
+    // knows mirror hosts that only the audio streams carry (issue #527).
+    let manifest_urls: Vec<String> = dash_data
+        .video
+        .iter()
+        .chain(dash_data.audio.iter())
+        .flat_map(|s| {
+            let mut v = vec![s.base_url.clone()];
+            v.extend(s.backup_urls.clone().unwrap_or_default());
+            v
+        })
+        .collect();
+    host_health.seed_mirrors_from_urls(&manifest_urls);
 
     // Diagnostic: record the audio stream landscape and any VIP-only
     // objects (dolby/flac) present in the manifest. Does not affect
@@ -885,6 +913,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             cookie.clone(),
             &dash_data.audio,
             &audio_refetch_ctx,
+            host_health.clone(),
         );
         // Refetch inputs for attempt > 1 (bilibili signed URLs expire after
         // 120 min). Cloned here because the move closure must own them, while
@@ -913,6 +942,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                 let temp_video_path = v_temp_video_path.clone();
                 let cookie = v_cookie.clone();
                 let download_id = v_download_id.clone();
+                let host_health = host_health.clone();
                 async move {
                     let (url, backups) = if attempt == 1 {
                         (video_url.clone(), video_backup_urls.clone())
@@ -947,6 +977,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
                         None,
                         false, // emit_complete: will be emitted after merge
                         segment_concurrency,
+                        host_health.clone(),
                     )
                     .await
                 }
@@ -1472,6 +1503,7 @@ async fn download_audio_with_fallback(
     cookie: Option<String>,
     all_audio_streams: &[crate::models::bilibili_api::XPlayerApiResponseVideo],
     refetch_ctx: &AudioRefetchCtx,
+    host_health: Arc<crate::utils::cdn_selector::HostHealth>,
 ) -> Result<(), String> {
     // Resolve the requested (primary) audio quality id from the stream
     // list so any fallback can be logged as an explicit
@@ -1505,6 +1537,7 @@ async fn download_audio_with_fallback(
     let a_backup_urls = backup_urls.clone();
     let a_output_path = output_path.clone();
     let a_cookie = cookie.clone();
+    let a_host_health = host_health.clone();
 
     // Try primary URL first
     let primary_result = retry_download(app, download_id, Some("audio"), move |attempt: u8| {
@@ -1517,6 +1550,7 @@ async fn download_audio_with_fallback(
         let output_path = a_output_path.clone();
         let cookie = a_cookie.clone();
         let download_id = a_download_id.clone();
+        let host_health = a_host_health.clone();
         async move {
             let (url, backups) = if attempt == 1 {
                 (primary_url.clone(), backup_urls.clone())
@@ -1545,6 +1579,7 @@ async fn download_audio_with_fallback(
                 None,
                 false,
                 segment_concurrency,
+                host_health,
             )
             .await
         }
@@ -1595,6 +1630,7 @@ async fn download_audio_with_fallback(
                     // Clone variables for the fallback closure to avoid move errors
                     let output_path_clone = output_path.clone();
                     let cookie_clone = cookie.clone();
+                    let stream_health = host_health.clone();
 
                     // CONSTRAINT: fallback loop intentionally does NOT refetch playurl on
                     // retry (issue #482 design decision). Each iteration already switches
@@ -1614,6 +1650,7 @@ async fn download_audio_with_fallback(
                                 None,
                                 false,
                                 segment_concurrency,
+                                stream_health.clone(),
                             )
                         })
                         .await;

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -179,6 +179,10 @@ pub async fn install_ffmpeg(app: &AppHandle) -> Result<bool> {
         None,
         true, // emit progress so the splash can show a download progress bar
         segment_concurrency,
+        // Throwaway health scope: the ffmpeg archive comes from github/evermeet
+        // hosts, which are outside the bilivideo.com substitution domain, so
+        // sharing state would be meaningless here.
+        std::sync::Arc::new(crate::utils::cdn_selector::HostHealth::new()),
     )
     .await
     .is_err()

--- a/src-tauri/src/utils/cdn_selector.rs
+++ b/src-tauri/src/utils/cdn_selector.rs
@@ -3,8 +3,11 @@
 //! Orders CDN URLs from best to worst before the segmented download starts,
 //! so the primary request does not land on a slow P2P/MCDN edge. Combines:
 //! 1. a static domain filter that removes known P2P/MCDN nodes (falling back
-//!    to the original list when every candidate is P2P), and
-//! 2. a bounded parallel latency probe (HEAD -> 1-byte Range fallback) that
+//!    to the original list when every candidate is P2P),
+//! 2. unhealthy-host substitution — URLs whose host failed connection
+//!    establishment earlier in the same download are rewritten to a healthy
+//!    mirror host (see [`HostHealth`]), and
+//! 3. a bounded parallel latency probe (HEAD -> 1-byte Range fallback) that
 //!    also recovers the total file size.
 //!
 //! On total probe failure it falls back to the statically-filtered list, so
@@ -15,6 +18,7 @@ use crate::constants::{CDN_PROBE_CONCURRENCY, CDN_PROBE_TIMEOUT_SECS, REFERER, U
 use crate::utils::downloads::{apply_cookie, is_media_content_type};
 use futures::stream::{FuturesUnordered, StreamExt};
 use reqwest::header;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -27,6 +31,213 @@ pub struct ProbeOutcome {
     /// Total file size in bytes recovered during probing. `None` signals the
     /// caller to fall back to single-stream download (Range unsupported).
     pub total_size: Option<u64>,
+}
+
+/// Per-download CDN host health memory (issue #527).
+///
+/// Owned by the download orchestrator (`download_video`) and shared by
+/// `Arc` with the video stream, audio stream(s), every retry attempt, and
+/// the parallel segment tasks of that one download. Dropping the last `Arc`
+/// when the download ends clears the state — no explicit cleanup, no TTL.
+///
+/// Two kinds of evidence are recorded:
+/// - *unhealthy*: a host where connection-establishment failures exhausted
+///   the same-URL HTTP retries. This is host-level evidence — slow streams,
+///   HTTP statuses, or size mismatches never mark a host.
+/// - *mirrors*: the pool of known-eligible mirror hosts harvested from the
+///   download's own URL universe (manifest + probe results). Substitution
+///   targets are drawn from this pool, never from a hardcoded list.
+pub struct HostHealth {
+    inner: std::sync::Mutex<HostHealthInner>,
+}
+
+#[derive(Default)]
+struct HostHealthInner {
+    /// Known eligible mirror hosts, insertion-ordered, deduped, lowercase.
+    mirrors: Vec<String>,
+    /// Hosts with connection-establishment failure evidence.
+    unhealthy: HashSet<String>,
+}
+
+impl Default for HostHealth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostHealth {
+    pub fn new() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(HostHealthInner::default()),
+        }
+    }
+
+    /// Seeds the mirror pool from URLs (eligible `.bilivideo.com` non-P2P
+    /// hosts only; idempotent; no-op for github/akamaized/etc.).
+    pub fn seed_mirrors_from_urls(&self, urls: &[String]) {
+        let mut inner = self.inner.lock().unwrap();
+        for host in harvest_mirror_hosts(urls) {
+            if !inner.mirrors.contains(&host) {
+                inner.mirrors.push(host);
+            }
+        }
+    }
+
+    /// Marks the URL's host unhealthy and removes it from the mirror pool.
+    pub fn mark_url_unhealthy(&self, url: &str) {
+        if let Some(host) = extract_host(url) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.unhealthy.insert(host.clone());
+            inner.mirrors.retain(|m| *m != host);
+        }
+    }
+
+    /// Records the URL's host as alive: clears an unhealthy mark and adds
+    /// the host back to the mirror pool when eligible. Called from probe
+    /// successes so a recovered host is trusted again.
+    pub fn record_url_healthy(&self, url: &str) {
+        if let Some(host) = extract_host(url) {
+            let mut inner = self.inner.lock().unwrap();
+            inner.unhealthy.remove(&host);
+            if is_mirror_host(&host) && !inner.mirrors.contains(&host) {
+                inner.mirrors.push(host);
+            }
+        }
+    }
+
+    /// Copy-out state for the pure decision functions.
+    pub(crate) fn snapshot(&self) -> HealthSnapshot {
+        let inner = self.inner.lock().unwrap();
+        HealthSnapshot {
+            mirrors: inner.mirrors.clone(),
+            unhealthy: inner.unhealthy.clone(),
+        }
+    }
+}
+
+/// Point-in-time copy of [`HostHealth`] consumed by the pure substitution
+/// functions (kept `pub(crate)` so `downloads.rs` can call them without
+/// re-deriving state).
+#[derive(Clone)]
+pub(crate) struct HealthSnapshot {
+    pub(crate) mirrors: Vec<String>,
+    pub(crate) unhealthy: HashSet<String>,
+}
+
+/// True for hosts on the `bilivideo.com` CDN family — the only domain where
+/// signed bilibili URLs are verified to work cross-host (issue #527:
+/// same path+query returned 206 across `upos-sz-mirror*.bilivideo.com`,
+/// while `*.akamaized.net` uses a different signing scheme and fails).
+fn is_bilivideo_com_host(host: &str) -> bool {
+    host.to_ascii_lowercase().ends_with(".bilivideo.com")
+}
+
+/// True for hosts eligible as substitution targets: `upos-sz-mirror*`
+/// mirrors on `bilivideo.com`, excluding P2P nodes.
+// Caution: this shape is deliberately narrow. Cross-host reuse of signed
+// URLs was verified only for these mirrors (issue #527); do not widen
+// without re-verifying that the signature still returns 206.
+fn is_mirror_host(host: &str) -> bool {
+    let h = host.to_ascii_lowercase();
+    is_bilivideo_com_host(&h) && h.starts_with("upos-sz-mirror") && !is_p2p_cdn_host(&h)
+}
+
+/// Collects deduped eligible mirror hosts from a URL list, preserving order.
+fn harvest_mirror_hosts(urls: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for url in urls {
+        if let Some(host) = extract_host(url) {
+            if is_mirror_host(&host) && seen.insert(host.clone()) {
+                out.push(host);
+            }
+        }
+    }
+    out
+}
+
+/// Rewrites only the host of `url`, preserving scheme/path/query (the
+/// signature). Returns `None` when `url` does not parse.
+fn substitute_host(url: &str, new_host: &str) -> Option<String> {
+    let mut parsed = reqwest::Url::parse(url).ok()?;
+    // set_host with None port keeps scheme/path/query intact.
+    parsed.set_host(Some(new_host)).ok()?;
+    // Constraint: the url crate's set_host (2.5.4, set_host_internal with
+    // opt_new_port: None) leaves an existing explicit port untouched, so a
+    // port carried by the original host would survive the swap. Drop it —
+    // mirrors serve on the scheme's default port.
+    let _ = parsed.set_port(None);
+    Some(parsed.to_string())
+}
+
+/// Picks a substitution target: mirrors minus unhealthy, spread by `salt`
+/// so repeated substitutions distribute load across the pool.
+/// Deterministic. `None` when no eligible mirror exists.
+fn pick_mirror(snap: &HealthSnapshot, salt: usize) -> Option<String> {
+    let eligible: Vec<&String> = snap
+        .mirrors
+        .iter()
+        .filter(|m| !snap.unhealthy.contains(*m))
+        .collect();
+    if eligible.is_empty() {
+        return None;
+    }
+    Some(eligible[salt % eligible.len()].clone())
+}
+
+/// Pre-selection layer: rewrites every URL whose host is unhealthy (and is
+/// on `bilivideo.com`) to a pool mirror. No-op until at least one unhealthy
+/// mark exists, so plain-P2P lists keep relying on the static filter.
+/// URLs that cannot be substituted are returned unchanged — never dropped.
+pub(crate) fn substitute_in_list(urls: &[String], snap: &HealthSnapshot) -> Vec<String> {
+    if urls.is_empty() || snap.unhealthy.is_empty() || snap.mirrors.is_empty() {
+        return urls.to_vec();
+    }
+    urls.iter()
+        .enumerate()
+        .map(|(i, url)| {
+            let Some(host) = extract_host(url) else {
+                return url.clone();
+            };
+            // Why: the second arm rewrites bilivideo.com P2P hosts that
+            // carry no unhealthy mark. It only matters when the whole list
+            // is P2P — otherwise filter_out_p2p (running after this) drops
+            // such URLs anyway, but its all-P2P fallback would keep them
+            // verbatim, so substitution must rescue that case first.
+            let needs_rewrite = snap.unhealthy.contains(&host)
+                || (is_bilivideo_com_host(&host) && is_p2p_cdn_host(&host));
+            if !needs_rewrite || !is_bilivideo_com_host(&host) {
+                return url.clone();
+            }
+            match pick_mirror(snap, i) {
+                Some(target) => {
+                    log::info!(
+                        "[BE] cdn_selector: substituting unhealthy/P2P host {} -> {}",
+                        host,
+                        target
+                    );
+                    substitute_host(url, &target).unwrap_or_else(|| url.clone())
+                }
+                None => url.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Rotation-time layer: the URL to actually request. URLs on healthy or
+/// ineligible hosts pass through byte-identical; URLs on unhealthy
+/// `bilivideo.com` hosts are rewritten to a pool mirror chosen by `salt`.
+pub(crate) fn resolve_effective_url(url: &str, snap: &HealthSnapshot, salt: usize) -> String {
+    let Some(host) = extract_host(url) else {
+        return url.to_string();
+    };
+    if !snap.unhealthy.contains(&host) || !is_bilivideo_com_host(&host) {
+        return url.to_string();
+    }
+    match pick_mirror(snap, salt) {
+        Some(target) => substitute_host(url, &target).unwrap_or_else(|| url.to_string()),
+        None => url.to_string(),
+    }
 }
 
 /// Per-CDN probe result. Carries `original_index` for stable tie-breaking.
@@ -58,7 +269,7 @@ fn is_p2p_cdn_host(host: &str) -> bool {
 
 /// Extracts the lowercased host from a URL string. Returns `None` on parse
 /// failure (the caller treats unparseable URLs as non-P2P).
-fn extract_host(url: &str) -> Option<String> {
+pub(crate) fn extract_host(url: &str) -> Option<String> {
     reqwest::Url::parse(url)
         .ok()
         .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
@@ -196,13 +407,20 @@ async fn probe_single(
 /// Selects and ranks CDN URLs via static filtering + parallel latency probe.
 ///
 /// Pipeline:
-/// 1. Statically filter out P2P/MCDN nodes (fall back to original list when
+/// 1. Seed the shared mirror pool from this URL list, then substitute hosts
+///    marked unhealthy in `health` with healthy pool mirrors.
+/// 2. Statically filter out P2P/MCDN nodes (fall back to original list when
 ///    every candidate is P2P).
-/// 2. Probe every URL in parallel, bounded by `CDN_PROBE_CONCURRENCY`.
-/// 3. Sort by latency (failed probes last).
-/// 4. Recover the total size from the first successful probe.
-/// 5. Fallback: if no probe succeeded, keep the statically-filtered list.
-pub async fn select_best_cdns(urls: Vec<String>, cookie: Option<String>) -> ProbeOutcome {
+/// 3. Probe every URL in parallel, bounded by `CDN_PROBE_CONCURRENCY`;
+///    successful probes record their host healthy (recovery).
+/// 4. Sort by latency (failed probes last).
+/// 5. Recover the total size from the first successful probe.
+/// 6. Fallback: if no probe succeeded, keep the statically-filtered list.
+pub async fn select_best_cdns(
+    urls: Vec<String>,
+    cookie: Option<String>,
+    health: &HostHealth,
+) -> ProbeOutcome {
     log::info!("[BE] select_best_cdns: {} candidate CDNs", urls.len());
 
     if urls.is_empty() {
@@ -212,9 +430,17 @@ pub async fn select_best_cdns(urls: Vec<String>, cookie: Option<String>) -> Prob
         };
     }
 
-    // 1. Static filtering of P2P/MCDN nodes.
-    let candidates = filter_out_p2p(&urls);
-    let removed = urls.len() - candidates.len();
+    // 1a. Self-seed the mirror pool so every download_url call is
+    // self-contained (durl/bangumi/audio-fallback paths pass only URLs).
+    health.seed_mirrors_from_urls(&urls);
+
+    // 1b. Rewrite unhealthy hosts to healthy mirrors before probing, so a
+    // retry attempt does not burn its HTTP retries on a known-dead host.
+    let substituted = substitute_in_list(&urls, &health.snapshot());
+
+    // 2. Static filtering of P2P/MCDN nodes.
+    let candidates = filter_out_p2p(&substituted);
+    let removed = substituted.len() - candidates.len();
     log::info!(
         "[BE] select_best_cdns: static filter removed {} P2P CDN(s), {} remain = {:?}",
         removed,
@@ -263,6 +489,14 @@ pub async fn select_best_cdns(urls: Vec<String>, cookie: Option<String>) -> Prob
     while let Some(r) = futs.next().await {
         if let Some(res) = r {
             results.push(res);
+        }
+    }
+
+    // 3b. Successful probes count as host-recovery evidence: an unhealthy
+    // mark is cleared and the host re-enters the mirror pool.
+    for r in &results {
+        if r.latency_ms.is_some() {
+            health.record_url_healthy(&r.url);
         }
     }
 
@@ -452,5 +686,148 @@ mod tests {
 
     fn to_hv(s: &str) -> header::HeaderValue {
         header::HeaderValue::from_str(s).unwrap()
+    }
+
+    const SIGNED_URL_A: &str = "https://upos-sz-mirrorcosov.bilivideo.com/upgcxcode/57/23/1/1-30280.m4s?e=ig8eu&deadline=1787467312&upsig=abc&platform=pc";
+    const SIGNED_URL_B: &str = "https://upos-hz-mirrorakam.akamaized.net/upgcxcode/57/23/1/1-30280.m4s?e=ig8eu&deadline=1787467312&upsig=abc&platform=pc";
+    const MIRROR_COS: &str = "https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/57/23/1/1-30280.m4s?e=ig8eu&deadline=1787467312&upsig=abc&platform=pc";
+
+    fn snap(mirrors: &[&str], unhealthy: &[&str]) -> HealthSnapshot {
+        HealthSnapshot {
+            mirrors: mirrors.iter().map(|s| s.to_string()).collect(),
+            unhealthy: unhealthy.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn test_is_bilivideo_com_host() {
+        assert!(is_bilivideo_com_host("upos-sz-mirrorcos.bilivideo.com"));
+        assert!(is_bilivideo_com_host(
+            "upos-hz-mirrorakam.akamaized.net.bilivideo.com"
+        ));
+        assert!(!is_bilivideo_com_host("xy.mcdn.bilivideo.cn"));
+        assert!(!is_bilivideo_com_host("upos-hz-mirrorakam.akamaized.net"));
+        assert!(!is_bilivideo_com_host("bilivideo.com"));
+    }
+
+    #[test]
+    fn test_substitute_host_preserves_path_and_query() {
+        let rewritten = substitute_host(SIGNED_URL_A, "upos-sz-mirrorhw.bilivideo.com").unwrap();
+        let orig = reqwest::Url::parse(SIGNED_URL_A).unwrap();
+        let new = reqwest::Url::parse(&rewritten).unwrap();
+        assert_eq!(new.host_str().unwrap(), "upos-sz-mirrorhw.bilivideo.com");
+        assert_eq!(new.path(), orig.path());
+        assert_eq!(new.query(), orig.query());
+        assert!(substitute_host("not a url", "x").is_none());
+    }
+
+    #[test]
+    fn test_substitute_in_list_rewrites_unhealthy() {
+        let s = snap(
+            &["upos-sz-mirrorhw.bilivideo.com"],
+            &["upos-sz-mirrorcosov.bilivideo.com"],
+        );
+        let out = substitute_in_list(&[SIGNED_URL_A.to_string(), MIRROR_COS.to_string()], &s);
+        assert!(out[0].contains("upos-sz-mirrorhw.bilivideo.com"));
+        assert_eq!(out[1], MIRROR_COS, "healthy URL passes through unchanged");
+    }
+
+    #[test]
+    fn test_substitute_in_list_skips_non_bilivideo_source() {
+        let s = snap(
+            &["upos-sz-mirrorhw.bilivideo.com"],
+            &["upos-hz-mirrorakam.akamaized.net"],
+        );
+        let out = substitute_in_list(&[SIGNED_URL_B.to_string()], &s);
+        assert_eq!(out[0], SIGNED_URL_B, "akamaized source is never rewritten");
+    }
+
+    #[test]
+    fn test_substitute_in_list_noop_when_pool_empty() {
+        let s = snap(&[], &["upos-sz-mirrorcosov.bilivideo.com"]);
+        let out = substitute_in_list(&[SIGNED_URL_A.to_string()], &s);
+        assert_eq!(out[0], SIGNED_URL_A);
+    }
+
+    #[test]
+    fn test_substitute_in_list_all_unhealthy_is_noop() {
+        let host = "upos-sz-mirrorcosov.bilivideo.com";
+        let s = snap(&[host], &[host]);
+        let out = substitute_in_list(&[SIGNED_URL_A.to_string()], &s);
+        assert_eq!(
+            out[0], SIGNED_URL_A,
+            "target must never be unhealthy itself"
+        );
+    }
+
+    #[test]
+    fn test_resolve_effective_url_healthy_passthrough() {
+        let s = snap(&["upos-sz-mirrorhw.bilivideo.com"], &[]);
+        assert_eq!(resolve_effective_url(SIGNED_URL_A, &s, 0), SIGNED_URL_A);
+    }
+
+    #[test]
+    fn test_resolve_effective_url_rotates_mirrors_by_salt() {
+        let s = snap(
+            &[
+                "upos-sz-mirrorhw.bilivideo.com",
+                "upos-sz-mirror08c.bilivideo.com",
+            ],
+            &["upos-sz-mirrorcosov.bilivideo.com"],
+        );
+        let a = resolve_effective_url(SIGNED_URL_A, &s, 0);
+        let b = resolve_effective_url(SIGNED_URL_A, &s, 1);
+        assert!(a.contains("upos-sz-mirrorhw.bilivideo.com"));
+        assert!(b.contains("upos-sz-mirror08c.bilivideo.com"));
+    }
+
+    #[test]
+    fn test_harvest_mirror_hosts_dedupes_and_filters() {
+        let urls = vec![
+            SIGNED_URL_A.to_string(),
+            SIGNED_URL_A.to_string(),
+            MIRROR_COS.to_string(),
+            SIGNED_URL_B.to_string(),
+            "https://xy.mcdn.bilivideo.com/a".to_string(),
+        ];
+        let hosts = harvest_mirror_hosts(&urls);
+        assert_eq!(hosts.len(), 2);
+        assert!(hosts.contains(&"upos-sz-mirrorcosov.bilivideo.com".to_string()));
+        assert!(hosts.contains(&"upos-sz-mirrorcos.bilivideo.com".to_string()));
+    }
+
+    #[test]
+    fn test_host_health_mark_seed_recover() {
+        let h = HostHealth::new();
+        h.seed_mirrors_from_urls(&[SIGNED_URL_A.to_string(), SIGNED_URL_B.to_string()]);
+        let s = h.snapshot();
+        assert_eq!(
+            s.mirrors.len(),
+            1,
+            "only bilivideo.com upos mirrors are seeded"
+        );
+        assert!(s.unhealthy.is_empty());
+
+        h.mark_url_unhealthy(SIGNED_URL_A);
+        let s = h.snapshot();
+        assert!(s.unhealthy.contains("upos-sz-mirrorcosov.bilivideo.com"));
+        assert!(
+            s.mirrors.is_empty(),
+            "marking removes the host from the pool"
+        );
+
+        // Recovery: a successful probe clears the mark and re-adds the pool.
+        h.record_url_healthy(SIGNED_URL_A);
+        let s = h.snapshot();
+        assert!(s.unhealthy.is_empty());
+        assert_eq!(s.mirrors.len(), 1);
+    }
+
+    #[test]
+    fn test_host_health_seed_is_idempotent() {
+        let h = HostHealth::new();
+        h.seed_mirrors_from_urls(&[MIRROR_COS.to_string()]);
+        h.seed_mirrors_from_urls(&[MIRROR_COS.to_string()]);
+        assert_eq!(h.snapshot().mirrors.len(), 1);
     }
 }

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -329,6 +329,7 @@ pub async fn download_url(
     override_stage: Option<&str>,
     emit_complete: bool,
     concurrency: usize,
+    host_health: Arc<cdn_selector::HostHealth>,
 ) -> Result<()> {
     log::info!(
         "[BE] download_url: starting download to {:?}, cdn_count={}",
@@ -403,7 +404,8 @@ pub async fn download_url(
     //   *.mcdn.bilivideo.cn) by excluding/demoting it up front and probing the
     //   candidate CDNs in parallel for latency instead of reacting to slowness
     //   mid-download (issue #490).
-    let cdn_outcome = cdn_selector::select_best_cdns(cdn_urls.clone(), cookie.clone()).await;
+    let cdn_outcome =
+        cdn_selector::select_best_cdns(cdn_urls.clone(), cookie.clone(), &host_health).await;
 
     let ordered_urls = cdn_outcome.ordered_urls;
     let total = match cdn_outcome.total_size {
@@ -475,6 +477,7 @@ pub async fn download_url(
         let emits_c = emits.clone();
         let sem_c = sem.clone();
         let cancel_token_c = cancel_token.clone();
+        let host_health_c = host_health.clone();
         futs.push(tokio::spawn(async move {
             let _permit = sem_c.acquire().await.unwrap();
 
@@ -487,10 +490,12 @@ pub async fn download_url(
             }
 
             // `http_retries` counts HTTP-layer failures (invalid status,
-            // request error) bounded by MAX_SEG_RETRIES. CDN-rotation
-            // failures (size mismatch, stream error) use `cdn_rotation_count`,
-            // slow-speed rotations use `slow_rotations`, and same-CDN resume
-            // retries use `same_cdn_retries`. Keeping these budgets independent
+            // request error) bounded by MAX_SEG_RETRIES per selected URL;
+            // it resets when a request-error exhaustion rotates the CDN.
+            // CDN-rotation failures (size mismatch, stream error, connection
+            // failure) use `cdn_rotation_count`, slow-speed rotations use
+            // `slow_rotations`, and same-CDN resume retries use
+            // `same_cdn_retries`. Keeping these budgets independent
             // prevents CDN rotations from inflating the HTTP retry counter —
             // which previously disabled the in-segment chunk-retry budget
             // inside download_segment_with_speed_check and produced misleading
@@ -544,9 +549,27 @@ pub async fn download_url(
 
                 // Select CDN URL from the combined rotation count of both
                 // budgets so each rotation still advances to the next CDN.
+                // The rotation-time substitution layer then rewrites the
+                // URL when its host is marked unhealthy in this download —
+                // covering pools whose every URL lives on the same dead
+                // host, where index rotation alone cannot escape (issue #527).
                 let rotations_used = cdn_rotation_count as usize + slow_rotations as usize;
                 let cdn_idx = rotations_used % cdn_urls_c.len();
-                let current_url = &cdn_urls_c[cdn_idx];
+                let selected_url = &cdn_urls_c[cdn_idx];
+                let effective_url = cdn_selector::resolve_effective_url(
+                    selected_url,
+                    &host_health_c.snapshot(),
+                    rotations_used,
+                );
+                if &effective_url != selected_url {
+                    log::info!(
+                        "[BE] download_url: segment {} substituting unhealthy host: {} -> {}",
+                        idx,
+                        cdn_selector::extract_host(selected_url).unwrap_or_default(),
+                        cdn_selector::extract_host(&effective_url).unwrap_or_default()
+                    );
+                }
+                let current_url = &effective_url;
 
                 let req = apply_cookie(
                     client_c
@@ -827,6 +850,27 @@ pub async fn download_url(
                         );
                         if http_retries < MAX_SEG_RETRIES {
                             backoff_sleep(http_retries).await;
+                            continue;
+                        }
+                        // Connection-establishment failures exhausted this
+                        // URL's retries: host-level evidence, not a bad
+                        // signature — mark the host unhealthy for the rest of
+                        // this download and rotate away instead of failing the
+                        // segment (issue #527). Rotations draw from the shared
+                        // cdn_rotation_count budget; http_retries resets so
+                        // the next selected URL keeps its full retry value.
+                        host_health_c.mark_url_unhealthy(current_url);
+                        // Note: the mark is recorded BEFORE the rotation
+                        // budget check below — even when the budget is
+                        // exhausted and this segment fails, the next
+                        // retry_download attempt's pre-selection
+                        // substitutes away from this host, because a
+                        // playurl refetch can keep returning it (issue #527).
+                        if cdn_rotation_count < max_cdn_rotations {
+                            needs_full_restart = true; // CDN change => full restart (byte-stream rule)
+                            cdn_rotation_count += 1;
+                            http_retries = 0;
+                            backoff_sleep(cdn_rotation_count).await;
                             continue;
                         }
                         return Err(anyhow::anyhow!("segment {} request error: {e}", idx));


### PR DESCRIPTION
## Summary

Adds per-download CDN host health with two-layer netloc substitution, so a host-level outage no longer requires dropping quality to recover.

Closes #527

A pre-release failure showed the escape-proof pattern this fixes: primary and backup URLs on the same dead host → rotation re-hit it → every retry re-fetched playurls that kept returning the same host → saved only by falling back audio quality (30280 → 30216).

## Changes

- **`HostHealth`** (`cdn_selector.rs`): mirror pool + unhealthy set, created in `download_video`, shared by `Arc` with video/audio streams, every retry, and segment tasks of that one download. Dropping the last Arc clears state — no TTL, no explicit cleanup (RAII).
- **Pre-selection layer**: `select_best_cdns` rewrites URLs on unhealthy hosts to healthy pool mirrors *before* probing, so retry attempts never burn HTTP retries on a known-dead host. Successful probes record recovery and re-admit the host.
- **Rotation-time layer**: `resolve_effective_url` rewrites the selected URL when its host is unhealthy — covers pools whose every URL lives on the same dead host, where index rotation alone cannot escape.
- **Connection-failure marking**: exhausting same-URL HTTP retries with request errors marks the host unhealthy and rotates (existing `cdn_rotation_count` budget, `http_retries` reset, full segment restart per the byte-stream corruption rule). The mark is recorded before the budget check so budget-exhausted failures still protect the next retry's pre-selection.
- Mirror pool is harvested from the download's own URL universe (whole DASH manifest in `download_video` + self-seed in `select_best_cdns`) — no hardcoded mirror list to rot.
- Substitution restricted to `*.bilivideo.com` upos mirrors: the only domain where signed bilibili URLs are **verified by experiment** to work cross-host (206 OK across mirrors; `akamaized.net` uses a different signing scheme and fails). URLs are never dropped, only rewritten.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `cargo build` / `cargo test --lib` (120 passed, +11 new) / `cargo clippy` clean
- [x] Unit tests: host-eligibility, signature-preserving rewrite, list substitution (unhealthy rewrite / non-bilivideo skip / empty pool / all-unhealthy noop), salt-based mirror rotation, harvest dedup+filter, HostHealth mark/seed/recover lifecycle
- [x] Manual: 3 real downloads across two videos — all playable, integrity check success on all, zero substitutions fired (quiet when hosts are healthy, as designed)

## Screenshots / Videos (Optional)

N/A (backend download engine)

## Breaking Changes

None. Normal-condition behavior is byte-identical (substitution only fires after connection failures mark a host). Rotation budgets and the same-CDN resume path from #528 are untouched.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced — N/A, no user-facing strings changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)