### PR TITLE
fix(video): stop warning icon on codec-only fallback

### DIFF
--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -270,12 +270,20 @@ const VideoPartCard = memo(function VideoPartCard({
    * Whether any quality (video or audio) was substituted with a fallback
    * due to the originally requested quality being unavailable.
    * Drives the warning icon in the accordion trigger.
+   *
+   * WHY: codec fallback is excluded. The preferred codec being absent from
+   * the manifest leaves no alternative to choose, and the summary label
+   * already shows the actual codec (e.g. "1080p(AVC)"), so warning on it
+   * would fire on nearly every AVC-only video with pure noise.
    */
+  // Caution: with codec fallback excluded here, `videoCodecFallback` (sent by the
+  // backend download-quality-resolved event and stored via inputSlice
+  // setResolvedQuality) is no longer read anywhere in the UI. Introduced in
+  // PR #460 (a17c8da); keep-or-remove it end-to-end as a deliberate decision.
   const hasFallback = useMemo(() => {
     if (!resolvedQuality) return false
     return (
       resolvedQuality.videoQualityFallback ||
-      resolvedQuality.videoCodecFallback ||
       resolvedQuality.audioQualityFallback
     )
   }, [resolvedQuality])


### PR DESCRIPTION
## Summary

- Exclude `videoCodecFallback` from the `hasFallback` computation in `VideoPartCard`, so the quality-fallback warning icon (⚠️) no longer fires when only the codec fell back
- With the default codec priority (`av1First`), any AVC-only manifest (no AV1/HEVC rendition) was flagged as a codec fallback, so the warning fired on nearly every such video even though the requested quality (e.g. 1080p/192K) was delivered exactly
- Codec-only fallback leaves no alternative to choose, and the actual codec is already visible in the summary label (e.g. `1080p(AVC)`), so the warning was pure notification noise that diluted the signal for real quality fallbacks
- Video/audio quality fallbacks still trigger the icon; the backend payload and Redux state keep `videoCodecFallback` unchanged

## Related Issue

None (auto-search found no matching open issue; #484 covers download recovery, not the warning icon)

## Type of Change

- [x] \U0001F41B Bug fix
- [ ] ✨ New feature
- [ ] \U0001F4A5 Breaking change
- [ ] \U0001F4DD Documentation
- [ ] ♻️ Refactoring
- [ ] \U0001F527 Chore

## Test Plan

- [x] `npm run typecheck` / `npm run lint` / `npm run test` (177 passed) green in worktree
- [x] Manual: download https://www.bilibili.com/video/BV12arqBnEVL?p=2 — starts at 1080p(AVC)/192K with no ⚠️ icon
- [x] Manual: selecting an unavailable quality still shows the ⚠️ icon (quality fallback path intact)

## Screenshots / Videos (Optional)

N/A (icon removal only)

## Breaking Changes

None. Backend `download-quality-resolved` payload unchanged.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — existing tests cover regression
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — no key changes

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)