### PR TITLE
🚀 Release v1.50.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version `1.49.0` → `1.50.0` in `src-tauri/tauri.conf.json`
- Includes since v1.49.0:
  - feat(download): per-download host health with netloc substitution (#529)
  - fix(video): stop warning icon on codec-only fallback (#530)

## Related Issue

None (release branch)

## Type of Change

- [ ] \U0001F41B Bug fix
- [ ] ✨ New feature
- [ ] \U0001F4A5 Breaking change
- [ ] \U0001F4DD Documentation
- [ ] ♻️ Refactoring
- [x] \U0001F527 Chore

## Test Plan

- [ ] CI passes (ci-status required check)

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [ ] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator) — N/A (version bump only)
- [x] Conventional Commits format followed in commit messages
- [ ] Tests added/updated (or N/A for docs/chore) — N/A
- [ ] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)