### PR TITLE
fix(download): zero displayed transfer rate after 2s without byte progress

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -6,12 +6,19 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::{spawn, sync::watch, sync::Mutex, time};
 
 /// Progress update interval in milliseconds.
 const PROGRESS_UPDATE_INTERVAL_MS: u64 = 500;
+
+// Why 2s: above the 1s speed-calc window so a brief segment-boundary gap
+//   does not flicker the displayed rate to 0, while still turning the
+//   display truthful quickly during a real stall (issue #534).
+/// Seconds without any byte increase after which the displayed transfer
+/// rate is forced to 0 instead of keeping the last computed value.
+const SPEED_DISPLAY_IDLE_SECS: u64 = 2;
 
 /// Progress information structure sent to the frontend.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -68,6 +75,9 @@ struct EmitsInner {
     last_speed_calc_instant: Instant,
     last_speed_calc_bytes: u64,
     last_speed_kbps: f64,
+    /// When the downloaded byte count last increased. Drives the idle
+    /// zeroing of the displayed transfer rate (issue #534).
+    last_byte_increase: Instant,
 }
 
 impl Default for EmitsInner {
@@ -82,6 +92,7 @@ impl Default for EmitsInner {
             last_speed_calc_bytes: 0,
             is_complete: false,
             last_speed_kbps: 0.0,
+            last_byte_increase: now,
         }
     }
 }
@@ -330,6 +341,20 @@ impl Emits {
             }
 
             inner.last_downloaded_bytes = current_bytes;
+            inner.last_byte_increase = now;
+        } else if now.duration_since(inner.last_byte_increase)
+            >= Duration::from_secs(SPEED_DISPLAY_IDLE_SECS)
+        {
+            // Why: the speed recompute above only runs on ticks where bytes
+            //   changed, so during a full stall the last computed value
+            //   (e.g. 10 MB/s) kept being displayed while nothing moved
+            //   (issue #534). Force the display to 0 once no byte has
+            //   arrived for SPEED_DISPLAY_IDLE_SECS.
+            // Note: the threshold sits above the 1s speed-calc window so a
+            //   brief segment-boundary gap does not flicker the rate to 0;
+            //   a boundary pause shorter than this keeps the last value.
+            inner.progress.transfer_rate = 0.0;
+            inner.last_speed_kbps = 0.0;
         }
 
         inner.progress.delta_time = delta_time;

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -35,8 +35,10 @@ enum SegmentError {
     //   all pass while the payload itself differs across CDNs. Stitching
     //   CDN #0 bytes then CDN #1 bytes broke the moov atom (v1.49.0
     //   pre-release test: goi3.mp4 verified corrupt, goi2.mp4 with zero
-    //   rotations verified fine). Bili23-Downloader avoids this by never
-    //   switching CDN mid-download.
+    //   rotations verified fine). The safe designs are either never
+    //   switching CDN mid-download, or discarding all received bytes on
+    //   every CDN change — this codebase chose the latter so it can still
+    //   rotate away from a degraded node.
     /// Throughput below MIN_SPEED_THRESHOLD; rotate using the slow-speed
     /// budget (separate from the stream-error budget of Reconnect). The
     /// caller fully restarts the segment — resuming on another CDN is unsafe.


### PR DESCRIPTION
## Summary

The displayed transfer rate kept the last computed value during a full stall (e.g. "10 MB/s" while nothing moved) because the speed recompute in `send_progress_locked` only runs on ticks where the byte count changed — during a stall no recompute ever runs, so the stale rate is emitted forever.

Fix: track when the byte count last increased and force `transfer_rate` (and its cached `last_speed_kbps`, so the reuse branch cannot resurrect it) to 0 once no byte has arrived for `SPEED_DISPLAY_IDLE_SECS` (2s).

The 2s threshold sits above the 1s recompute window, so a brief segment-boundary gap keeps the last value instead of flickering the rate to 0. A boundary pause is now displayed as a truthful 0 only when it actually persists.

## Related Issue

Closes #534

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `cargo build` / `cargo clippy` / `cargo fmt` clean
- [x] Manual download test: 2 videos downloaded successfully; backend logs healthy (aggregate monitor sampling, 2 genuine sub-threshold rotations, 0 stalls)

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A — display-only change, no testable pure logic extracted)
- [x] i18n files synced (N/A — backend only, no user-facing strings)