### PR TITLE
feat(settings): add Open Logs button to settings dialog

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,7 @@ pub fn run() {
             search_history,
             export_history,
             reveal_in_folder,
+            reveal_log_file,
             open_file,
             get_release_notes,
             get_all_release_notes,
@@ -1075,6 +1076,40 @@ async fn reveal_in_folder(app: AppHandle, path: String) -> Result<(), String> {
     app.opener()
         .reveal_item_in_dir(&path)
         .map_err(|e| format!("Failed to reveal file: {}", e))
+}
+
+/// Reveals the current log file (`app.log`) in the system file manager.
+///
+/// Builds the log path from the app data directory using the same scheme
+/// as the log plugin setup, then asks the OS file manager to open the
+/// logs folder with `app.log` selected. The frontend never assembles
+/// backend-owned paths.
+///
+/// # Arguments
+///
+/// * `app` - Tauri application handle
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The app data directory cannot be resolved
+/// - The file manager cannot be opened
+#[tauri::command]
+async fn reveal_log_file(app: AppHandle) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    let log_file = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {}", e))?
+        // Note: "app.log" must stay in sync with the log plugin in run()'s
+        // setup() (log_dir join("logs") + file_name: Some("app".into())); the
+        // plugin appends the ".log" suffix, so grepping "app.log" will not find
+        // that site. Drift only fails at runtime when the user clicks the button.
+        .join("logs")
+        .join("app.log");
+    app.opener()
+        .reveal_item_in_dir(&log_file)
+        .map_err(|e| format!("Failed to reveal log file: {}", e))
 }
 
 /// Opens a file with the system's default application.

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -46,6 +46,7 @@ import {
 } from '@/features/settings/lib/fontSize'
 import type { FontSizePreset } from '@/features/settings/type'
 import { DevOptions } from '@/features/settings/ui/DevOptions'
+import { OpenLogsButton } from '@/features/settings/ui/OpenLogsButton'
 import { ReleaseNotesSection } from '@/features/settings/ui/ReleaseNotesSection'
 import { TitleReplacementSettings } from '@/features/settings/ui/TitleReplacementSettings'
 import { UpdateCheckButton } from '@/features/settings/ui/UpdateCheckButton'
@@ -1015,6 +1016,7 @@ function SettingsForm() {
             <UpdateCheckButton />
             <ReleaseNotesSection />
             <AboutDialog />
+            <OpenLogsButton />
           </div>
         </div>
         <Separator />

--- a/src/features/settings/ui/OpenLogsButton.tsx
+++ b/src/features/settings/ui/OpenLogsButton.tsx
@@ -1,0 +1,38 @@
+import { logger } from '@/shared/lib/logger'
+import { Button } from '@/shared/ui/button'
+import { toast } from '@/shared/ui/toast'
+import { invoke } from '@tauri-apps/api/core'
+import { ScrollText } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Settings-screen action button that reveals the log file.
+ *
+ * Invokes the backend 'reveal_log_file' command, which owns the log
+ * path scheme and opens the logs folder with `app.log` selected in the
+ * system file manager. The frontend stays a pure presentation layer.
+ *
+ * @example
+ * ```tsx
+ * <OpenLogsButton />
+ * ```
+ */
+export function OpenLogsButton() {
+  const { t } = useTranslation()
+
+  const handleOpenLogs = async () => {
+    try {
+      await invoke('reveal_log_file')
+    } catch (error) {
+      logger.error('OpenLogsButton: Failed to reveal log file', error)
+      toast.error(t('settings.open_logs_failed'))
+    }
+  }
+
+  return (
+    <Button type="button" variant="outline" onClick={handleOpenLogs}>
+      <ScrollText className="mr-2 size-4" />
+      {t('settings.open_logs_button')}
+    </Button>
+  )
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "Fast (Copy)",
     "trim_mode_reencode": "Accurate (Re-encode)",
     "app_section_label": "Application",
+    "open_logs_button": "Open Logs",
+    "open_logs_failed": "Failed to open logs",
     "show_github_stars_label": "Show GitHub Stars",
     "show_github_stars_description": "Display the star count in the app bar",
     "theme_label": "Theme",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "Rápido (Copiar)",
     "trim_mode_reencode": "Preciso (Recodificar)",
     "app_section_label": "Aplicación",
+    "open_logs_button": "Abrir registros",
+    "open_logs_failed": "No se pudieron abrir los registros",
     "show_github_stars_label": "Mostrar GitHub Stars",
     "show_github_stars_description": "Mostrar el recuento de estrellas en la barra de la aplicación",
     "theme_label": "Tema",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "Rapide (Copie)",
     "trim_mode_reencode": "Précis (Réencodage)",
     "app_section_label": "Application",
+    "open_logs_button": "Ouvrir les journaux",
+    "open_logs_failed": "Impossible d'ouvrir les journaux",
     "show_github_stars_label": "Afficher les GitHub Stars",
     "show_github_stars_description": "Afficher le nombre d'étoiles dans la barre d'application",
     "theme_label": "Thème",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "高速（コピー）",
     "trim_mode_reencode": "高精度（再エンコード）",
     "app_section_label": "アプリケーション",
+    "open_logs_button": "ログを開く",
+    "open_logs_failed": "ログを開けませんでした",
     "show_github_stars_label": "GitHub Stars を表示",
     "show_github_stars_description": "アプリバーにスター数を表示します",
     "theme_label": "テーマ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "빠른 속도 (복사)",
     "trim_mode_reencode": "정확한 (재인코딩)",
     "app_section_label": "애플리케이션",
+    "open_logs_button": "로그 열기",
+    "open_logs_failed": "로그를 열지 못했습니다",
     "show_github_stars_label": "GitHub Stars 표시",
     "show_github_stars_description": "앱 바에 스타 수를 표시합니다",
     "theme_label": "테마",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -399,6 +399,8 @@
     "trim_mode_copy": "快速（复制）",
     "trim_mode_reencode": "精确（重编码）",
     "app_section_label": "应用程序",
+    "open_logs_button": "打开日志",
+    "open_logs_failed": "无法打开日志",
     "show_github_stars_label": "显示 GitHub Stars",
     "show_github_stars_description": "在应用栏中显示星标数",
     "theme_label": "主题",


### PR DESCRIPTION
## Summary

Add an "Open Logs" button to the Application section of the settings dialog. Clicking it reveals the current log file (`app.log`) in the system file manager — the logs folder opens with `app.log` selected.

- New `reveal_log_file` Tauri command: the Rust side builds the log path (`app_data_dir/logs/app.log`, same scheme as the log plugin setup) and calls `reveal_item_in_dir`. The frontend stays a pure presentation layer and never assembles backend-owned paths
- New `OpenLogsButton` component (`outline` variant, `ScrollText` icon) placed alongside Update Check / Release Notes / About, matching the sibling button pattern
- Error path: `logger.error` + i18n-ized error toast
- i18n keys `settings.open_logs_button` / `settings.open_logs_failed` added to all 6 locales

## Related Issue

Related to #242 (log infrastructure enhancement; its notes list a user-facing log UI as a future consideration)

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] Run `npm run tauri dev`
- [x] Open the settings dialog
- [x] Click "Open Logs" in the Application section
- [x] Verify the file manager opens the logs folder with `app.log` selected

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — N/A: single invoke-only UI button, no new logic surface
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)