### PR TITLE
test: add rust-test CI job and fix all failing doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,38 @@ jobs:
 
       - name: Run Clippy
         working-directory: src-tauri
-        run: cargo clippy -- -D warnings
+        # Why: --all-targets also lints test targets; plain clippy covers lib/bins only, and
+        # the test-coverage plan (see dev-dependencies note in src-tauri/Cargo.toml) adds
+        # unit tests that must stay warning-free
+        run: cargo clippy --all-targets -- -D warnings
+
+  # Why: cargo test also compiles and runs doctests — this job enforces them and is what
+  # surfaced the 19 failing doc examples fixed in this PR
+  rust-test:
+    name: Rust Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: rust-ci
+
+      - name: Install dependencies (Ubuntu only)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev libglib2.0-dev
+
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test
 
   rust-format:
     name: Rust Format
@@ -248,6 +279,7 @@ jobs:
         test,
         rust-check,
         rust-clippy,
+        rust-test,
         rust-format,
         docs-format,
       ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -233,6 +233,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,9 +598,11 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-webdriver",
+ "tempfile",
  "tokio",
  "tokio-util",
  "url",
+ "wiremock",
  "xz2",
  "zip 2.4.2",
 ]
@@ -1289,6 +1301,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,7 +1399,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2120,7 +2150,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2296,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2467,13 +2497,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -3457,6 +3488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,7 +4124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8052,6 +8093,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,3 +76,17 @@ log = "0.4"
 tauri-plugin-webdriver = "0.2"
 tauri-plugin-mcp-bridge = "0.11"
 
+[dev-dependencies]
+# Why: declared up front (PR R1 of the test-coverage plan) so later PRs add
+# tests without re-touching Cargo.toml. No test code uses them yet — they are
+# consumed by upcoming PRs:
+# - tempfile: fs-touching tests (secure_storage, cookie Firefox fixtures, ...)
+# - wiremock: local mock HTTP server for BiliApi transport tests (no live network)
+# - tokio test-util: #[tokio::test(start_paused = true)] for deterministic time
+#   in emits.rs tests
+# - tauri "test" feature: tauri::test::mock_app() for AppHandle-coupled tests.
+#   Applies to test builds only; release binaries are unaffected.
+tempfile = "3"
+wiremock = "0.6"
+tokio = { version = "1", features = ["test-util"] }
+tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -195,7 +195,9 @@ use tauri::AppHandle;
 ///
 /// # Example
 ///
-/// ```
+/// Why: the example sends a live HTTP request; doctests now run in CI (rust-test job),
+/// so it must not execute
+/// ```ignore
 /// let client = build_client()?;
 /// let response = client.get("https://api.bilibili.com/...").send().await?;
 /// ```
@@ -303,7 +305,9 @@ fn validate_bangumi_response(code: i64, message: &str) -> Result<(), String> {
 ///
 /// # Example
 ///
-/// ```
+/// Why: private fn; doctests compile as a separate crate and cannot import it, even
+/// though the assertions themselves are pure (enforced by the rust-test CI job)
+/// ```ignore
 /// let url = "https://www.bilibili.com/bangumi/play/ep3051843";
 /// assert_eq!(extract_bangumi_ep_id(url), Some(3051843));
 /// ```
@@ -1149,7 +1153,9 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
 ///
 /// # Example
 ///
-/// ```no_run
+/// Why: private fn; doctests compile as a separate crate and cannot import it
+/// (enforced by the rust-test CI job)
+/// ```ignore
 /// # use std::path::Path;
 /// # let lib_path = Path::new("/app/lib");
 /// cleanup_subtitle_files(lib_path, "download-123");
@@ -1390,7 +1396,9 @@ async fn save_to_history(
 ///
 /// # Examples
 ///
-/// ```rust
+/// Why: private fn; doctests compile as a separate crate and cannot import it
+/// (enforced by the rust-test CI job)
+/// ```ignore
 /// let options = vec![&"".to_string(), &"1080P".to_string(), &"720P".to_string()];
 /// assert_eq!(first_non_empty(&options), Some("1080P".to_string()));
 /// ```
@@ -2520,7 +2528,9 @@ pub struct WatchHistoryResponse {
 /// - Initial request: `max=0`, `view_at=0`
 /// - Subsequent requests: Use `cursor.max`, `cursor.view_at` from previous response
 ///
-/// ```rust
+/// Why: needs a live AppHandle with real Bilibili cookies; doctests run in CI
+/// (rust-test job) and must stay hermetic
+/// ```ignore
 /// let first_page = fetch_watch_history(app, 0, 0).await?;
 /// let next_page = fetch_watch_history(app, first_page.cursor.max, first_page.cursor.view_at).await?;
 /// ```
@@ -3813,7 +3823,9 @@ pub async fn fetch_bangumi_part_qualities(
 ///
 /// # Example
 ///
-/// ```rust
+/// Why: expand_short_url follows a live b23.tv redirect over the network; doctests
+/// run in CI (rust-test job) and must not hit external services
+/// ```ignore
 /// let full_url = expand_short_url("https://b23.tv/abc123".to_string()).await?;
 /// assert!(full_url.starts_with("https://www.bilibili.com/video/"));
 /// ```

--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -99,9 +99,10 @@ pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> Cleanu
 ///
 /// # Examples
 ///
-/// ```
+/// Why: private fn; doctests compile as a separate crate and cannot import it, even
+/// though the assertions themselves are pure (enforced by the rust-test CI job)
+/// ```ignore
 /// # use std::path::Path;
-/// # use crate::handlers::cleanup::is_temp_file;
 /// assert!(is_temp_file(Path::new("temp_video_123.m4s")));
 /// assert!(is_temp_file(Path::new("temp_audio_456.m4s")));
 /// assert!(is_temp_file(Path::new("temp_sub_789.srt")));

--- a/src-tauri/src/handlers/concurrency.rs
+++ b/src-tauri/src/handlers/concurrency.rs
@@ -32,9 +32,14 @@ const DEFAULT_MAX_CONCURRENT_DOWNLOADS: usize = 8;
 ///
 /// # Example
 ///
+/// Why: doctests compile as separate crates, so `crate::` paths do not resolve —
+/// import via the lib crate name instead (this PR's doctest policy)
+/// Note: this example is executed by `cargo test` in CI; acquiring one permit from
+/// the 8-permit semaphore cannot deadlock
 /// ```rust
-/// use crate::handlers::concurrency::VIDEO_SEMAPHORE;
+/// use bilibili_downloader_gui_lib::handlers::concurrency::VIDEO_SEMAPHORE;
 ///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Acquire semaphore (async)
 /// let permit = VIDEO_SEMAPHORE.clone().acquire_owned().await?;
 ///
@@ -43,6 +48,8 @@ const DEFAULT_MAX_CONCURRENT_DOWNLOADS: usize = 8;
 ///
 /// // Release semaphore
 /// drop(permit);
+/// # Ok(())
+/// # }
 /// ```
 pub static VIDEO_SEMAPHORE: Lazy<Arc<Semaphore>> =
     Lazy::new(|| Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_DOWNLOADS)));

--- a/src-tauri/src/handlers/favorites.rs
+++ b/src-tauri/src/handlers/favorites.rs
@@ -53,7 +53,9 @@ use crate::models::frontend_dto::{
 ///
 /// # Examples
 ///
-/// ```rust
+/// Why: needs a live AppHandle with authenticated Bilibili API access; doctests run
+/// in CI (rust-test job) and must stay hermetic
+/// ```ignore
 /// use tauri::AppHandle;
 ///
 /// // Fetch favorite folders for user with mid = 123456
@@ -160,7 +162,9 @@ pub async fn fetch_favorite_folders(
 ///
 /// # Examples
 ///
-/// ```rust
+/// Why: needs a live AppHandle with authenticated Bilibili API access; doctests run
+/// in CI (rust-test job) and must stay hermetic
+/// ```ignore
 /// use tauri::AppHandle;
 ///
 /// // Fetch first page (10 items) from folder with ID 98765

--- a/src-tauri/src/handlers/github.rs
+++ b/src-tauri/src/handlers/github.rs
@@ -28,14 +28,15 @@ use octocrab::Octocrab;
 ///
 /// # Example
 ///
-/// ```rust
-/// use crate::handlers::github::fetch_repo_stars;
+/// Why: fetch_repo_stars queries the live GitHub API; doctests run in CI (rust-test
+/// job) and must not hit external services
+/// Note: the full-crate-path import is kept for documentation only — it is inert
+/// inside an ignored block
+/// ```ignore
+/// use bilibili_downloader_gui_lib::handlers::github::fetch_repo_stars;
 ///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let stars = fetch_repo_stars("j4rviscmd", "bilibili-downloader-gui").await?;
 /// println!("Stars: {}", stars);
-/// # Ok(())
-/// # }
 /// ```
 pub async fn fetch_repo_stars(owner: &str, repo: &str) -> Result<usize> {
     log::info!(

--- a/src-tauri/src/handlers/updater.rs
+++ b/src-tauri/src/handlers/updater.rs
@@ -30,7 +30,9 @@ use octocrab::Octocrab;
 ///
 /// # Example
 ///
-/// ```rust
+/// Why: fetch_all_release_notes paginates the live GitHub API; doctests run in CI
+/// (rust-test job) and must not hit external services
+/// ```ignore
 /// let notes = fetch_all_release_notes("j4rviscmd", "bilibili-downloader-gui", "1.1.0").await?;
 /// assert!(notes.contains("## v1.1.1"));
 /// ```

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1137,7 +1137,9 @@ async fn open_file(app: AppHandle, path: String) -> Result<(), String> {
 ///
 /// # Example
 ///
-/// ```rust
+/// Why: private #[tauri::command] making a live GitHub API call; doctests compile as a
+/// separate crate and can neither import private items nor hit the network (rust-test job)
+/// ```ignore
 /// let notes = get_release_notes("j4rviscmd", "bilibili-downloader-gui", "1.1.0").await?;
 /// // notes contains Markdown formatted release notes for all newer versions
 /// ```
@@ -1200,15 +1202,11 @@ async fn get_all_release_notes(owner: String, repo: String) -> Result<String, St
 ///
 /// # Example
 ///
-/// ```rust
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// use tauri::AppHandle;
-///
-/// # let app: AppHandle = unimplemented!();
+/// Why: private #[tauri::command] making a live GitHub API call; doctests compile as a
+/// separate crate and can neither import private items nor hit the network (rust-test job)
+/// ```ignore
 /// let stars = get_repo_stars("j4rviscmd", "bilibili-downloader-gui".to_string()).await?;
 /// println!("Stars: {}", stars);
-/// # Ok(())
-/// # }
 /// ```
 #[tauri::command]
 async fn get_repo_stars(owner: String, repo: String) -> Result<usize, String> {

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -26,7 +26,11 @@ impl TitleReplacement {
     ///
     /// # Examples
     ///
+    /// Why: doctests compile as separate crates, so bare/unqualified item names do not
+    /// resolve — import via the lib crate name (this PR's doctest policy)
     /// ```
+    /// use bilibili_downloader_gui_lib::models::settings::TitleReplacement;
+    ///
     /// let rule = TitleReplacement::new(":", "_", true);
     /// assert_eq!(rule.from, ":");
     /// assert_eq!(rule.to, "_");
@@ -60,7 +64,11 @@ impl TitleReplacement {
 ///
 /// # Examples
 ///
+/// Why: doctests compile as separate crates, so bare/unqualified item names do not
+/// resolve — import via the lib crate name (this PR's doctest policy)
 /// ```
+/// use bilibili_downloader_gui_lib::models::settings::default_title_replacements;
+///
 /// let rules = default_title_replacements();
 /// assert_eq!(rules.len(), 8);
 /// assert!(rules.iter().all(|r| r.enabled));

--- a/src-tauri/src/utils/error_handler.rs
+++ b/src-tauri/src/utils/error_handler.rs
@@ -13,8 +13,10 @@ use std::panic;
 ///
 /// # Example
 ///
+/// Why: doctests compile as separate crates, so `crate::` paths do not resolve — use
+/// the lib crate name instead (this PR's doctest policy)
 /// ```rust,no_run
-/// crate::utils::error_handler::setup_panic_hook();
+/// bilibili_downloader_gui_lib::utils::error_handler::setup_panic_hook();
 /// ```
 pub fn setup_panic_hook() {
     panic::set_hook(Box::new(|panic_info| {

--- a/src-tauri/src/utils/log_cleanup.rs
+++ b/src-tauri/src/utils/log_cleanup.rs
@@ -26,11 +26,13 @@ const SECONDS_PER_DAY: u64 = 86400;
 ///
 /// # Example
 ///
+/// Why: doctests compile as separate crates, so `crate::` paths do not resolve — use
+/// the lib crate name instead (this PR's doctest policy)
 /// ```rust,no_run
 /// use std::path::Path;
 ///
 /// let log_dir = Path::new("/path/to/logs");
-/// crate::utils::log_cleanup::cleanup_old_logs(log_dir, 30).ok();
+/// bilibili_downloader_gui_lib::utils::log_cleanup::cleanup_old_logs(log_dir, 30).ok();
 /// ```
 pub fn cleanup_old_logs(log_dir: &Path, days_to_keep: u64) -> Result<usize, String> {
     let mut deleted_count = 0;

--- a/src-tauri/src/utils/sanitize.rs
+++ b/src-tauri/src/utils/sanitize.rs
@@ -40,7 +40,11 @@ pub fn apply_title_replacements(
 ///
 /// # Examples
 ///
+/// Why: doctests compile as separate crates, so bare/unqualified item names do not
+/// resolve — import via the lib crate name (this PR's doctest policy)
 /// ```
+/// use bilibili_downloader_gui_lib::utils::sanitize::resolve_duplicate_titles;
+///
 /// let titles = vec![
 ///     "Part 1".to_string(),
 ///     "Part 2".to_string(),


### PR DESCRIPTION
## Summary

- Fix all 19 failing doctests (compile errors): examples referencing public + pure items now import via the full crate path `bilibili_downloader_gui_lib::...` (6 made runnable); examples referencing private items or hitting the network are marked ```ignore` (13)
- Add `[dev-dependencies]` for the upcoming test-coverage PRs: `tempfile`, `wiremock`, `tokio` (test-util), `tauri` (test feature — test builds only, release binaries unaffected)
- Add a `rust-test` CI job running `cargo test`, registered in the required `ci-status` aggregate
- Switch `rust-clippy` to `--all-targets` so future test code stays warning-free

## Testing

`cargo test` result: 123 unit tests + 10 doctests pass, 14 ignored, 0 failures (previously 19 doctest failures). Verified locally: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build` all green.

First PR (R1) of the Rust test-coverage expansion plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)