### PR TITLE
test: add serde contract tests for models with bilibili API fixtures

### DIFF
--- a/src-tauri/src/models/bilibili_api.rs
+++ b/src-tauri/src/models/bilibili_api.rs
@@ -707,3 +707,475 @@ pub struct SupportFormat {
     #[serde(default)]
     pub display_desc: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Why: fixture payloads are shaped after the response examples in
+    // references/bilibili-API-collect/docs/ (video/info.md,
+    // video/videostream_url.md, bangumi/videostream_url.md) with identifiers
+    // and URL paths replaced by synthetic values, so parsing is exercised
+    // against realistic full-response breadth rather than minimal objects.
+    // Note: unmapped fields (rights, owner, stat, dolby, ...) are kept on
+    // purpose — do not trim fixtures to mapped fields only. Files must also
+    // stay strict JSON (no comments): serde_json parses the include_str!
+    // output directly.
+    const WEB_INTERFACE_VIEW: &str = include_str!("../../tests/fixtures/web_interface_view.json");
+    const XPLAYER_PLAYURL: &str = include_str!("../../tests/fixtures/xplayer_playurl.json");
+    const BANGUMI_PLAYER: &str = include_str!("../../tests/fixtures/bangumi_player.json");
+
+    #[test]
+    fn parses_web_interface_view_fixture() {
+        let resp: WebInterfaceApiResponse = serde_json::from_str(WEB_INTERFACE_VIEW).unwrap();
+        assert_eq!(resp.code, 0);
+
+        let data = resp.data.expect("data present");
+        assert_eq!(data.title, "【BW2019】自营 CUT");
+        assert_eq!(data.cid, 146224527);
+        assert!(data.redirect_url.is_none(), "no redirect in fixture");
+
+        let pages = data.pages.expect("pages present");
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].cid, 146224527);
+        assert_eq!(pages[0].page, 1);
+        assert_eq!(pages[0].part, "1");
+        assert_eq!(pages[0].duration, 265);
+        assert!(
+            pages[0].first_frame.is_none(),
+            "first_frame absent on page 1"
+        );
+        assert_eq!(
+            pages[1].first_frame.as_deref(),
+            Some("http://i0.hdslb.com/bfs/story-fn/first-frame.jpg")
+        );
+    }
+
+    #[test]
+    fn web_interface_view_defaults_missing_optionals() {
+        // Minimal payload: pages/redirect_url omitted (serde defaults),
+        // unknown fields ignored.
+        let resp: WebInterfaceApiResponse = serde_json::from_str(
+            r#"{
+                "code": -404,
+                "message": "啥都木有",
+                "ttl": 1,
+                "data": {
+                    "title": "t", "pic": "p", "cid": 1,
+                    "bvid": "BV1xx", "aid": 2, "unknown_future_field": true
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(resp.code, -404);
+        let data = resp.data.unwrap();
+        assert!(data.pages.is_none());
+        assert!(data.redirect_url.is_none());
+    }
+
+    #[test]
+    fn web_interface_view_data_absent_yields_none() {
+        // Error responses carry no data field at all.
+        let resp: WebInterfaceApiResponse =
+            serde_json::from_str(r#"{"code": 62002, "message": "稿件不可见"}"#).unwrap();
+        assert_eq!(resp.code, 62002);
+        assert!(resp.data.is_none());
+    }
+
+    #[test]
+    fn parses_xplayer_playurl_dash_fixture() {
+        let resp: XPlayerApiResponse = serde_json::from_str(XPLAYER_PLAYURL).unwrap();
+        assert_eq!(resp.code, 0);
+
+        let data = resp.data.expect("data present");
+        assert_eq!(data.quality, Some(80));
+
+        let dash = data.dash.expect("dash present");
+        assert_eq!(dash.video.len(), 2);
+        assert_eq!(dash.audio.len(), 2);
+
+        let v127 = &dash.video[0];
+        assert_eq!(v127.id, 127);
+        assert_eq!(v127.codecid, 12);
+        assert_eq!(v127.bandwidth, 4317613);
+        assert_eq!(v127.width, 1920);
+        assert_eq!(v127.height, 1080);
+        assert!(v127.base_url.contains("example127.m4s"), "baseUrl rename");
+        assert_eq!(
+            v127.backup_urls.as_deref().map(|u| u.len()),
+            Some(2),
+            "backupUrl rename"
+        );
+
+        // VIP-only objects are captured via flatten for diagnostics, never
+        // fed into stream selection (see issue #467 investigation).
+        assert!(dash.extra.contains_key("dolby"));
+        assert!(dash.extra.contains_key("flac"));
+
+        let formats = data.support_formats.expect("support_formats present");
+        assert_eq!(formats.len(), 3);
+        assert_eq!(formats[0].quality, 16);
+        assert_eq!(formats[2].display_desc, "1080P 高清");
+    }
+
+    #[test]
+    fn parses_xplayer_durl_only_variant() {
+        // Older (non-DASH) videos: dash absent, durl present instead.
+        let resp: XPlayerApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "quality": 32,
+                    "durl": [
+                        {
+                            "order": 1, "length": 205000, "size": 12345678,
+                            "url": "https://example.com/seg.mp4",
+                            "backup_url": ["https://example.com/seg_bak.mp4"]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let data = resp.data.unwrap();
+        assert!(data.dash.is_none());
+        let durl = data.durl.expect("durl present");
+        assert_eq!(durl.len(), 1);
+        assert_eq!(durl[0].order, 1);
+        assert_eq!(durl[0].size, 12345678);
+        assert_eq!(durl[0].url, "https://example.com/seg.mp4");
+        assert_eq!(durl[0].backup_url.as_deref().map(|u| u.len()), Some(1));
+    }
+
+    #[test]
+    fn parses_bangumi_player_fixture() {
+        let resp: BangumiPlayerApiResponse = serde_json::from_str(BANGUMI_PLAYER).unwrap();
+        assert_eq!(resp.code, 0);
+
+        let result = resp.result.expect("result present");
+        assert_eq!(result.quality, Some(64));
+        assert_eq!(result.timelength, Some(1432000));
+        assert_eq!(result.is_preview, Some(0));
+
+        // DASH and durl coexist in this fixture; durls carries per-quality MP4.
+        let dash = result.dash.expect("dash present");
+        assert_eq!(dash.video.len(), 2);
+        assert_eq!(dash.audio.len(), 1);
+        assert_eq!(dash.audio[0].id, 30216);
+
+        assert!(result.durl.as_deref().map(|d| d.len()) == Some(1));
+        let durls = result.durls.expect("durls present");
+        assert_eq!(durls.len(), 2);
+        assert_eq!(durls[0].quality, 32);
+        assert_eq!(durls[0].durl.len(), 1);
+
+        let formats = result.support_formats.expect("support_formats");
+        assert_eq!(formats[0].quality, 80);
+        assert_eq!(formats[0].description, "1080P 高清");
+    }
+
+    #[test]
+    fn parses_bangumi_season_and_episode_defaults() {
+        let resp: BangumiSeasonApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "success",
+                "result": {
+                    "season_id": 28237, "title": "season", "cover": "c",
+                    "episodes": [
+                        {
+                            "id": 3051843, "cid": 45776577, "aid": 74707191,
+                            "cover": "ec", "badge": "",
+                            "title": "1", "long_title": "Un cas"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = resp.result.unwrap();
+        assert_eq!(result.season_id, 28237);
+        // status/duration omitted -> serde defaults
+        assert_eq!(result.episodes.len(), 1);
+        let ep = &result.episodes[0];
+        assert_eq!(ep.id, 3051843);
+        assert_eq!(ep.cid, 45776577);
+        assert_eq!(ep.aid, 74707191);
+        assert_eq!(ep.long_title, "Un cas");
+        assert_eq!(ep.status, 0);
+        assert_eq!(ep.duration, 0);
+    }
+
+    #[test]
+    fn parses_user_api_response_with_is_login_rename() {
+        let resp: UserApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0", "ttl": 1,
+                "data": {
+                    "isLogin": true,
+                    "mid": 10000,
+                    "uname": "tester",
+                    "wbi_img": { "img_url": "i", "sub_url": "s" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert!(resp.data.is_login, "isLogin rename");
+        assert_eq!(resp.data.mid, Some(10000));
+        assert_eq!(resp.data.uname.as_deref(), Some("tester"));
+        assert_eq!(resp.data.wbi_img.img_url, "i");
+    }
+
+    #[test]
+    fn parses_user_api_response_logged_out() {
+        // Logged-out nav: mid/uname are null, isLogin false.
+        let resp: UserApiResponse = serde_json::from_str(
+            r#"{
+                "code": -101, "message": "账号未登录", "ttl": 1,
+                "data": {
+                    "isLogin": false, "mid": null, "uname": "",
+                    "wbi_img": { "img_url": "i", "sub_url": "s" }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(!resp.data.is_login);
+        assert!(resp.data.mid.is_none());
+    }
+
+    #[test]
+    fn parses_favorite_folder_list_all() {
+        // list-all returns the minimal subset; optional fields absent.
+        let resp: FavoriteFolderListApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "count": 1,
+                    "list": [
+                        {
+                            "id": 111, "fid": 111, "mid": 222, "attr": 0,
+                            "title": "默认收藏夹", "media_count": 7
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let data = resp.data.unwrap();
+        assert_eq!(data.count, 1);
+        let folder = &data.list.expect("list present")[0];
+        assert_eq!(folder.id, 111);
+        assert_eq!(folder.title, "默认收藏夹");
+        assert_eq!(folder.media_count, 7);
+        assert!(folder.cover.is_none());
+        assert!(folder.upper.is_none());
+        assert!(folder.fav_state.is_none());
+    }
+
+    #[test]
+    fn parses_favorite_resource_list() {
+        let resp: FavoriteResourceListApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "info": {
+                        "id": 111, "fid": 111, "mid": 222, "attr": 0,
+                        "title": "默认收藏夹", "cover": "c",
+                        "upper": { "mid": 222, "name": "u", "face": "f" },
+                        "cover_type": 0,
+                        "cnt_info": { "collect": 0, "play": 0, "thumb_up": 0, "share": 0 },
+                        "type": 0, "intro": "", "ctime": 1, "mtime": 2,
+                        "state": 0, "fav_state": 0, "media_count": 1
+                    },
+                    "medias": [
+                        {
+                            "id": 1, "type": 2, "title": "v", "cover": "cv",
+                            "intro": "", "page": 1, "duration": 60,
+                            "upper": { "mid": 3, "name": "up", "face": "fc" },
+                            "attr": 0,
+                            "cnt_info": { "collect": 1, "play": 2, "danmaku": 3 },
+                            "link": "https://www.bilibili.com/video/BV1xx",
+                            "ctime": 1, "pubtime": 1, "fav_time": 1,
+                            "bv_id": "BV1xx", "bvid": "BV1xx"
+                        }
+                    ],
+                    "has_more": true
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let data = resp.data.unwrap();
+        assert_eq!(data.info.id, 111);
+        // "type" renames to folder_type in info, media_type in medias
+        assert_eq!(data.info.folder_type, 0);
+        assert!(data.has_more);
+        let media = &data.medias.expect("medias")[0];
+        assert_eq!(media.media_type, 2);
+        assert_eq!(media.cnt_info.danmaku, 3);
+        assert_eq!(media.bvid, "BV1xx");
+    }
+
+    #[test]
+    fn parses_watch_history_with_defaults() {
+        let resp: WatchHistoryApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "list": [
+                        {
+                            "title": "1", "cover": "c",
+                            "history": { "bvid": "BV1h", "cid": 9, "page": 1 },
+                            "view_at": 1700000000, "duration": 100,
+                            "progress": -1
+                        }
+                    ],
+                    "cursor": { "view_at": 1700000000, "max": 1700000000, "is_end": false }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let data = resp.data.unwrap();
+        assert_eq!(data.list.len(), 1);
+        assert_eq!(data.list[0].history.bvid, "BV1h");
+        assert_eq!(data.list[0].progress, -1);
+        assert_eq!(data.cursor.max, 1700000000);
+        assert!(!data.cursor.is_end);
+    }
+
+    #[test]
+    fn watch_history_missing_optionals_default() {
+        // progress/cid/page are serde defaults; absent history fields must
+        // not fail the parse for legacy entries.
+        let resp: WatchHistoryApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "list": [
+                        {
+                            "title": "t", "cover": "c",
+                            "history": { "bvid": "BV1x" },
+                            "view_at": 1, "duration": 2
+                        }
+                    ],
+                    "cursor": { "view_at": 1, "max": 1 }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let item = &resp.data.unwrap().list[0];
+        assert_eq!(item.progress, 0);
+        assert_eq!(item.history.cid, 0);
+        assert_eq!(item.history.page, 0);
+    }
+
+    #[test]
+    fn parses_player_v2_subtitles_with_ai_type() {
+        let resp: PlayerV2ApiResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "subtitle": {
+                        "subtitles": [
+                            {
+                                "lan": "zh-CN", "lan_doc": "中文（简体）",
+                                "subtitle_url": "//aisubtitle.hdslb.com/bfs/ai_subtitle/1.bcc.json",
+                                "ai_type": 0
+                            },
+                            {
+                                "lan": "ai-zh", "lan_doc": "中文（自动生成）",
+                                "subtitle_url": "//aisubtitle.hdslb.com/bfs/ai_subtitle/2.bcc.json",
+                                "ai_status": 0
+                            },
+                            {
+                                "lan": "en", "lan_doc": "English",
+                                "subtitle_url": "//i0.hdslb.com/bfs/subtitle/3.bcc.json"
+                            }
+                        ]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let subs = resp
+            .data
+            .and_then(|d| d.subtitle)
+            .and_then(|s| s.subtitles)
+            .expect("subtitles present");
+        assert_eq!(subs.len(), 3);
+        assert_eq!(subs[0].ai_type, Some(0));
+        assert_eq!(subs[0].lan_doc, "中文（简体）");
+        assert!(
+            subs[1].ai_type.is_none(),
+            "ai_status (different field) must not leak into ai_type"
+        );
+        assert!(subs[2].ai_type.is_none(), "manual subtitle has no ai_type");
+    }
+
+    #[test]
+    fn bcc_subtitle_parses_manual_format() {
+        let bcc: BccSubtitle = serde_json::from_str(
+            r#"{
+                "font_size": 0.4,
+                "font_color": "0xFFFFFF",
+                "background_alpha": 0.5,
+                "background_color": "0x000000",
+                "Stroke": "none",
+                "type": "ai",
+                "body": [
+                    { "from": 0.0, "to": 2.5, "location": 0, "content": "こんにちは" },
+                    { "from": 2.5, "to": 4.0, "content": "second line" }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(bcc.font_size, 0.4);
+        assert_eq!(bcc.font_color, "0xFFFFFF");
+        assert_eq!(bcc.background_alpha, 0.5);
+        assert_eq!(bcc.stroke, "none", "Stroke capital-S rename");
+        assert_eq!(bcc.body.len(), 2);
+        assert_eq!(bcc.body[0].from, 0.0);
+        assert_eq!(bcc.body[0].to, 2.5);
+        assert_eq!(bcc.body[0].location, 0);
+        assert_eq!(bcc.body[0].content, "こんにちは");
+        assert_eq!(bcc.body[1].location, 0, "location serde default");
+    }
+
+    #[test]
+    fn bcc_subtitle_applies_ai_defaults() {
+        // AI subtitles omit styling fields — serde defaults must kick in.
+        let bcc: BccSubtitle =
+            serde_json::from_str(r#"{ "body": [ { "from": 1.0, "to": 2.0, "content": "ai" } ] }"#)
+                .unwrap();
+
+        assert_eq!(bcc.font_size, 0.0);
+        assert_eq!(bcc.font_color, "0xFFFFFF");
+        assert_eq!(bcc.background_alpha, 0.0);
+        assert_eq!(bcc.background_color, "0x000000");
+        assert_eq!(bcc.stroke, "");
+    }
+
+    #[test]
+    fn xplayer_roundtrip_preserves_renames() {
+        let resp: XPlayerApiResponse = serde_json::from_str(XPLAYER_PLAYURL).unwrap();
+        let json = serde_json::to_value(&resp).unwrap();
+        let reparsed: XPlayerApiResponse = serde_json::from_value(json.clone()).unwrap();
+
+        let orig = resp.data.and_then(|d| d.dash).unwrap();
+        let again = reparsed.data.and_then(|d| d.dash).unwrap();
+        assert_eq!(orig.video.len(), again.video.len());
+        assert_eq!(again.video[0].base_url, orig.video[0].base_url);
+        // flatten'd extra survives the roundtrip as a map
+        assert!(again.extra.contains_key("dolby"));
+        // serialized form uses the API field names
+        assert!(json["data"]["dash"]["video"][0].get("baseUrl").is_some());
+    }
+}

--- a/src-tauri/src/models/cookie.rs
+++ b/src-tauri/src/models/cookie.rs
@@ -40,3 +40,51 @@ pub struct SimulateLogoutFlag {
     /// Thread-safe flag indicating whether to simulate logout state
     pub enabled: Mutex<bool>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cookie_entry_roundtrips_snake_case_fields() {
+        let json = r#"{ "host": ".bilibili.com", "name": "SESSDATA", "value": "v" }"#;
+        let entry: CookieEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.host, ".bilibili.com");
+        assert_eq!(entry.name, "SESSDATA");
+        assert_eq!(entry.value, "v");
+
+        let out = serde_json::to_value(&entry).unwrap();
+        assert_eq!(out["host"], ".bilibili.com");
+        assert_eq!(out["name"], "SESSDATA");
+    }
+
+    #[test]
+    fn cookie_entry_default_is_empty() {
+        let entry = CookieEntry::default();
+        assert!(entry.host.is_empty());
+        assert!(entry.name.is_empty());
+        assert!(entry.value.is_empty());
+    }
+
+    #[test]
+    fn cookie_cache_starts_empty_and_accepts_locks() {
+        let cache = CookieCache::default();
+        assert!(cache.cookies.lock().unwrap().is_empty());
+
+        cache.cookies.lock().unwrap().push(CookieEntry {
+            host: ".bilibili.com".into(),
+            name: "buvid3".into(),
+            value: "x".into(),
+        });
+        assert_eq!(cache.cookies.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn simulate_logout_flag_defaults_false() {
+        let flag = SimulateLogoutFlag::default();
+        assert!(!*flag.enabled.lock().unwrap());
+
+        *flag.enabled.lock().unwrap() = true;
+        assert!(*flag.enabled.lock().unwrap());
+    }
+}

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -249,3 +249,197 @@ pub struct DownloadRetrying {
     /// Whether the download is currently retrying
     pub is_retrying: bool,
 }
+
+// Why: these DTOs are the Tauri→frontend wire contract consumed by TS types
+// (e.g. src/features/video/types.ts) with no compile-time cross-language
+// check; these tests make a camelCase rename fail here instead of silently
+// breaking the frontend at runtime.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_renames_is_login_and_defaults_has_cookie() {
+        let json = r#"{
+            "code": 0, "message": "0",
+            "data": { "mid": 7, "uname": "u", "isLogin": true }
+        }"#;
+        let user: User = serde_json::from_str(json).unwrap();
+        assert!(user.data.is_login, "isLogin rename");
+        assert_eq!(user.data.mid, Some(7));
+        assert!(!user.has_cookie, "absent has_cookie defaults to false");
+
+        let out = serde_json::to_value(&user).unwrap();
+        assert_eq!(out["data"]["isLogin"], true);
+        assert_eq!(out["hasCookie"], false);
+    }
+
+    fn sample_video() -> Video {
+        Video {
+            title: "t".into(),
+            bvid: "BV1xx".into(),
+            parts: vec![VideoPart {
+                cid: 11,
+                page: 1,
+                part: "P1".into(),
+                sanitized_part: None,
+                duration: 60,
+                thumbnail: Thumbnail {
+                    url: "http://thumb".into(),
+                },
+                video_qualities: vec![Quality {
+                    id: 80,
+                    codecid: 7,
+                    quality: "1080P".into(),
+                }],
+                audio_qualities: vec![],
+                subtitles: vec![SubtitleDto {
+                    lan: "zh-CN".into(),
+                    lan_doc: "中文（简体）".into(),
+                    subtitle_url: "http://sub.bcc".into(),
+                    is_ai: true,
+                    ai_type: Some(0),
+                }],
+                ep_id: None,
+                status: None,
+                aid: None,
+                is_preview: None,
+            }],
+            is_limited_quality: true,
+            content_type: "bangumi".into(),
+            ep_id: Some(3051843),
+            season_title: Some("Season".into()),
+        }
+    }
+
+    #[test]
+    fn video_roundtrips_camel_case() {
+        let video = sample_video();
+        let out = serde_json::to_value(&video).unwrap();
+        assert_eq!(out["title"], "t");
+        assert_eq!(out["bvid"], "BV1xx");
+        assert_eq!(out["isLimitedQuality"], true);
+        assert_eq!(out["contentType"], "bangumi");
+        assert_eq!(out["epId"], 3051843);
+        assert_eq!(out["seasonTitle"], "Season");
+
+        let part = &out["parts"][0];
+        assert_eq!(part["cid"], 11);
+        assert_eq!(part["sanitizedPart"], serde_json::Value::Null);
+        assert_eq!(part["subtitles"][0]["subtitleUrl"], "http://sub.bcc");
+        assert_eq!(part["subtitles"][0]["aiType"], 0);
+
+        let back: Video = serde_json::from_value(out).unwrap();
+        assert_eq!(back.parts.len(), 1);
+        assert_eq!(back.parts[0].video_qualities[0].quality, "1080P");
+        assert!(back.parts[0].subtitles[0].is_ai);
+    }
+
+    #[test]
+    fn video_defaults_content_type_video() {
+        let json = r#"{
+            "title": "t", "bvid": "BV1x",
+            "parts": [{ "cid": 1, "page": 1, "part": "p", "duration": 1,
+                        "thumbnail": { "url": "u" },
+                        "videoQualities": [], "audioQualities": [] }]
+        }"#;
+        let video: Video = serde_json::from_str(json).unwrap();
+        assert_eq!(video.content_type, "video");
+        assert!(!video.is_limited_quality);
+        assert!(video.ep_id.is_none());
+        assert!(video.season_title.is_none());
+        assert!(video.parts[0].subtitles.is_empty());
+        assert!(video.parts[0].sanitized_part.is_none());
+    }
+
+    #[test]
+    fn video_part_omits_sanitized_when_none() {
+        let video = sample_video();
+        let json = serde_json::to_string(&video).unwrap();
+        assert!(
+            !json.contains("sanitizedPart"),
+            "skip_serializing_if drops the key when None"
+        );
+    }
+
+    #[test]
+    fn favorite_dtos_roundtrip_camel_case() {
+        let resp = FavoriteVideoListResponse {
+            videos: vec![FavoriteVideo {
+                id: 1,
+                bvid: "BV1f".into(),
+                title: "v".into(),
+                cover: "c".into(),
+                duration: 90,
+                page: 1,
+                upper: FavoriteVideoUpperDto {
+                    mid: 2,
+                    name: "up".into(),
+                    face: "f".into(),
+                },
+                attr: 0,
+                play_count: 10,
+                collect_count: 3,
+                link: "l".into(),
+            }],
+            has_more: true,
+            total_count: 1,
+        };
+        let out = serde_json::to_value(&resp).unwrap();
+        assert_eq!(out["hasMore"], true);
+        assert_eq!(out["totalCount"], 1);
+        assert_eq!(out["videos"][0]["playCount"], 10);
+
+        let folder = FavoriteFolder {
+            id: 9,
+            title: "default".into(),
+            cover: None,
+            media_count: 4,
+            upper: None,
+        };
+        let folder_out = serde_json::to_value(&folder).unwrap();
+        assert_eq!(folder_out["mediaCount"], 4);
+        assert_eq!(folder_out["cover"], serde_json::Value::Null);
+        assert_eq!(folder_out["upper"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn watch_history_entry_serializes_camel_case() {
+        let entry = WatchHistoryEntry {
+            title: "t".into(),
+            cover: "c".into(),
+            bvid: "BV1w".into(),
+            cid: 5,
+            page: 2,
+            view_at: 1700000000,
+            duration: 100,
+            progress: 50,
+            url: "u".into(),
+        };
+        let out = serde_json::to_value(&entry).unwrap();
+        assert_eq!(out["viewAt"], 1700000000);
+        assert_eq!(out["bvid"], "BV1w");
+
+        let cursor = WatchHistoryCursor {
+            view_at: 1,
+            max: 2,
+            is_end: true,
+        };
+        let cursor_out = serde_json::to_value(&cursor).unwrap();
+        assert_eq!(cursor_out["viewAt"], 1);
+        assert_eq!(cursor_out["isEnd"], true);
+    }
+
+    #[test]
+    fn download_retrying_serializes_camel_case() {
+        let evt = DownloadRetrying {
+            download_id: "dl-1".into(),
+            stage: Some("video".into()),
+            is_retrying: true,
+        };
+        let out = serde_json::to_value(&evt).unwrap();
+        assert_eq!(out["downloadId"], "dl-1");
+        assert_eq!(out["stage"], "video");
+        assert_eq!(out["isRetrying"], true);
+    }
+}

--- a/src-tauri/src/models/history.rs
+++ b/src-tauri/src/models/history.rs
@@ -55,3 +55,79 @@ pub struct HistoryFilters {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date_from: Option<String>,
 }
+
+// Why: HistoryEntry's camelCase JSON is also the on-disk format persisted to
+// history.json (src-tauri/src/store/history_store.rs); renaming fields would
+// orphan existing users' history files, so the wire names are pinned here.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_entry_roundtrips_camel_case() {
+        let json = r#"{
+            "id": "abc-1",
+            "title": "【示例】動画",
+            "bvid": "BV1h4y1w7h7",
+            "url": "https://www.bilibili.com/video/BV1h4y1w7h7",
+            "downloadedAt": "2026-08-24T10:00:00Z",
+            "status": "completed",
+            "fileSize": 123456789,
+            "quality": "1080P60",
+            "thumbnailUrl": "http://i0.hdslb.com/bfs/archive/thumb.jpg",
+            "version": "1.0"
+        }"#;
+        let entry: HistoryEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.id, "abc-1");
+        assert_eq!(entry.bvid.as_deref(), Some("BV1h4y1w7h7"));
+        assert_eq!(entry.file_size, Some(123456789));
+        assert_eq!(entry.quality.as_deref(), Some("1080P60"));
+        assert_eq!(entry.version, "1.0");
+
+        let out = serde_json::to_value(&entry).unwrap();
+        assert_eq!(out["downloadedAt"], "2026-08-24T10:00:00Z");
+        assert_eq!(out["fileSize"], 123456789);
+        assert_eq!(
+            out["thumbnailUrl"],
+            "http://i0.hdslb.com/bfs/archive/thumb.jpg"
+        );
+        assert_eq!(out["version"], "1.0");
+    }
+
+    #[test]
+    fn history_entry_defaults_and_omits() {
+        // Legacy entries lack bvid and version (v1.0 migration path).
+        let entry: HistoryEntry = serde_json::from_str(
+            r#"{
+                "id": "old-1", "title": "t",
+                "url": "u", "downloadedAt": "2020-01-01T00:00:00Z",
+                "status": "failed", "fileSize": null, "quality": null
+            }"#,
+        )
+        .unwrap();
+        assert!(entry.bvid.is_none());
+        assert!(entry.thumbnail_url.is_none());
+        assert_eq!(entry.version, "1.0", "missing version defaults to 1.0");
+
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(!out.contains("bvid"), "None bvid is skipped on serialize");
+    }
+
+    #[test]
+    fn history_filters_skip_none_fields() {
+        let filters = HistoryFilters::default();
+        let out = serde_json::to_string(&filters).unwrap();
+        assert_eq!(out, "{}", "all-None filters serialize to empty object");
+
+        let filters = HistoryFilters {
+            status: Some("completed".into()),
+            date_from: Some("2026-01-01".into()),
+        };
+        let out = serde_json::to_value(&filters).unwrap();
+        assert_eq!(out["status"], "completed");
+        assert_eq!(out["dateFrom"], "2026-01-01");
+
+        let back: HistoryFilters = serde_json::from_value(out).expect("roundtrip parses camelCase");
+        assert_eq!(back.status.as_deref(), Some("completed"));
+    }
+}

--- a/src-tauri/src/models/qr_login.rs
+++ b/src-tauri/src/models/qr_login.rs
@@ -260,3 +260,240 @@ pub struct BuvidData {
     #[serde(rename = "b_4")]
     pub b_4: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qr_code_status_maps_api_codes() {
+        assert_eq!(QrCodeStatus::from(0), QrCodeStatus::Success);
+        assert_eq!(QrCodeStatus::from(86038), QrCodeStatus::Expired);
+        assert_eq!(
+            QrCodeStatus::from(86090),
+            QrCodeStatus::ScannedWaitingConfirm
+        );
+        assert_eq!(QrCodeStatus::from(86101), QrCodeStatus::WaitingForScan);
+        assert_eq!(QrCodeStatus::from(999), QrCodeStatus::Error);
+        assert_eq!(QrCodeStatus::from(-1), QrCodeStatus::Error);
+    }
+
+    #[test]
+    fn qr_code_status_serializes_camel_case() {
+        assert_eq!(
+            serde_json::to_string(&QrCodeStatus::WaitingForScan).unwrap(),
+            r#""waitingForScan""#
+        );
+        assert_eq!(
+            serde_json::to_string(&QrCodeStatus::ScannedWaitingConfirm).unwrap(),
+            r#""scannedWaitingConfirm""#
+        );
+        // Roundtrip through the serialized form
+        let status: QrCodeStatus =
+            serde_json::from_str(r#""expired""#).expect("camelCase deserialize");
+        assert_eq!(status, QrCodeStatus::Expired);
+    }
+
+    #[test]
+    fn qr_poll_data_renames_status_code_field() {
+        let resp: QrCodePollResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "url": "https://passport.biligame.com/crossDomain?...",
+                    "refresh_token": "rtoken",
+                    "timestamp": 1700000000000,
+                    "code": 86101,
+                    "message": "未扫码"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let data = resp.data.unwrap();
+        // Inner "code" maps to status_code (renamed to avoid clashing with
+        // the outer response code).
+        assert_eq!(data.status_code, 86101);
+        assert_eq!(data.message, "未扫码");
+        assert_eq!(data.refresh_token, "rtoken");
+        assert_eq!(
+            QrCodeStatus::from(data.status_code),
+            QrCodeStatus::WaitingForScan
+        );
+    }
+
+    #[test]
+    fn qr_generate_response_parses() {
+        let resp: QrCodeGenerateResponse = serde_json::from_str(
+            r#"{
+                "code": 0, "message": "0",
+                "data": {
+                    "url": "https://passport.bilibili.com/h5-app/passport/login/scan?navhide=1&qrcode_key=abc",
+                    "qrcode_key": "abcdef0123456789abcdef0123456789"
+                }
+            }"#,
+        )
+        .unwrap();
+        let data = resp.data.unwrap();
+        assert_eq!(data.qrcode_key.len(), 32);
+        assert!(data.url.contains("qrcode_key=abc"));
+    }
+
+    #[test]
+    fn session_renames_cookie_field_names() {
+        let json = r#"{
+            "sessdata": "sd%2Cvalue",
+            "biliJct": "csrf",
+            "dedeUserId": "42",
+            "dedeUserIdCkMd5": "md5hash",
+            "refresh_token": "rt",
+            "timestamp": 1700000000,
+            "uname": "tester",
+            "buvid3": "b3",
+            "buvid4": "b4"
+        }"#;
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(session.sessdata, "sd%2Cvalue");
+        assert_eq!(session.bili_jct, "csrf");
+        assert_eq!(session.dede_user_id, "42");
+        assert_eq!(session.dede_user_id_ck_md5, "md5hash");
+        assert_eq!(session.refresh_token, "rt");
+        assert_eq!(session.timestamp, 1700000000);
+        assert_eq!(session.uname, "tester");
+        assert_eq!(session.buvid3, "b3");
+        assert_eq!(session.buvid4, "b4");
+
+        // Roundtrip keeps the wire format stable (encrypted storage and the
+        // frontend both depend on these names).
+        let out = serde_json::to_value(&session).unwrap();
+        assert_eq!(out["sessdata"], "sd%2Cvalue");
+        assert_eq!(out["biliJct"], "csrf");
+        assert_eq!(out["dedeUserId"], "42");
+        assert_eq!(out["dedeUserIdCkMd5"], "md5hash");
+    }
+
+    #[test]
+    fn session_missing_optionals_default_empty() {
+        // uname/buvid3/buvid4 are optional; core auth fields are required
+        // (renamed but NOT defaulted — a session without them is corrupt).
+        let session: Session = serde_json::from_str(
+            r#"{
+                "sessdata": "s", "biliJct": "j", "dedeUserId": "1",
+                "dedeUserIdCkMd5": "m", "refresh_token": "r", "timestamp": 1
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(session.uname, "");
+        assert_eq!(session.buvid3, "");
+        assert_eq!(session.buvid4, "");
+
+        let default = Session::default();
+        assert_eq!(default.timestamp, 0);
+        assert!(default.sessdata.is_empty());
+    }
+
+    #[test]
+    fn session_rejects_missing_required_auth_fields() {
+        // Guarding the intentional strictness: biliJct is required.
+        let err = serde_json::from_str::<Session>(
+            r#"{ "sessdata": "s", "refresh_token": "r", "timestamp": 1 }"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("biliJct"),
+            "missing biliJct must fail: {err}"
+        );
+    }
+
+    #[test]
+    fn login_method_defaults_to_firefox() {
+        assert_eq!(LoginMethod::default(), LoginMethod::Firefox);
+        assert_ne!(LoginMethod::Firefox, LoginMethod::QrCode);
+
+        let method: LoginMethod = serde_json::from_str(r#""qrCode""#).unwrap();
+        assert_eq!(method, LoginMethod::QrCode);
+        assert_eq!(
+            serde_json::to_string(&LoginMethod::Firefox).unwrap(),
+            r#""firefox""#
+        );
+    }
+
+    #[test]
+    fn login_state_keeps_session_key() {
+        let state = LoginState {
+            method: LoginMethod::QrCode,
+            session: Some(Session {
+                sessdata: "s".into(),
+                timestamp: 5,
+                ..Default::default()
+            }),
+        };
+        let out = serde_json::to_value(&state).unwrap();
+        assert_eq!(out["method"], "qrCode");
+        assert_eq!(out["session"]["sessdata"], "s");
+        assert_eq!(out["session"]["timestamp"], 5);
+
+        let back: LoginState = serde_json::from_value(out).unwrap();
+        assert_eq!(back.method, LoginMethod::QrCode);
+        assert_eq!(back.session.unwrap().sessdata, "s");
+    }
+
+    #[test]
+    fn cookie_refresh_info_parses() {
+        let resp: CookieRefreshInfoResponse = serde_json::from_str(
+            r#"{ "code": 0, "message": "0", "data": { "refresh": true, "timestamp": 1700000000000 } }"#,
+        )
+        .unwrap();
+        let info = resp.data.unwrap();
+        assert!(info.refresh);
+        assert_eq!(info.timestamp, 1700000000000);
+    }
+
+    #[test]
+    fn cookie_refresh_response_parses() {
+        let resp: CookieRefreshResponse = serde_json::from_str(
+            r#"{ "code": 0, "message": "0", "data": { "status": 0, "message": "m", "refresh_token": "new_rt" } }"#,
+        )
+        .unwrap();
+        assert_eq!(resp.data.unwrap().refresh_token, "new_rt");
+    }
+
+    #[test]
+    fn buvid_data_renames_b3_b4() {
+        let resp: BuvidResponse = serde_json::from_str(
+            r#"{ "code": 0, "message": "0", "data": { "b_3": "bv3xxx", "b_4": "bv4yyy" } }"#,
+        )
+        .unwrap();
+        let data = resp.data.unwrap();
+        assert_eq!(data.b_3, "bv3xxx");
+        assert_eq!(data.b_4, "bv4yyy");
+    }
+
+    #[test]
+    fn qr_poll_result_wraps_status_and_session() {
+        let result = QrPollResult {
+            status: QrCodeStatus::Success,
+            message: "OK".into(),
+            session: Some(Session::default()),
+        };
+        let out = serde_json::to_value(&result).unwrap();
+        assert_eq!(out["status"], "success");
+        assert_eq!(out["message"], "OK");
+        assert!(out["session"].is_object());
+
+        let back: QrPollResult = serde_json::from_value(out).unwrap();
+        assert_eq!(back.status, QrCodeStatus::Success);
+        assert!(back.session.is_some());
+    }
+
+    #[test]
+    fn qr_code_result_serializes_camel_case() {
+        let result = QrCodeResult {
+            qr_code_image: "iVBORw0K...".into(),
+            qrcode_key: "k".into(),
+        };
+        let out = serde_json::to_value(&result).unwrap();
+        assert_eq!(out["qrCodeImage"], "iVBORw0K...");
+        assert_eq!(out["qrcodeKey"], "k");
+    }
+}

--- a/src-tauri/tests/fixtures/bangumi_player.json
+++ b/src-tauri/tests/fixtures/bangumi_player.json
@@ -1,0 +1,136 @@
+{
+  "code": 0,
+  "message": "success",
+  "result": {
+    "is_preview": 0,
+    "type": "DASH",
+    "timelength": 1432000,
+    "quality": 64,
+    "format": "flv480",
+    "accept_quality": [80, 64, 32, 16],
+    "accept_format": "hdflv2,flv,flv480,mp4",
+    "accept_description": ["1080P 高清", "720P 高清", "480P 清晰", "360P 流畅"],
+    "video_codecid": 7,
+    "seek_param": "",
+    "seek_type": "",
+    "dash": {
+      "duration": 1432,
+      "video": [
+        {
+          "id": 64,
+          "codecid": 7,
+          "baseUrl": "https://upos-sz-mirrorcoso1.bilivideo.com/example64.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/example64_backup1.m4s",
+            "https://upos-sz-mirrorcosb.bilivideo.com/example64_backup2.m4s"
+          ],
+          "bandwidth": 1199872,
+          "mimeType": "video/mp4",
+          "codecs": "avc1.640028",
+          "width": 1280,
+          "height": 720,
+          "frameRate": "25000/1000"
+        },
+        {
+          "id": 32,
+          "codecid": 7,
+          "baseUrl": "https://upos-sz-mirrorcoso1.bilivideo.com/example32.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/example32_backup1.m4s"
+          ],
+          "bandwidth": 515723,
+          "mimeType": "video/mp4",
+          "codecs": "avc1.64001f",
+          "width": 852,
+          "height": 480,
+          "frameRate": "25000/1000"
+        }
+      ],
+      "audio": [
+        {
+          "id": 30216,
+          "codecid": 0,
+          "baseUrl": "https://upos-sz-mirrorcoso1.bilivideo.com/example_audio30216.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/example_audio30216_backup.m4s"
+          ],
+          "bandwidth": 66077,
+          "mimeType": "audio/mp4",
+          "codecs": "mp4a.40.2",
+          "width": 0,
+          "height": 0
+        }
+      ]
+    },
+    "durl": [
+      {
+        "order": 1,
+        "length": 1432000,
+        "size": 214748364,
+        "url": "https://upos-sz-mirrorcos.bilivideo.com/example_durl.mp4",
+        "backup_url": [
+          "https://upos-sz-mirrorcosb.bilivideo.com/example_durl_backup.mp4"
+        ],
+        "md5": "",
+        "hash": ""
+      }
+    ],
+    "durls": [
+      {
+        "quality": 32,
+        "durl": [
+          {
+            "order": 1,
+            "length": 1432000,
+            "size": 92000000,
+            "url": "https://upos-sz-mirrorcos.bilivideo.com/example_durls_32.mp4",
+            "backup_url": [
+              "https://upos-sz-mirrorcosb.bilivideo.com/example_durls_32_backup.mp4"
+            ],
+            "md5": "",
+            "hash": ""
+          }
+        ]
+      },
+      {
+        "quality": 16,
+        "durl": [
+          {
+            "order": 1,
+            "length": 1432000,
+            "size": 52000000,
+            "url": "https://upos-sz-mirrorcos.bilivideo.com/example_durls_16.mp4",
+            "backup_url": [
+              "https://upos-sz-mirrorcosb.bilivideo.com/example_durls_16_backup.mp4"
+            ],
+            "md5": "",
+            "hash": ""
+          }
+        ]
+      }
+    ],
+    "support_formats": [
+      {
+        "quality": 80,
+        "format": "flv",
+        "description": "1080P 高清",
+        "new_description": "1080P 高清",
+        "display_desc": "1080P 高清",
+        "superscript": "",
+        "codecs": ["avc1.640032"]
+      },
+      {
+        "quality": 64,
+        "format": "flv",
+        "description": "720P 高清",
+        "new_description": "720P 高清",
+        "display_desc": "720P 高清",
+        "superscript": "",
+        "codecs": ["avc1.640028"]
+      }
+    ],
+    "last_play_cid": "",
+    "last_play_time": 0,
+    "view_points": []
+  }
+}

--- a/src-tauri/tests/fixtures/web_interface_view.json
+++ b/src-tauri/tests/fixtures/web_interface_view.json
@@ -1,0 +1,90 @@
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "bvid": "BV1GJ411x7h7",
+    "aid": 85440373,
+    "videos": 2,
+    "tid": 21,
+    "tname": "日常",
+    "copyright": 1,
+    "pic": "http://i0.hdslb.com/bfs/archive/74f0d4d6ce811f65a7b8a54d0b1b1e0b.jpg",
+    "title": "【BW2019】自营 CUT",
+    "pubdate": 1564235142,
+    "ctime": 1564235142,
+    "desc": "-",
+    "state": 0,
+    "duration": 470,
+    "rights": {
+      "bp": 0,
+      "elec": 0,
+      "download": 0,
+      "movie": 0,
+      "pay": 0,
+      "hd5": 1,
+      "no_reprint": 1,
+      "autoplay": 1,
+      "ugc_pay": 0,
+      "is_cooperation": 0,
+      "ugc_pay_preview": 0,
+      "no_background": 0
+    },
+    "owner": {
+      "mid": 320164265,
+      "name": "example_owner",
+      "face": "http://i0.hdslb.com/bfs/face/0e6b95d0.jpg"
+    },
+    "stat": {
+      "aid": 85440373,
+      "view": 1726,
+      "danmaku": 20,
+      "reply": 11,
+      "favorite": 33,
+      "coin": 9,
+      "share": 4,
+      "now_rank": 0,
+      "his_rank": 0,
+      "like": 48,
+      "dislike": 0
+    },
+    "dynamic": "",
+    "cid": 146224527,
+    "dimension": {
+      "width": 1920,
+      "height": 1080,
+      "rotate": 0
+    },
+    "pages": [
+      {
+        "cid": 146224527,
+        "page": 1,
+        "from": "vupload",
+        "part": "1",
+        "duration": 265,
+        "vid": "",
+        "weblink": "",
+        "dimension": {
+          "width": 1920,
+          "height": 1080,
+          "rotate": 0
+        }
+      },
+      {
+        "cid": 146225172,
+        "page": 2,
+        "from": "vupload",
+        "part": "2",
+        "duration": 205,
+        "vid": "",
+        "weblink": "",
+        "first_frame": "http://i0.hdslb.com/bfs/story-fn/first-frame.jpg",
+        "dimension": {
+          "width": 1920,
+          "height": 1080,
+          "rotate": 0
+        }
+      }
+    ]
+  }
+}

--- a/src-tauri/tests/fixtures/xplayer_playurl.json
+++ b/src-tauri/tests/fixtures/xplayer_playurl.json
@@ -122,11 +122,7 @@
         "new_description": "360P 流畅",
         "display_desc": "360P 流畅",
         "superscript": "",
-        "codecs": [
-          "avc1.64001E",
-          "hev1.1.6.L120.90",
-          "av01.0.0M.08"
-        ]
+        "codecs": ["avc1.64001E", "hev1.1.6.L120.90", "av01.0.0M.08"]
       },
       {
         "quality": 32,
@@ -134,11 +130,7 @@
         "new_description": "480P 清晰",
         "display_desc": "480P 清晰",
         "superscript": "",
-        "codecs": [
-          "avc1.64001F",
-          "hev1.1.6.L120.90",
-          "av01.0.0M.08"
-        ]
+        "codecs": ["avc1.64001F", "hev1.1.6.L120.90", "av01.0.0M.08"]
       },
       {
         "quality": 80,
@@ -146,11 +138,7 @@
         "new_description": "1080P 高清",
         "display_desc": "1080P 高清",
         "superscript": "",
-        "codecs": [
-          "avc1.640032",
-          "hev1.1.6.L150.90",
-          "av01.0.08M.08"
-        ]
+        "codecs": ["avc1.640032", "hev1.1.6.L150.90", "av01.0.08M.08"]
       }
     ],
     "high_format": true

--- a/src-tauri/tests/fixtures/xplayer_playurl.json
+++ b/src-tauri/tests/fixtures/xplayer_playurl.json
@@ -1,0 +1,158 @@
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "accept_quality": [127, 126, 125, 120, 116, 112, 80, 64, 32, 16],
+    "accept_format": "hdflv2,flv,flv720,flv480,mp4",
+    "accept_description": [
+      "8K 超高清",
+      "杜比视界",
+      "HDR 真彩色",
+      "4K 超清",
+      "1080P60 高帧率",
+      "1080P 高码率",
+      "1080P 高清",
+      "720P 高清",
+      "480P 清晰",
+      "360P 流畅"
+    ],
+    "quality": 80,
+    "format_code": 0,
+    "has_dolby": true,
+    "has_flac": true,
+    "timelength": 265000,
+    "video_codecid": 7,
+    "seek_param": "",
+    "seek_type": "",
+    "dash": {
+      "duration": 265,
+      "video": [
+        {
+          "id": 127,
+          "codecid": 12,
+          "md5": "",
+          "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example127.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/vod-mirrorcos/example127.m4s",
+            "https://upos-sz-mirrorhw.bilivideo.com/vod-mirrorhw/example127.m4s"
+          ],
+          "bandwidth": 4317613,
+          "mimeType": "video/mp4",
+          "codecs": "av01.0.12M.08",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "16000/657"
+        },
+        {
+          "id": 80,
+          "codecid": 7,
+          "md5": "",
+          "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example80.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/vod-mirrorcos/example80.m4s"
+          ],
+          "bandwidth": 2434664,
+          "mimeType": "video/mp4",
+          "codecs": "avc1.640032",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "16000/657"
+        }
+      ],
+      "audio": [
+        {
+          "id": 30280,
+          "codecid": 13,
+          "md5": "",
+          "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example30280.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/vod-mirrorcos/example30280.m4s"
+          ],
+          "bandwidth": 316271,
+          "mimeType": "audio/mp4",
+          "codecs": "ec-3",
+          "width": 0,
+          "height": 0
+        },
+        {
+          "id": 30216,
+          "codecid": 0,
+          "md5": "",
+          "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example30216.m4s",
+          "backupUrl": [
+            "https://upos-sz-mirrorcos.bilivideo.com/vod-mirrorcos/example30216.m4s"
+          ],
+          "bandwidth": 67574,
+          "mimeType": "audio/mp4",
+          "codecs": "mp4a.40.2",
+          "width": 0,
+          "height": 0
+        }
+      ],
+      "dolby": {
+        "type": 1,
+        "audio": [
+          {
+            "id": 30255,
+            "codecid": 13,
+            "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example30255.m4s",
+            "bandwidth": 640000,
+            "mimeType": "audio/mp4",
+            "codecs": "ec-3"
+          }
+        ]
+      },
+      "flac": {
+        "display": true,
+        "audio": {
+          "id": 30251,
+          "codecid": 13,
+          "baseUrl": "https://upos-sz-mirror08h.bilivideo.com/vod-mirror08h/example30251.m4s",
+          "bandwidth": 815459,
+          "mimeType": "audio/mp4",
+          "codecs": "fLaC"
+        }
+      }
+    },
+    "support_formats": [
+      {
+        "quality": 16,
+        "format": "mp4",
+        "new_description": "360P 流畅",
+        "display_desc": "360P 流畅",
+        "superscript": "",
+        "codecs": [
+          "avc1.64001E",
+          "hev1.1.6.L120.90",
+          "av01.0.0M.08"
+        ]
+      },
+      {
+        "quality": 32,
+        "format": "mp4",
+        "new_description": "480P 清晰",
+        "display_desc": "480P 清晰",
+        "superscript": "",
+        "codecs": [
+          "avc1.64001F",
+          "hev1.1.6.L120.90",
+          "av01.0.0M.08"
+        ]
+      },
+      {
+        "quality": 80,
+        "format": "mp4",
+        "new_description": "1080P 高清",
+        "display_desc": "1080P 高清",
+        "superscript": "",
+        "codecs": [
+          "avc1.640032",
+          "hev1.1.6.L150.90",
+          "av01.0.08M.08"
+        ]
+      }
+    ],
+    "high_format": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add 45 serde contract tests across all 5 model files (`bilibili_api`, `qr_login`, `frontend_dto`, `history`, `cookie`), pinning field renames (`isLogin`, `biliJct`, `baseUrl`/`backupUrl`, `Stroke`, `code`→`status_code`), `#[serde(default)]` behavior, `skip_serializing_if`, and the `flatten` passthrough of VIP-only `dolby`/`flac` objects
- Add 3 fixture JSONs under `tests/fixtures/` shaped after the real payload examples in `references/bilibili-API-collect` (web-interface view, DASH playurl, bangumi player with durl+durls), embedded via `include_str!`
- Guard the intentional strictness of `Session` auth fields: a session missing `biliJct` must fail to parse (documented via test)
- Test-only change: **no production code touched**

## Testing

`cargo test`: 168 passed / 0 failed (was 123). Verified locally: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build` all green.

Second PR (R2) of the Rust test-coverage expansion plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)