### PR TITLE
test: add pure-helper tests across bilibili handlers and utils

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -394,3 +394,42 @@ fn round_to(v: f64, places: i32) -> f64 {
     let p = 10f64.powi(places.max(0));
     (v * p).round() / p
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_percentage_uses_mb_denominator() {
+        // 5 MiB downloaded against 10 MiB total -> 50% (both sides are
+        // 1024-based despite the filesize_mb naming; see bytes_to_mb)
+        assert_eq!(
+            Emits::calculate_percentage(5 * 1024 * 1024, Some(10.0)),
+            50.0
+        );
+        // Zero progress stays 0
+        assert_eq!(Emits::calculate_percentage(0, Some(10.0)), 0.0);
+    }
+
+    #[test]
+    fn calculate_percentage_unknown_size_is_zero() {
+        // Unknown filesize (None) or zero filesize must not divide by zero.
+        assert_eq!(Emits::calculate_percentage(12345, None), 0.0);
+        assert_eq!(Emits::calculate_percentage(12345, Some(0.0)), 0.0);
+    }
+
+    #[test]
+    fn round_to_rounds_to_requested_places() {
+        assert_eq!(round_to(1.23456, 2), 1.23);
+        assert_eq!(round_to(2.5, 0), 3.0);
+        // Negative places clamp to zero
+        assert_eq!(round_to(1.618, -3), 2.0);
+    }
+
+    #[test]
+    fn round_to_non_finite_becomes_zero() {
+        assert_eq!(round_to(f64::NAN, 2), 0.0);
+        assert_eq!(round_to(f64::INFINITY, 2), 0.0);
+        assert_eq!(round_to(f64::NEG_INFINITY, 2), 0.0);
+    }
+}

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1264,6 +1264,314 @@ mod tests {
         let err = bangumi_player_result_to_xplayer(result).unwrap_err();
         assert_eq!(err, "ERR::BANGUMI_DURL_NOT_SUPPORTED");
     }
+
+    // ---- validate_api_response ----
+
+    // Why: ERR::* literals are a cross-boundary contract — the frontend maps
+    //   these exact strings to i18n keys (src/shared/lib/mapBackendError.ts;
+    //   see "Map backend ERR:: error codes" in CLAUDE.md), so a renamed code
+    //   must be mirrored there and in all 6 locale files.
+    #[test]
+    fn validate_api_response_maps_error_codes() {
+        // -101 drives the frontend to the login prompt; -404 to video error.
+        assert_eq!(
+            validate_api_response::<serde_json::Value>(-101, None),
+            Err("ERR::UNAUTHORIZED".to_string())
+        );
+        assert_eq!(
+            validate_api_response::<serde_json::Value>(-404, None),
+            Err("ERR::VIDEO_NOT_FOUND".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_api_response_requires_data_on_success() {
+        let data = serde_json::json!({"pages": []});
+        assert!(validate_api_response(0, Some(&data)).is_ok());
+        // code 0 with no data field (empty payload) is an API error, not success
+        assert_eq!(
+            validate_api_response::<serde_json::Value>(0, None),
+            Err("ERR::API_ERROR".to_string())
+        );
+        // any other non-zero code falls through to the generic API error
+        assert_eq!(
+            validate_api_response::<serde_json::Value>(62002, Some(&data)),
+            Err("ERR::API_ERROR".to_string())
+        );
+    }
+
+    // ---- check_http_status ----
+
+    #[test]
+    fn check_http_status_classifies_status_ranges() {
+        use reqwest::StatusCode;
+
+        assert!(check_http_status(StatusCode::OK).is_ok());
+        assert!(check_http_status(StatusCode::CREATED).is_ok());
+        assert!(check_http_status(StatusCode::PARTIAL_CONTENT).is_ok());
+
+        assert_eq!(
+            check_http_status(StatusCode::TOO_MANY_REQUESTS),
+            Err("ERR::RATE_LIMITED".to_string())
+        );
+        assert_eq!(
+            check_http_status(StatusCode::FORBIDDEN),
+            Err("ERR::API_ERROR".to_string())
+        );
+        assert_eq!(
+            check_http_status(StatusCode::INTERNAL_SERVER_ERROR),
+            Err("ERR::API_ERROR".to_string())
+        );
+    }
+
+    // ---- validate_bangumi_response ----
+
+    #[test]
+    fn validate_bangumi_response_maps_special_codes() {
+        assert!(validate_bangumi_response(0, "").is_ok());
+        assert_eq!(
+            validate_bangumi_response(-101, ""),
+            Err("ERR::UNAUTHORIZED".to_string())
+        );
+        assert_eq!(
+            validate_bangumi_response(-404, ""),
+            Err("ERR::BANGUMI_NOT_FOUND".to_string())
+        );
+        assert_eq!(
+            validate_bangumi_response(-403, ""),
+            Err("ERR::BANGUMI_ACCESS_DENIED".to_string())
+        );
+        assert_eq!(
+            validate_bangumi_response(-688, ""),
+            Err("ERR::BANGUMI_REGION_RESTRICTED".to_string())
+        );
+        assert_eq!(
+            validate_bangumi_response(-689, ""),
+            Err("ERR::BANGUMI_COPYRIGHT_RESTRICTED".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_bangumi_response_includes_code_and_message() {
+        let err = validate_bangumi_response(-999, "boom").unwrap_err();
+        assert!(
+            err.starts_with("ERR::API_ERROR (code -999): "),
+            "generic error must embed code and message: {err}"
+        );
+    }
+
+    // ---- first_non_empty (promoted from ignored doctest) ----
+
+    #[test]
+    fn first_non_empty_returns_first_non_empty_string() {
+        let empty = "".to_string();
+        let a = "1080P".to_string();
+        let b = "720P".to_string();
+        let options = vec![&empty, &a, &b];
+        assert_eq!(first_non_empty(&options), Some("1080P".to_string()));
+        assert_eq!(first_non_empty(&[&empty]), None);
+        assert_eq!(first_non_empty(&[]), None);
+    }
+
+    // ---- extract_bangumi_ep_id (promoted from ignored doctest) ----
+
+    #[test]
+    fn extract_bangumi_ep_id_parses_redirect_urls() {
+        assert_eq!(
+            extract_bangumi_ep_id("https://www.bilibili.com/bangumi/play/ep3051843"),
+            Some(3051843)
+        );
+        // Trailing path segments after the numeric id are ignored
+        assert_eq!(
+            extract_bangumi_ep_id("https://www.bilibili.com/bangumi/play/ep123?from=search"),
+            Some(123)
+        );
+        assert_eq!(
+            extract_bangumi_ep_id("https://www.bilibili.com/video/BV1xx"),
+            None
+        );
+        assert_eq!(
+            extract_bangumi_ep_id("https://www.bilibili.com/bangumi/play/ss123"),
+            None
+        );
+    }
+
+    // ---- url_host ----
+
+    #[test]
+    fn url_host_hides_signed_query_params() {
+        // Signed CDN URLs carry auth params that must never reach logs.
+        assert_eq!(
+            url_host("https://upos-sz-mirror08h.bilivideo.com/vod/x.m4s?upsig=secret&deadline=1"),
+            "upos-sz-mirror08h.bilivideo.com".to_string()
+        );
+        assert_eq!(url_host("not a url"), "<invalid>".to_string());
+    }
+
+    // ---- build_cookie_header ----
+
+    #[test]
+    fn build_cookie_header_filters_non_bilibili_hosts() {
+        use crate::models::cookie::CookieEntry;
+
+        let cookies = vec![
+            CookieEntry {
+                host: ".bilibili.com".into(),
+                name: "SESSDATA".into(),
+                value: "abc".into(),
+            },
+            CookieEntry {
+                host: ".biliapi.net".into(),
+                name: "OTHER".into(),
+                value: "x".into(),
+            },
+            CookieEntry {
+                host: "bilibili.com".into(),
+                name: "buvid3".into(),
+                value: "y".into(),
+            },
+        ];
+        assert_eq!(build_cookie_header(&cookies), "SESSDATA=abc; buvid3=y");
+        assert_eq!(build_cookie_header(&[]), "");
+    }
+
+    // ---- convert_qualities ----
+
+    fn stream(id: i32, codecid: i16) -> crate::models::bilibili_api::XPlayerApiResponseVideo {
+        crate::models::bilibili_api::XPlayerApiResponseVideo {
+            id,
+            codecid,
+            bandwidth: 0,
+            width: 0,
+            height: 0,
+            base_url: format!("https://example.com/{id}.m4s"),
+            backup_urls: None,
+        }
+    }
+
+    #[test]
+    fn convert_qualities_dedupes_by_highest_codecid_and_sorts_desc() {
+        let streams = vec![
+            stream(80, 7),  // avc 1080P
+            stream(80, 12), // av1 1080P — higher codecid wins the slot
+            stream(64, 7),  // 720P
+        ];
+        let qualities = convert_qualities(&streams);
+        let ids: Vec<i32> = qualities.iter().map(|q| q.id).collect();
+        assert_eq!(ids, vec![80, 64], "qualities sorted best-first");
+        assert_eq!(qualities[0].codecid, 12, "highest codecid kept for 80");
+        assert_eq!(qualities[0].quality, "1080P");
+        assert_eq!(qualities[1].quality, "720P");
+    }
+
+    // ---- select_stream_url ----
+
+    #[test]
+    fn select_stream_url_exact_match_marks_no_fallback() {
+        let items = vec![stream(80, 7), stream(64, 7)];
+        let (url, _backup, fell_back) = select_stream_url(&items, 64).unwrap();
+        assert_eq!(url, "https://example.com/64.m4s");
+        assert!(!fell_back);
+    }
+
+    #[test]
+    fn select_stream_url_unknown_quality_falls_back_to_first() {
+        let items = vec![stream(80, 7), stream(64, 7)];
+        let (url, _, fell_back) = select_stream_url(&items, 127).unwrap();
+        assert_eq!(url, "https://example.com/80.m4s");
+        assert!(fell_back, "caller shows a quality-fallback warning");
+    }
+
+    #[test]
+    fn select_stream_url_empty_list_errors() {
+        assert_eq!(
+            select_stream_url(&[], 80),
+            Err("ERR::QUALITY_NOT_FOUND".to_string())
+        );
+    }
+
+    // ---- auto_rename (fs, tempfile) ----
+
+    #[test]
+    fn auto_rename_appends_counter_until_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = dir.path().join("video.mp4");
+        std::fs::write(&original, b"x").unwrap();
+
+        let first = auto_rename(&original);
+        assert_eq!(
+            first.file_name().unwrap().to_str().unwrap(),
+            "video (1).mp4"
+        );
+
+        std::fs::write(&first, b"x").unwrap();
+        let second = auto_rename(&original);
+        assert_eq!(
+            second.file_name().unwrap().to_str().unwrap(),
+            "video (2).mp4"
+        );
+    }
+
+    #[test]
+    fn auto_rename_missing_file_returns_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never_written.mp4");
+        let renamed = auto_rename(&path);
+        assert_eq!(renamed, path, "no collision when the file does not exist");
+    }
+
+    // ---- ensure_free_space (fs, tempfile) ----
+
+    #[test]
+    fn ensure_free_space_accepts_small_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.mp4");
+        // 1 byte against a real (temp) filesystem with space available
+        assert!(ensure_free_space(&target, 1).is_ok());
+    }
+
+    // Why: the disk-space check is statvfs (unix-only); on Windows the
+    // function unconditionally returns Ok(()) and this assertion cannot hold.
+    #[cfg(target_family = "unix")]
+    #[test]
+    fn ensure_free_space_rejects_impossible_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.mp4");
+        // u64::MAX bytes can never fit; the guard must trip ERR::DISK_FULL
+        assert_eq!(
+            ensure_free_space(&target, u64::MAX),
+            Err("ERR::DISK_FULL".to_string())
+        );
+    }
+
+    // ---- cleanup_subtitle_files (fs, tempfile; promoted from ignored doctest) ----
+
+    #[test]
+    fn cleanup_subtitle_files_removes_only_matching_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let keep_video = dir.path().join("video.mp4");
+        let keep_other_id = dir.path().join("temp_sub_other-id_en.srt");
+        let drop_en = dir.path().join("temp_sub_dl-1_en.srt");
+        let drop_ja = dir.path().join("temp_sub_dl-1_ja.srt");
+        for p in [&keep_video, &keep_other_id, &drop_en, &drop_ja] {
+            std::fs::write(p, b"x").unwrap();
+        }
+
+        cleanup_subtitle_files(dir.path(), "dl-1");
+
+        assert!(keep_video.exists());
+        assert!(keep_other_id.exists(), "other download ids untouched");
+        assert!(!drop_en.exists());
+        assert!(!drop_ja.exists());
+    }
+
+    #[test]
+    fn cleanup_subtitle_files_missing_dir_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        // Must not panic on a nonexistent directory.
+        cleanup_subtitle_files(&missing, "any");
+    }
 }
 
 /// Spawns an async task to save download history.

--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -120,3 +120,28 @@ fn is_temp_file(path: &Path) -> bool {
 
     is_video || is_audio || is_subtitle
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn is_temp_file_matches_temp_prefixes() {
+        // Promoted from the ignored doctest: private fn, pure assertions.
+        assert!(is_temp_file(Path::new("temp_video_123.m4s")));
+        assert!(is_temp_file(Path::new("temp_audio_456.m4s")));
+        assert!(is_temp_file(Path::new("temp_sub_789.srt")));
+        assert!(!is_temp_file(Path::new("final_video.mp4")));
+    }
+
+    #[test]
+    fn is_temp_file_rejects_mismatched_pairs() {
+        // Prefix without the matching extension (and vice versa) must not match.
+        assert!(!is_temp_file(Path::new("temp_video_123.mp4")));
+        assert!(!is_temp_file(Path::new("temp_audio_456.srt")));
+        assert!(!is_temp_file(Path::new("temp_sub_789.m4s")));
+        assert!(!is_temp_file(Path::new("temp_")));
+        assert!(!is_temp_file(Path::new("/dir/other.m4s")));
+    }
+}

--- a/src-tauri/src/utils/analytics.rs
+++ b/src-tauri/src/utils/analytics.rs
@@ -395,3 +395,30 @@ fn current_time_ms() -> u128 {
         .map(|d| d.as_millis())
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: the "::detail" suffix is a dynamic original message (e.g.
+    //   "ERR::NETWORK::{msg}" produced in handlers/bilibili.rs), so only the
+    //   first segment is a stable bucket; the frontend parser
+    //   (src/shared/lib/mapBackendError.ts) splits on the same segment.
+    #[test]
+    fn extract_error_category_takes_first_segment() {
+        assert_eq!(
+            extract_error_category("ERR::NETWORK::connection reset"),
+            Some("NETWORK".to_string())
+        );
+        assert_eq!(
+            extract_error_category("ERR::VIDEO_NOT_FOUND"),
+            Some("VIDEO_NOT_FOUND".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_error_category_ignores_non_err_strings() {
+        assert_eq!(extract_error_category("connection reset by peer"), None);
+        assert_eq!(extract_error_category(""), None);
+    }
+}

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -1476,4 +1476,26 @@ mod tests {
         let junk = header::HeaderValue::from_static("items 1-2");
         assert_eq!(content_range_start(&junk), None);
     }
+
+    #[test]
+    fn calculate_segments_splits_total_into_ranges() {
+        // 10 bytes / size 4 -> [0-3],[4-7],[8-9]
+        assert_eq!(calculate_segments(10, 4), vec![(0, 3), (4, 7), (8, 9)]);
+        // Exact multiples leave no tail segment
+        assert_eq!(calculate_segments(8, 4), vec![(0, 3), (4, 7)]);
+        // Single segment when total < size
+        assert_eq!(calculate_segments(3, 4), vec![(0, 2)]);
+        // Zero total -> no segments (no infinite loop)
+        assert!(calculate_segments(0, 4).is_empty());
+    }
+
+    #[test]
+    fn cdn_rotation_limit_caps_url_count_and_multiplies_loops() {
+        use crate::constants::MAX_CDN_LOOPS;
+        assert_eq!(cdn_rotation_limit(0), 0);
+        assert_eq!(cdn_rotation_limit(1), MAX_CDN_LOOPS);
+        assert_eq!(cdn_rotation_limit(5), 5 * MAX_CDN_LOOPS);
+        // Saturating u8 arithmetic: 300 urls -> 255 cap -> 255*3 saturates at u8::MAX
+        assert_eq!(cdn_rotation_limit(300), u8::MAX);
+    }
 }

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -138,3 +138,36 @@ fn parse_trailing_kbps(line: &str) -> Option<u32> {
         .find(|t| !t.is_empty() && t.chars().all(|c| c.is_ascii_digit()))?;
     token.parse::<u32>().ok()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_resolution_finds_width_x_height_token() {
+        assert_eq!(
+            parse_resolution("Stream #0:0[0x1](und): Video: h264, 1920x1080 [SAR 1:1]"),
+            Some((1920, 1080))
+        );
+        assert_eq!(parse_resolution("640x360"), Some((640, 360)));
+        assert_eq!(parse_resolution("no dims here"), None);
+    }
+
+    #[test]
+    fn parse_resolution_rejects_zero_dims() {
+        // 0x0 streams (audio-only) must not be mistaken for video dims.
+        assert_eq!(parse_resolution("0x0"), None);
+        assert_eq!(parse_resolution("1920x0"), None);
+    }
+
+    #[test]
+    fn parse_trailing_kbps_takes_last_number_before_unit() {
+        assert_eq!(
+            parse_trailing_kbps("Video: h264, 1920x1080, 5000 kb/s, 30 fps"),
+            Some(5000)
+        );
+        assert_eq!(parse_trailing_kbps("Audio: aac, 320 kb/s"), Some(320));
+        assert_eq!(parse_trailing_kbps("no bitrate"), None);
+        assert_eq!(parse_trailing_kbps("kb/s"), None);
+    }
+}


### PR DESCRIPTION
## Summary

- **Test-only change**: no production code touched. +32 tests (168 → 200)
- `bilibili.rs` pure helpers: ERR:: error-code mapping for `validate_api_response` / `check_http_status` / `validate_bangumi_response` (these strings are the frontend i18n contract via `mapBackendError.ts`), `first_non_empty` / `extract_bangumi_ep_id` promoted from ignored doctests, `url_host` signed-query stripping, `build_cookie_header` host filtering, `convert_qualities` dedup + ordering, `select_stream_url` fallback flag, tempfile-based `auto_rename` / `ensure_free_space` (disk-space test unix-gated to match the statvfs cfg) / `cleanup_subtitle_files`
- `cleanup.rs` `is_temp_file` prefix+extension pairing; `downloads.rs` `calculate_segments` + `cdn_rotation_limit` saturating math; `ffmpeg_probe.rs` parsers; `analytics.rs` `extract_error_category`; `emits.rs` percentage math + `round_to`

These also serve as characterization tests ahead of the planned R4 (extraction refactors) and R5 (BiliApi transport refactor) PRs.

## Testing

`cargo test`: 200 passed / 0 failed. `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build` green.

Third PR (R3) of the Rust test-coverage expansion plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)