### PR TITLE
refactor: extract testable seams from AppHandle/fs-coupled modules

### DIFF
--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -6,8 +6,15 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
+// Why: tokio's Instant, not std, so the paused-clock tests below work:
+// with the test-util feature (dev-dependency only, src-tauri/Cargo.toml)
+// Instant::now() follows tokio::time::advance(); without it tokio
+// re-exports std::time::Instant, so runtime behavior is identical.
+// Note: reverting to std::time::Instant compiles but silently breaks
+// every #[tokio::test(start_paused = true)] in this module.
+use tokio::time::Instant;
 use tokio::{spawn, sync::watch, sync::Mutex, time};
 
 /// Progress update interval in milliseconds.
@@ -298,7 +305,15 @@ impl Emits {
     ///
     /// * `app` - Tauri application handle for event emission
     /// * `inner` - Mutable reference to the locked inner state
-    fn send_progress_locked(app: &AppHandle, inner: &mut EmitsInner, current_bytes: u64) {
+    // Why: generic over R — production callers pass AppHandle
+    // (= AppHandle<Wry>) while the tests pass tauri::test::mock_app()'s
+    // AppHandle<MockRuntime> (tauri "test" dev-dependency feature,
+    // src-tauri/Cargo.toml); Emitter<R> is the minimal bound covering both.
+    fn send_progress_locked<R: tauri::Runtime>(
+        app: &impl Emitter<R>,
+        inner: &mut EmitsInner,
+        current_bytes: u64,
+    ) {
         let now = Instant::now();
         let delta_time = now.duration_since(inner.last_instant).as_secs_f64();
         let elapsed_time = now.duration_since(inner.start_instant).as_secs_f64();
@@ -431,5 +446,87 @@ mod tests {
         assert_eq!(round_to(f64::NAN, 2), 0.0);
         assert_eq!(round_to(f64::INFINITY, 2), 0.0);
         assert_eq!(round_to(f64::NEG_INFINITY, 2), 0.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_stall_zeroes_displayed_rate() {
+        let app = tauri::test::mock_app();
+        let mut inner = EmitsInner::default();
+        // Seed a previously computed non-zero rate as if a fast phase just ended
+        inner.progress.transfer_rate = 10_000.0;
+        inner.last_speed_kbps = 10_000.0;
+        inner.last_downloaded_bytes = 5 * 1024 * 1024;
+
+        // No bytes arrive for longer than SPEED_DISPLAY_IDLE_SECS (issue #534)
+        tokio::time::advance(Duration::from_secs(SPEED_DISPLAY_IDLE_SECS + 1)).await;
+        Emits::send_progress_locked(app.handle(), &mut inner, 5 * 1024 * 1024);
+
+        assert_eq!(inner.progress.transfer_rate, 0.0);
+        assert_eq!(inner.last_speed_kbps, 0.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn brief_gap_keeps_last_rate() {
+        let app = tauri::test::mock_app();
+        let mut inner = EmitsInner::default();
+        inner.progress.transfer_rate = 5_000.0;
+        inner.last_speed_kbps = 5_000.0;
+        inner.last_downloaded_bytes = 1024;
+
+        // A segment-boundary pause shorter than the idle threshold must NOT
+        // flicker the rate to 0.
+        tokio::time::advance(Duration::from_secs(SPEED_DISPLAY_IDLE_SECS - 1)).await;
+        Emits::send_progress_locked(app.handle(), &mut inner, 1024);
+
+        assert_eq!(inner.progress.transfer_rate, 5_000.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn byte_progress_recomputes_rate_after_one_second() {
+        let app = tauri::test::mock_app();
+        let mut inner = EmitsInner::default();
+        inner.progress.filesize = Some(4.0); // 4 MiB total
+        let baseline = 1024 * 1024u64;
+        inner.last_downloaded_bytes = baseline;
+        inner.last_speed_calc_bytes = baseline;
+
+        // 1 MiB arrives over 2s -> 512 KiB/s
+        tokio::time::advance(Duration::from_secs(2)).await;
+        Emits::send_progress_locked(app.handle(), &mut inner, baseline + 1024 * 1024);
+
+        assert!((inner.progress.transfer_rate - 512.0).abs() < 0.2);
+        assert_eq!(inner.progress.downloaded, Some(2.0));
+        assert_eq!(inner.progress.percentage, 50.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sub_second_update_reuses_last_rate() {
+        let app = tauri::test::mock_app();
+        let mut inner = EmitsInner {
+            last_speed_kbps: 3_000.0,
+            ..Default::default()
+        };
+        inner.progress.transfer_rate = 3_000.0;
+
+        // 0.5s since last calc -> below the 1s window, rate is reused as-is
+        tokio::time::advance(Duration::from_millis(500)).await;
+        Emits::send_progress_locked(app.handle(), &mut inner, 2048);
+
+        assert_eq!(inner.progress.transfer_rate, 3_000.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn percentage_caps_at_hundred() {
+        let app = tauri::test::mock_app();
+        let mut inner = EmitsInner::default();
+        inner.progress.filesize = Some(1.0); // 1 MiB total
+        inner.last_downloaded_bytes = 0;
+
+        // Server reports more bytes than the announced size (shouldn't happen,
+        // but the display must never show 101%)
+        Emits::send_progress_locked(app.handle(), &mut inner, 2 * 1024 * 1024);
+
+        assert_eq!(inner.progress.percentage, 100.0);
+        assert_eq!(inner.progress.downloaded, Some(2.0));
     }
 }

--- a/src-tauri/src/handlers/cookie.rs
+++ b/src-tauri/src/handlers/cookie.rs
@@ -317,3 +317,85 @@ fn read_bilibili_cookies(
     }
     Ok(count > 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn make_profile(root: &Path, name: &str) -> PathBuf {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("cookies.sqlite"), b"stub").unwrap();
+        dir
+    }
+
+    fn write_ini(root: &Path, content: &str) {
+        std::fs::write(root.join("profiles.ini"), content).unwrap();
+    }
+
+    #[test]
+    fn resolves_via_install_section_default() {
+        let root = tempfile::tempdir().unwrap();
+        let expected = make_profile(root.path(), "abcd.default-release");
+        write_ini(
+            root.path(),
+            "[InstallC3C80A9D53B24A61]\nDefault=abcd.default-release\nLock=abc\n",
+        );
+        assert_eq!(find_active_firefox_profile(root.path()), Some(expected));
+    }
+
+    #[test]
+    fn install_section_ignored_when_cookies_missing() {
+        // Points at a profile without cookies.sqlite -> falls through to None
+        // (caller then directory-scans).
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("empty.profile")).unwrap();
+        write_ini(root.path(), "[InstallX]\nDefault=empty.profile\n");
+        assert_eq!(find_active_firefox_profile(root.path()), None);
+    }
+
+    #[test]
+    fn resolves_via_profile_section_default_flag() {
+        let root = tempfile::tempdir().unwrap();
+        let expected = make_profile(root.path(), "second.default");
+        make_profile(root.path(), "first.profile");
+        // Default=1 written BEFORE Path= (order independence)
+        write_ini(
+            root.path(),
+            "[Profile0]\nIsRelative=1\nPath=first.profile\n\n\
+             [Profile1]\nDefault=1\nPath=second.default\n",
+        );
+        assert_eq!(find_active_firefox_profile(root.path()), Some(expected));
+    }
+
+    #[test]
+    fn last_install_section_wins_over_profile_default() {
+        let root = tempfile::tempdir().unwrap();
+        let install_profile = make_profile(root.path(), "install.pick");
+        make_profile(root.path(), "legacy.pick");
+        write_ini(
+            root.path(),
+            "[Install1]\nDefault=install.pick\n\n\
+             [Profile0]\nDefault=1\nPath=legacy.pick\n",
+        );
+        // Priority 1 ([Install*]) beats Priority 2 ([Profile*] Default=1)
+        assert_eq!(
+            find_active_firefox_profile(root.path()),
+            Some(install_profile)
+        );
+    }
+
+    #[test]
+    fn missing_ini_or_file_yields_none() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(find_active_firefox_profile(root.path()), None);
+    }
+
+    #[test]
+    fn garbage_ini_yields_none() {
+        let root = tempfile::tempdir().unwrap();
+        write_ini(root.path(), "not an ini file at all\n[broken\n");
+        assert_eq!(find_active_firefox_profile(root.path()), None);
+    }
+}

--- a/src-tauri/src/handlers/qr_login.rs
+++ b/src-tauri/src/handlers/qr_login.rs
@@ -953,7 +953,13 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
     log::debug!("[BE] Refresh API response status: {}", response.status());
 
     // Extract new cookies from Set-Cookie headers
-    let new_cookies = extract_cookies_from_response(&response);
+    let set_cookie_values: Vec<String> = response
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_string))
+        .collect();
+    let new_cookies = parse_set_cookie_values(&set_cookie_values);
     log::debug!("[BE] Extracted {} cookies from response", new_cookies.len());
 
     let response_text = response
@@ -1068,24 +1074,23 @@ fn get_cookie_header(app: &AppHandle) -> String {
         .join("; ")
 }
 
-/// Extracts cookies from Set-Cookie headers.
+/// Extracts cookies from Set-Cookie header values.
 ///
-/// Parses every `Set-Cookie` header on `response`, splitting on the first
-/// `=` to capture the name/value pair and ignoring attribute pairs such as
-/// `Path=` or `HttpOnly`. When the same cookie name appears multiple times,
-/// the last occurrence wins.
-fn extract_cookies_from_response(
-    response: &reqwest::Response,
-) -> std::collections::HashMap<String, String> {
+/// Parses each raw `Set-Cookie` value, splitting on the first `=` to
+/// capture the name/value pair and ignoring attribute pairs such as
+/// `Path=` or `HttpOnly`. When the same cookie name appears multiple
+/// times, the last occurrence wins.
+///
+/// Takes the raw header values (rather than a `reqwest::Response`) so the
+/// parsing logic is testable without network plumbing.
+fn parse_set_cookie_values(values: &[String]) -> std::collections::HashMap<String, String> {
     let mut cookies = std::collections::HashMap::new();
 
-    for cookie in response.headers().get_all(reqwest::header::SET_COOKIE) {
-        if let Ok(cookie_str) = cookie.to_str() {
-            // Parse "name=value; Path=/; ..."
-            if let Some(cookie_part) = cookie_str.split(';').next() {
-                if let Some((name, value)) = cookie_part.split_once('=') {
-                    cookies.insert(name.trim().to_string(), value.trim().to_string());
-                }
+    for cookie_str in values {
+        // Parse "name=value; Path=/; ..."
+        if let Some(cookie_part) = cookie_str.split(';').next() {
+            if let Some((name, value)) = cookie_part.split_once('=') {
+                cookies.insert(name.trim().to_string(), value.trim().to_string());
             }
         }
     }
@@ -1095,7 +1100,7 @@ fn extract_cookies_from_response(
 
 /// Builds a Cookie header from a HashMap.
 ///
-/// Inverse of [`extract_cookies_from_response`]: joins each entry with
+/// Inverse of [`parse_set_cookie_values`]: joins each entry with
 /// `; ` to form a value suitable for the `Cookie` request header.
 fn build_cookie_header(cookies: &std::collections::HashMap<String, String>) -> String {
     cookies
@@ -1103,4 +1108,81 @@ fn build_cookie_header(cookies: &std::collections::HashMap<String, String>) -> S
         .map(|(k, v)| format!("{}={}", k, v))
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_session_from_url_maps_query_params() {
+        let url = "https://passport.biligame.com/crossDomain?\
+                   DedeUserID=42&DedeUserID__ckMd5=abc&SESSDATA=s%2Cd&bili_jct=jct";
+        let session = extract_session_from_url(url, "rt", 1700000000).unwrap();
+        assert_eq!(session.sessdata, "s,d", "query values are URL-decoded");
+        assert_eq!(session.bili_jct, "jct");
+        assert_eq!(session.dede_user_id, "42");
+        assert_eq!(session.dede_user_id_ck_md5, "abc");
+        assert_eq!(session.refresh_token, "rt");
+        assert_eq!(session.timestamp, 1700000000);
+        assert!(session.uname.is_empty());
+    }
+
+    #[test]
+    fn extract_session_from_url_missing_params_default_empty() {
+        let session =
+            extract_session_from_url("https://example.com/crossDomain?x=1", "rt", 1).unwrap();
+        assert!(session.sessdata.is_empty());
+        assert!(session.bili_jct.is_empty());
+        assert_eq!(session.refresh_token, "rt");
+    }
+
+    #[test]
+    fn extract_session_from_url_rejects_garbage() {
+        assert!(extract_session_from_url("not a url", "rt", 1).is_err());
+    }
+
+    #[test]
+    fn parse_set_cookie_values_keeps_last_and_strips_attributes() {
+        let values = vec![
+            "SESSDATA=first%2Cvalue; Path=/; HttpOnly; Secure".to_string(),
+            // Same cookie set again later must win
+            "SESSDATA=second; Path=/".to_string(),
+            "bili_jct=jct; Path=/; SameSite=None".to_string(),
+            // No '=' pair at all -> ignored
+            "novalue".to_string(),
+        ];
+        let cookies = parse_set_cookie_values(&values);
+        assert_eq!(cookies.get("SESSDATA").map(String::as_str), Some("second"));
+        assert_eq!(cookies.get("bili_jct").map(String::as_str), Some("jct"));
+        assert_eq!(cookies.len(), 2);
+    }
+
+    #[test]
+    fn build_cookie_header_joins_pairs() {
+        let mut cookies = std::collections::HashMap::new();
+        cookies.insert("SESSDATA".to_string(), "v1".to_string());
+        cookies.insert("buvid3".to_string(), "v2".to_string());
+        let header = build_cookie_header(&cookies);
+        // HashMap order is unspecified; assert both pairs are present
+        assert!(header.contains("SESSDATA=v1"));
+        assert!(header.contains("buvid3=v2"));
+        assert_eq!(header.matches("; ").count(), 1);
+        assert!(build_cookie_header(&std::collections::HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn generate_correspond_path_produces_rsa_sized_hex() {
+        // RSA-OAEP with a 1024-bit key -> 128-byte ciphertext -> 256 hex chars.
+        // OAEP padding is randomized, so output must also be non-deterministic.
+        let a = generate_correspond_path(1700000000).unwrap();
+        let b = generate_correspond_path(1700000000).unwrap();
+        assert_eq!(a.len(), 256, "128-byte ciphertext as lowercase hex");
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "base16ct lower-case encoding"
+        );
+        assert_ne!(a, b, "randomized OAEP padding");
+    }
 }

--- a/src-tauri/src/handlers/updater.rs
+++ b/src-tauri/src/handlers/updater.rs
@@ -89,39 +89,12 @@ pub async fn fetch_all_release_notes(
         }
     }
 
-    if releases.is_empty() {
-        return Ok("No new releases available".to_string());
-    }
-
-    // Sort releases by version (newest first)
-    releases.sort_by(|a, b| {
-        let parse_ver = |r: &octocrab::models::repos::Release| {
-            Version::parse(r.tag_name.strip_prefix('v').unwrap_or(&r.tag_name)).ok()
-        };
-        match (parse_ver(b), parse_ver(a)) {
-            (Some(vb), Some(va)) => vb.cmp(&va),
-            _ => std::cmp::Ordering::Equal,
-        }
-    });
-
-    // Generate release notes for each version
-    let mut notes = String::new();
-    const DEFAULT_BODY: &str = "See the assets to download this version and install.";
-
-    for release in releases {
-        if let Some(body) = &release.body {
-            if !body.is_empty() && body != DEFAULT_BODY {
-                notes.push_str(&format!("## {}\n\n{}\n\n---\n\n", release.tag_name, body));
-            }
-        }
-    }
-
-    notes.push_str(&format!(
-        "*View [latest release](https://github.com/{}/{}/releases/latest) on GitHub*\n",
-        owner, repo
-    ));
-
-    Ok(notes)
+    Ok(format_releases_markdown(
+        releases,
+        &format!("https://github.com/{}/{}/releases/latest", owner, repo),
+        "latest release",
+        "No new releases available",
+    ))
 }
 
 /// Fetches all releases from GitHub as a Markdown document.
@@ -134,7 +107,6 @@ pub async fn fetch_all_releases_markdown(owner: &str, repo: &str) -> Result<Stri
         owner,
         repo
     );
-    use semver::Version;
 
     let github = Octocrab::builder().build()?;
     const PER_PAGE: u8 = 30;
@@ -162,8 +134,30 @@ pub async fn fetch_all_releases_markdown(owner: &str, repo: &str) -> Result<Stri
         }
     }
 
+    Ok(format_releases_markdown(
+        releases,
+        &format!("https://github.com/{}/{}/releases", owner, repo),
+        "all releases",
+        "No releases found.",
+    ))
+}
+
+/// Pure Markdown assembly shared by both fetchers: sort releases
+/// newest-first by `v`-stripped semver tag and render note bodies.
+///
+/// Releases whose body is missing, empty, or the auto-generated
+/// "download assets" placeholder are skipped (heading omitted entirely).
+/// Unparsable tags keep their relative order (sort comparator is Equal).
+fn format_releases_markdown(
+    mut releases: Vec<octocrab::models::repos::Release>,
+    link_url: &str,
+    link_label: &str,
+    empty_message: &str,
+) -> String {
+    use semver::Version;
+
     if releases.is_empty() {
-        return Ok("No releases found.".to_string());
+        return empty_message.to_string();
     }
 
     releases.sort_by(|a, b| {
@@ -187,10 +181,103 @@ pub async fn fetch_all_releases_markdown(owner: &str, repo: &str) -> Result<Stri
         }
     }
 
-    notes.push_str(&format!(
-        "*View [all releases](https://github.com/{}/{}/releases) on GitHub*\n",
-        owner, repo
-    ));
+    notes.push_str(&format!("*View [{link_label}]({link_url}) on GitHub*\n"));
 
-    Ok(notes)
+    notes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    // Why: built via serde_json rather than a struct literal — octocrab's
+    // Release has ~20 fields (several Url-typed, each needing Url::parse in
+    // a literal) and its nested Author is #[non_exhaustive] with no
+    // constructor, so JSON deserialization is the tersest fixture
+    // construction; omitted Option fields deserialize as None.
+    fn release(tag: &str, body: Option<&str>) -> octocrab::models::repos::Release {
+        let created_at: Option<DateTime<Utc>> =
+            DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .ok()
+                .map(|d| d.with_timezone(&Utc));
+        serde_json::from_value(serde_json::json!({
+            "url": "https://example.com/u",
+            "id": 1,
+            "node_id": "rel",
+            "tag_name": tag,
+            "target_commitish": "main",
+            "name": format!("{tag} name"),
+            "body": body,
+            "draft": false,
+            "prerelease": false,
+            "created_at": created_at,
+            "published_at": created_at,
+            "assets": [],
+            "author": {
+                "login": "j4rviscmd", "id": 1, "node_id": "n",
+                "avatar_url": "https://example.com/a", "gravatar_id": "",
+                "url": "https://example.com/u", "html_url": "https://example.com/u",
+                "followers_url": "https://example.com/f",
+                "following_url": "https://example.com/fg",
+                "gists_url": "https://example.com/g",
+                "starred_url": "https://example.com/s",
+                "subscriptions_url": "https://example.com/sub",
+                "organizations_url": "https://example.com/org",
+                "repos_url": "https://example.com/repos",
+                "events_url": "https://example.com/events",
+                "received_events_url": "https://example.com/re",
+                "type": "User", "site_admin": false
+            },
+            "html_url": "https://example.com/u",
+            "upload_url": "https://example.com/u",
+            "assets_url": "https://example.com/assets",
+            "zipball_url": "https://example.com/z", "tarball_url": "https://example.com/t"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn sorts_newest_first_and_renders_bodies() {
+        let releases = vec![
+            release("v1.0.0", Some("first")),
+            release("v1.10.0", Some("semver compare, not lexicographic")),
+            release("v1.2.0", Some("third")),
+        ];
+        let out = format_releases_markdown(releases, "https://ex/r", "latest release", "empty");
+        let first_heading = out.find("## ").unwrap();
+        assert!(out[first_heading..].starts_with("## v1.10.0"), "{out}");
+        assert!(out.contains("## v1.2.0"));
+        assert!(out.contains("## v1.0.0"));
+        // v1.10.0 > v1.2.0 > v1.0.0 by semver
+        assert!(out.find("## v1.10.0").unwrap() < out.find("## v1.2.0").unwrap());
+        assert!(out.find("## v1.2.0").unwrap() < out.find("## v1.0.0").unwrap());
+        assert!(out.contains("*View [latest release](https://ex/r) on GitHub*"));
+    }
+
+    #[test]
+    fn skips_placeholder_and_missing_bodies() {
+        let releases = vec![
+            release("v1.1.0", None),
+            release("v1.2.0", Some("")),
+            release(
+                "v1.3.0",
+                Some("See the assets to download this version and install."),
+            ),
+            release("v1.4.0", Some("real")),
+        ];
+        let out = format_releases_markdown(releases, "u", "l", "empty");
+        assert!(!out.contains("v1.1.0"));
+        assert!(!out.contains("v1.2.0"));
+        assert!(!out.contains("v1.3.0"));
+        assert!(out.contains("## v1.4.0"));
+    }
+
+    #[test]
+    fn empty_input_returns_message() {
+        assert_eq!(
+            format_releases_markdown(vec![], "u", "l", "No releases found."),
+            "No releases found."
+        );
+    }
 }

--- a/src-tauri/src/store/history_store.rs
+++ b/src-tauri/src/store/history_store.rs
@@ -151,53 +151,177 @@ impl HistoryStore {
 
     /// Searches history entries with optional query string and filters.
     ///
-    /// # Filtering Logic
-    ///
-    /// - **Query**: Searches case-insensitive in title and URL
-    /// - **Status**: Filters by status ("completed", "failed", or "all")
-    /// - **Date range**: Filters entries after `date_from` (if provided)
+    /// Delegates the actual matching to [`filter_entries`].
     pub fn search(
         &self,
         query: Option<String>,
         filters: Option<HistoryFilters>,
     ) -> Vec<HistoryEntry> {
         let entries = self.get_all();
-        let filters = filters.unwrap_or_default();
+        filter_entries(entries, query.as_deref(), &filters.unwrap_or_default())
+    }
+}
 
-        entries
-            .into_iter()
-            .filter(|entry| {
-                // Query search: match title or URL case-insensitively
-                if let Some(q) = query.as_ref().filter(|s| !s.is_empty()) {
-                    let query_lower = q.to_lowercase();
-                    let matches = entry.title.to_lowercase().contains(&query_lower)
-                        || entry.url.to_lowercase().contains(&query_lower);
-                    if !matches {
-                        return false;
-                    }
+/// Pure history filtering logic, extracted from `HistoryStore::search`.
+///
+/// # Filtering Logic
+///
+/// - **Query**: Searches case-insensitive in title and URL
+/// - **Status**: Filters by status ("completed", "failed", or "all");
+///   the legacy "success" status is treated as "completed"
+/// - **Date range**: Filters entries after `date_from` (if provided,
+///   ISO 8601 string comparison)
+fn filter_entries(
+    entries: Vec<HistoryEntry>,
+    query: Option<&str>,
+    filters: &HistoryFilters,
+) -> Vec<HistoryEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| {
+            // Query search: match title or URL case-insensitively
+            if let Some(q) = query.filter(|s| !s.is_empty()) {
+                let query_lower = q.to_lowercase();
+                let matches = entry.title.to_lowercase().contains(&query_lower)
+                    || entry.url.to_lowercase().contains(&query_lower);
+                if !matches {
+                    return false;
                 }
+            }
 
-                // Status filter
-                if let Some(status) = filters.status.as_ref().filter(|s| *s != "all") {
-                    let entry_status = if entry.status == "success" || entry.status == "completed" {
-                        "completed"
-                    } else {
-                        entry.status.as_str()
-                    };
-                    if entry_status != status {
-                        return false;
-                    }
+            // Status filter
+            if let Some(status) = filters.status.as_ref().filter(|s| *s != "all") {
+                let entry_status = if entry.status == "success" || entry.status == "completed" {
+                    "completed"
+                } else {
+                    entry.status.as_str()
+                };
+                if entry_status != status {
+                    return false;
                 }
+            }
 
-                // Date range filter
-                if let Some(date_from) = filters.date_from.as_ref() {
-                    if &entry.downloaded_at < date_from {
-                        return false;
-                    }
+            // Date range filter
+            if let Some(date_from) = filters.date_from.as_ref() {
+                if &entry.downloaded_at < date_from {
+                    return false;
                 }
+            }
 
-                true
-            })
-            .collect()
+            true
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, title: &str, status: &str, downloaded_at: &str) -> HistoryEntry {
+        HistoryEntry {
+            id: id.into(),
+            title: title.into(),
+            bvid: None,
+            url: format!("https://www.bilibili.com/video/{id}"),
+            downloaded_at: downloaded_at.into(),
+            status: status.into(),
+            file_size: None,
+            quality: None,
+            thumbnail_url: None,
+            version: "1.0".into(),
+        }
+    }
+
+    #[test]
+    fn filter_entries_no_filters_returns_all() {
+        let entries = vec![entry("a", "A", "completed", "2026-01-01T00:00:00Z")];
+        let out = filter_entries(entries.clone(), None, &HistoryFilters::default());
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn filter_entries_query_matches_title_or_url_case_insensitive() {
+        let entries = vec![
+            entry(
+                "a",
+                "【歌ってみた】Song Cover",
+                "completed",
+                "2026-01-01T00:00:00Z",
+            ),
+            entry("b", " unrelated", "completed", "2026-01-02T00:00:00Z"),
+        ];
+        let out = filter_entries(entries, Some("SONG"), &HistoryFilters::default());
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "a");
+
+        // URL match also hits
+        let entries = vec![entry(
+            "x",
+            "no title match",
+            "completed",
+            "2026-01-01T00:00:00Z",
+        )];
+        let out = filter_entries(entries, Some("/video/x"), &HistoryFilters::default());
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn filter_entries_empty_query_is_ignored() {
+        let entries = vec![entry("a", "t", "completed", "2026-01-01T00:00:00Z")];
+        let out = filter_entries(entries, Some(""), &HistoryFilters::default());
+        assert_eq!(out.len(), 1, "empty query must not filter anything out");
+    }
+
+    #[test]
+    fn filter_entries_status_treats_legacy_success_as_completed() {
+        let entries = vec![
+            entry("old", "t", "success", "2026-01-01T00:00:00Z"),
+            entry("new", "t", "completed", "2026-01-02T00:00:00Z"),
+            entry("bad", "t", "failed", "2026-01-03T00:00:00Z"),
+        ];
+        let filters = HistoryFilters {
+            status: Some("completed".into()),
+            date_from: None,
+        };
+        let out = filter_entries(entries, None, &filters);
+        let ids: Vec<&str> = out.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["old", "new"]);
+
+        let entries = vec![entry("bad", "t", "failed", "2026-01-01T00:00:00Z")];
+        let out = filter_entries(entries, None, &filters);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn filter_entries_status_all_keeps_everything() {
+        let entries = vec![
+            entry("a", "t", "completed", "2026-01-01T00:00:00Z"),
+            entry("b", "t", "failed", "2026-01-02T00:00:00Z"),
+        ];
+        let filters = HistoryFilters {
+            status: Some("all".into()),
+            date_from: None,
+        };
+        assert_eq!(filter_entries(entries, None, &filters).len(), 2);
+    }
+
+    #[test]
+    fn filter_entries_date_from_keeps_entries_on_or_after() {
+        let entries = vec![
+            entry("old", "t", "completed", "2026-01-01T00:00:00Z"),
+            entry("edge", "t", "completed", "2026-01-02T00:00:00Z"),
+            entry("new", "t", "completed", "2026-01-03T00:00:00Z"),
+        ];
+        let filters = HistoryFilters {
+            status: None,
+            date_from: Some("2026-01-02T00:00:00Z".into()),
+        };
+        let out = filter_entries(entries, None, &filters);
+        let ids: Vec<&str> = out.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["edge", "new"],
+            "boundary is inclusive (string compare >=)"
+        );
     }
 }

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -170,4 +170,67 @@ mod tests {
         assert_eq!(parse_trailing_kbps("no bitrate"), None);
         assert_eq!(parse_trailing_kbps("kb/s"), None);
     }
+
+    /// Writes a fake "ffmpeg" executable that prints the given stderr and
+    /// exits, so probe_duration_sec / probe_audio_bitrate_kbps can be tested
+    /// without a real ffmpeg binary.
+    #[cfg(unix)]
+    fn write_fake_ffmpeg(dir: &std::path::Path, stderr_text: &str) -> std::path::PathBuf {
+        let script = format!("#!/bin/sh\ncat 1>&2 <<'EOF'\n{stderr_text}\nEOF\nexit 0\n");
+        let path = dir.join("fake-ffmpeg");
+        std::fs::write(&path, script).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_duration_parses_ffmpeg_stderr_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg(
+            dir.path(),
+            "Input #0, mov,mp4,m4a, from 'x.mp4':\n  Duration: 00:01:02.75, start: 0.000000, bitrate: 5000 kb/s\n",
+        );
+        let secs = probe_duration_sec(&ffmpeg, "x.mp4").await;
+        assert_eq!(secs, Some(62.75));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_duration_missing_line_yields_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg(dir.path(), "no duration info here\n");
+        assert!(probe_duration_sec(&ffmpeg, "x.mp4").await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_audio_bitrate_takes_audio_line_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg(
+            dir.path(),
+            "  Duration: 00:01:02.75, start: 0.000000, bitrate: 5000 kb/s\n  Stream #0:1[0x2](und): Audio: aac (LC), 44100 Hz, stereo, fltp, 192 kb/s\n",
+        );
+        // The Video line's 5000 kb/s must NOT win; the Audio line's 192 does.
+        assert_eq!(probe_audio_bitrate_kbps(&ffmpeg, "x.mp4").await, Some(192));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_audio_bitrate_na_falls_back_to_preceding_number() {
+        // Why: pins ACTUAL behavior — for "N/A kb/s" the parser grabs the
+        // last all-digit token before "kb/s" (the sample rate 44100), NOT
+        // None as the doc comment on parse_trailing_kbps claims. Kept as-is
+        // in this refactor PR; flagged for a follow-up fix decision.
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg(
+            dir.path(),
+            "  Stream #0:1: Audio: flac, 44100 Hz, stereo, N/A kb/s\n",
+        );
+        assert_eq!(
+            probe_audio_bitrate_kbps(&ffmpeg, "x.mp4").await,
+            Some(44100)
+        );
+    }
 }

--- a/src-tauri/src/utils/secure_storage.rs
+++ b/src-tauri/src/utils/secure_storage.rs
@@ -57,68 +57,22 @@ impl Default for EncryptedFileStorage {
 
 impl SecureStorage for EncryptedFileStorage {
     fn save(&self, app: &AppHandle, session: &Session) -> Result<()> {
-        let json = serde_json::to_vec(session)
-            .map_err(|e| format!("Failed to serialize session: {}", e))?;
-
-        let key = derive_key()?;
-        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-        let cipher = Aes256Gcm::new_from_slice(&key)
-            .map_err(|e| format!("Failed to create cipher: {}", e))?;
-
-        let ciphertext = cipher
-            .encrypt(&nonce, json.as_ref())
-            .map_err(|e| format!("Encryption failed: {}", e))?;
-
-        let mut blob = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
-        blob.extend_from_slice(&nonce);
-        blob.extend_from_slice(&ciphertext);
-
         let path = session_file_path(app);
-        fs::write(&path, &blob).map_err(|e| format!("Failed to write session file: {}", e))?;
-
-        set_file_permissions(&path);
-
-        log::info!("[BE] secure_storage::save: wrote {} bytes", blob.len());
-        Ok(())
+        let key = derive_key()?;
+        save_at(&path, session, &key)
     }
 
     fn load(&self, app: &AppHandle) -> Result<Option<Session>> {
         let path = session_file_path(app);
+        // Why: check existence BEFORE deriving the key — argon2id costs
+        // ~64 MiB / hundreds of ms, and most launches (logged-out or fresh
+        // install) have no session file at all. Also keeps hostname::get()
+        // failures from turning a "no session" result into an error.
         if !path.exists() {
             return Ok(None);
         }
-
-        let blob = fs::read(&path).map_err(|e| format!("Failed to read session file: {}", e))?;
-
-        if blob.len() <= NONCE_SIZE {
-            log::warn!("[BE] secure_storage::load: file too short, treating as empty");
-            return Ok(None);
-        }
-
-        let (nonce_bytes, ciphertext) = blob.split_at(NONCE_SIZE);
-        let nonce = Nonce::from_slice(nonce_bytes);
-
         let key = derive_key()?;
-        let cipher = Aes256Gcm::new_from_slice(&key)
-            .map_err(|e| format!("Failed to create cipher: {}", e))?;
-
-        let plaintext = match cipher.decrypt(nonce, ciphertext) {
-            Ok(p) => p,
-            Err(e) => {
-                log::warn!(
-                    "[BE] secure_storage::load: decryption failed ({}), \
-                     treating as no session",
-                    e
-                );
-                return Ok(None);
-            }
-        };
-
-        let session: Session = serde_json::from_slice(&plaintext)
-            .map_err(|e| format!("Failed to deserialize session: {}", e))?;
-
-        log::info!("[BE] secure_storage::load: session loaded successfully");
-        Ok(Some(session))
+        load_at(&path, &key)
     }
 
     fn delete(&self, app: &AppHandle) -> Result<()> {
@@ -133,18 +87,79 @@ impl SecureStorage for EncryptedFileStorage {
     }
 }
 
-/// Derives a 256-bit encryption key using argon2id.
+/// Writes an encrypted session blob to `path` using the given key.
 ///
-/// The key material is derived from:
-/// - **Password**: `"bilibili-dl-session:{USER}"` (or `USERNAME` on Windows)
-/// - **Salt**: `"bilibili-dl:{hostname}:{user}"`
+/// Split out of `SecureStorage::save` so tests can exercise the
+/// encrypt/decrypt round-trip against a tempfile without an AppHandle.
+fn save_at(path: &Path, session: &Session, key: &[u8; 32]) -> Result<()> {
+    let json =
+        serde_json::to_vec(session).map_err(|e| format!("Failed to serialize session: {}", e))?;
+
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let cipher =
+        Aes256Gcm::new_from_slice(key).map_err(|e| format!("Failed to create cipher: {}", e))?;
+
+    let ciphertext = cipher
+        .encrypt(&nonce, json.as_ref())
+        .map_err(|e| format!("Encryption failed: {}", e))?;
+
+    let mut blob = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+    blob.extend_from_slice(&nonce);
+    blob.extend_from_slice(&ciphertext);
+
+    fs::write(path, &blob).map_err(|e| format!("Failed to write session file: {}", e))?;
+
+    set_file_permissions(path);
+
+    log::info!("[BE] secure_storage::save: wrote {} bytes", blob.len());
+    Ok(())
+}
+
+/// Reads and decrypts a session blob from `path` using the given key.
 ///
-/// Argon2 parameters: 64 MiB memory, 3 iterations, 4 parallelism.
+/// Returns `Ok(None)` for a missing file, a too-short blob, or a failed
+/// decryption (e.g. key mismatch after hostname/user change) — callers
+/// treat all of these as "no stored session".
+fn load_at(path: &Path, key: &[u8; 32]) -> Result<Option<Session>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let blob = fs::read(path).map_err(|e| format!("Failed to read session file: {}", e))?;
+
+    if blob.len() <= NONCE_SIZE {
+        log::warn!("[BE] secure_storage::load: file too short, treating as empty");
+        return Ok(None);
+    }
+
+    let (nonce_bytes, ciphertext) = blob.split_at(NONCE_SIZE);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let cipher =
+        Aes256Gcm::new_from_slice(key).map_err(|e| format!("Failed to create cipher: {}", e))?;
+
+    let plaintext = match cipher.decrypt(nonce, ciphertext) {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!(
+                "[BE] secure_storage::load: decryption failed ({}), \
+                 treating as no session",
+                e
+            );
+            return Ok(None);
+        }
+    };
+
+    let session: Session = serde_json::from_slice(&plaintext)
+        .map_err(|e| format!("Failed to deserialize session: {}", e))?;
+
+    log::info!("[BE] secure_storage::load: session loaded successfully");
+    Ok(Some(session))
+}
+
+/// Derives a 256-bit encryption key using argon2id from the machine identity.
 ///
-/// # Errors
-///
-/// Returns an error if the hostname cannot be resolved or argon2
-/// parameter construction / hashing fails.
+/// See [`derive_key_from`] for the derivation inputs.
 fn derive_key() -> Result<[u8; 32]> {
     let host = hostname::get()
         .map_err(|e| format!("Failed to get hostname: {}", e))?
@@ -155,6 +170,23 @@ fn derive_key() -> Result<[u8; 32]> {
         .or_else(|_| std::env::var("USERNAME"))
         .unwrap_or_else(|_| "unknown".to_string());
 
+    derive_key_from(&host, &user)
+}
+
+/// Derives a 256-bit argon2id key from an explicit host/user pair.
+///
+/// The key material is derived from:
+/// - **Password**: `"bilibili-dl-session:{user}"`
+/// - **Salt**: `"bilibili-dl:{host}:{user}"`
+///
+/// Argon2 parameters: 64 MiB memory, 3 iterations, 4 parallelism.
+/// Host and user are injected as parameters (rather than read from the
+/// environment) so tests can derive keys deterministically.
+///
+/// # Errors
+///
+/// Returns an error if argon2 parameter construction or hashing fails.
+fn derive_key_from(host: &str, user: &str) -> Result<[u8; 32]> {
     let password = format!("bilibili-dl-session:{}", user);
     let salt_input = format!("bilibili-dl:{}:{}", host, user);
 
@@ -199,3 +231,93 @@ fn set_file_permissions(path: &Path) {
 /// Windows uses ACLs; the file inherits the user's permissions by default.
 #[cfg(not(unix))]
 fn set_file_permissions(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Keep the argon2 call count low: each derivation costs ~64 MiB / ~300ms.
+    // Deriving once per test run and reusing via std::sync::LazyLock keeps the
+    // suite fast while still exercising real key derivation.
+    fn test_key() -> [u8; 32] {
+        static KEY: std::sync::OnceLock<[u8; 32]> = std::sync::OnceLock::new();
+        *KEY.get_or_init(|| derive_key_from("test-host", "test-user").unwrap())
+    }
+
+    fn sample_session() -> Session {
+        Session {
+            sessdata: "sess".into(),
+            bili_jct: "jct".into(),
+            dede_user_id: "42".into(),
+            dede_user_id_ck_md5: "md5".into(),
+            refresh_token: "rt".into(),
+            timestamp: 1700000000,
+            uname: "tester".into(),
+            buvid3: "b3".into(),
+            buvid4: "b4".into(),
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".session.enc");
+        let key = test_key();
+
+        save_at(&path, &sample_session(), &key).unwrap();
+        let loaded = load_at(&path, &key).unwrap().expect("session roundtrips");
+        assert_eq!(loaded.sessdata, "sess");
+        assert_eq!(loaded.bili_jct, "jct");
+        assert_eq!(loaded.timestamp, 1700000000);
+    }
+
+    #[test]
+    fn wrong_key_yields_none_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".session.enc");
+
+        save_at(&path, &sample_session(), &test_key()).unwrap();
+        let other_key = derive_key_from("other-host", "other-user").unwrap();
+        // GCM auth failure is surfaced as "no session", not an error
+        assert!(load_at(&path, &other_key).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_file_yields_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never.existed");
+        assert!(load_at(&path, &test_key()).unwrap().is_none());
+    }
+
+    #[test]
+    fn truncated_blob_yields_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".session.enc");
+        // <= NONCE_SIZE bytes cannot contain nonce + ciphertext
+        std::fs::write(&path, vec![0u8; NONCE_SIZE]).unwrap();
+        assert!(load_at(&path, &test_key()).unwrap().is_none());
+    }
+
+    #[test]
+    fn derive_key_is_deterministic_and_input_sensitive() {
+        let a1 = derive_key_from("host-a", "user").unwrap();
+        let a2 = derive_key_from("host-a", "user").unwrap();
+        assert_eq!(a1, a2, "same inputs derive the same key");
+
+        let b = derive_key_from("host-b", "user").unwrap();
+        assert_ne!(a1, b, "different host derives a different key");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn saved_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".session.enc");
+        save_at(&path, &sample_session(), &test_key()).unwrap();
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "session file must be 0o600");
+    }
+}

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -456,49 +456,100 @@ fn available_monitors(app: &AppHandle) -> Vec<tauri::Monitor> {
     app.available_monitors().unwrap_or_default()
 }
 
-/// Returns true if the given logical dimensions are at least as large as some
-/// monitor's work area — i.e. the size corresponds to a maximized window, not
-/// a normal user-chosen size.
+/// A monitor's geometry in logical coordinates plus its work-area size.
 ///
-/// Why: maximize() can dispatch its Resized event before is_maximized() flips
-/// to true, so without this guard a maximized window would be persisted with
-/// work-area-sized bounds as the "normal" geometry, corrupting the real normal
-/// size. It also self-heals store entries written that way by older versions.
-fn is_maximize_sized(app: &AppHandle, width: f64, height: f64) -> bool {
-    available_monitors(app).iter().any(|m| {
-        let work = m.work_area();
+/// Extracted from the AppHandle-coupled checks so the geometry math is
+/// unit-testable without a running window manager.
+#[derive(Debug, Clone, Copy)]
+struct MonitorRect {
+    /// Monitor origin in logical coordinates
+    x: f64,
+    y: f64,
+    /// Full monitor size in logical coordinates
+    w: f64,
+    h: f64,
+    /// Work-area (menu-bar/taskbar excluded) size in logical coordinates
+    work_w: f64,
+    work_h: f64,
+}
+
+impl MonitorRect {
+    /// Physical-px tolerance for window-manager borders (see
+    /// `position_on_screen`); converted to logical per monitor scale.
+    const OFFSCREEN_MARGIN_PHYSICAL_PX: f64 = 16.0;
+
+    fn from_tauri(m: &tauri::Monitor) -> Self {
         let scale = m.scale_factor();
-        let work_w = work.size.width as f64 / scale;
-        let work_h = work.size.height as f64 / scale;
-        width >= work_w && height >= work_h
-    })
+        let pos = m.position();
+        let size = m.size();
+        let work = m.work_area();
+        Self {
+            x: pos.x as f64 / scale,
+            y: pos.y as f64 / scale,
+            w: size.width as f64 / scale,
+            h: size.height as f64 / scale,
+            work_w: work.size.width as f64 / scale,
+            work_h: work.size.height as f64 / scale,
+        }
+    }
+
+    /// True when the given logical dimensions are at least as large as this
+    /// monitor's work area — i.e. the size corresponds to a maximized window,
+    /// not a normal user-chosen size.
+    ///
+    /// Why: maximize() can dispatch its Resized event before is_maximized()
+    /// flips to true, so without this guard a maximized window would be
+    /// persisted with work-area-sized bounds as the "normal" geometry,
+    /// corrupting the real normal size. It also self-heals store entries
+    /// written that way by older versions.
+    fn maximize_sized(&self, width: f64, height: f64) -> bool {
+        width >= self.work_w && height >= self.work_h
+    }
+
+    /// True when the given logical coordinates fall within this monitor,
+    /// allowing a small negative-direction margin.
+    fn contains_point(&self, scale: f64, x: f64, y: f64) -> bool {
+        // Why: Windows has an invisible resize border (~7 physical px), so a
+        // window snapped to the screen's left/top edge reports a slightly
+        // negative outer_position. Strictly rejecting that marks the saved
+        // geometry as "offscreen" and falls back to defaults, losing both
+        // size and position restore (surfaces after Win+arrow snap or
+        // un-maximize). Allow a small physical-px margin in the negative
+        // direction to tolerate this.
+        let margin = Self::OFFSCREEN_MARGIN_PHYSICAL_PX / scale;
+        x >= self.x - margin && x < self.x + self.w && y >= self.y - margin && y < self.y + self.h
+    }
+
+    /// True when the given logical dimensions fit within this monitor.
+    fn fits(&self, width: f64, height: f64) -> bool {
+        width <= self.w && height <= self.h
+    }
+}
+
+/// Converts the app's monitors into logical-coordinate rects.
+fn monitor_rects(app: &AppHandle) -> Vec<MonitorRect> {
+    available_monitors(app)
+        .iter()
+        .map(MonitorRect::from_tauri)
+        .collect()
+}
+
+/// Returns true if the given logical dimensions are at least as large as some
+/// monitor's work area — see [`MonitorRect::maximize_sized`] for the rationale.
+fn is_maximize_sized(app: &AppHandle, width: f64, height: f64) -> bool {
+    monitor_rects(app)
+        .iter()
+        .any(|m| m.maximize_sized(width, height))
 }
 
 /// Checks whether the given logical coordinates fall within any monitor's bounds.
-///
-/// Converts physical monitor positions/sizes to logical coordinates using
-/// each monitor's scale factor before performing the hit test.
 fn is_position_on_screen(app: &AppHandle, x: f64, y: f64) -> bool {
-    // Why: Windows has an invisible resize border (~7 physical px), so a
-    // window snapped to the screen's left/top edge reports a slightly negative
-    // outer_position. Strictly rejecting that marks the saved geometry as
-    // "offscreen" and falls back to defaults, losing both size and position
-    // restore (surfaces after Win+arrow snap or un-maximize). Allow a small
-    // physical-px margin in the negative direction to tolerate this.
-    const OFFSCREEN_MARGIN_PHYSICAL_PX: f64 = 16.0;
+    // The margin conversion needs the per-monitor scale; approximating with
+    // the rect's own scale keeps the math pure (scale is only used for the
+    // border-tolerance conversion, not for the stored logical bounds).
     available_monitors(app).iter().any(|m| {
-        let pos = m.position();
-        let size = m.size();
-        let scale = m.scale_factor();
-        let mx = pos.x as f64 / scale;
-        let my = pos.y as f64 / scale;
-        let mw = size.width as f64 / scale;
-        let mh = size.height as f64 / scale;
-        // Why: ~7px border in physical pixels; allow 16 physical px (covers
-        // high-DPI scales) converted to logical per monitor.
-        let margin = OFFSCREEN_MARGIN_PHYSICAL_PX / scale;
-
-        x >= mx - margin && x < mx + mw && y >= my - margin && y < my + mh
+        let rect = MonitorRect::from_tauri(m);
+        rect.contains_point(m.scale_factor(), x, y)
     })
 }
 
@@ -507,12 +558,64 @@ fn is_position_on_screen(app: &AppHandle, x: f64, y: f64) -> bool {
 /// Used to prevent restoring a window size that would be larger than
 /// all connected monitors (e.g., after disconnecting an external display).
 fn fits_on_any_monitor(app: &AppHandle, width: f64, height: f64) -> bool {
-    available_monitors(app).iter().any(|m| {
-        let size = m.size();
-        let scale = m.scale_factor();
-        let mw = size.width as f64 / scale;
-        let mh = size.height as f64 / scale;
+    monitor_rects(app).iter().any(|m| m.fits(width, height))
+}
 
-        width <= mw && height <= mh
-    })
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor(x: f64, y: f64, w: f64, h: f64, work_w: f64, work_h: f64) -> MonitorRect {
+        MonitorRect {
+            x,
+            y,
+            w,
+            h,
+            work_w,
+            work_h,
+        }
+    }
+
+    #[test]
+    fn maximize_sized_compares_against_work_area() {
+        let m = monitor(0.0, 0.0, 1920.0, 1080.0, 1920.0, 1040.0);
+        // Exactly work-area sized -> treated as maximized
+        assert!(m.maximize_sized(1920.0, 1040.0));
+        assert!(m.maximize_sized(2000.0, 1100.0), "oversized counts too");
+        // Normal user sizes stay below the work area
+        assert!(!m.maximize_sized(1919.0, 1040.0));
+        assert!(!m.maximize_sized(1920.0, 1039.0));
+    }
+
+    #[test]
+    fn contains_point_allows_negative_border_margin() {
+        let scale = 2.0;
+        let m = monitor(0.0, 0.0, 1920.0, 1080.0, 1920.0, 1040.0);
+        // 16 physical px at scale 2 -> 8 logical px of tolerance
+        assert!(m.contains_point(scale, -7.9, 0.0), "snap border tolerated");
+        assert!(
+            !m.contains_point(scale, -8.1, 0.0),
+            "beyond margin rejected"
+        );
+        assert!(m.contains_point(scale, 100.0, 100.0));
+        assert!(!m.contains_point(scale, 2000.0, 100.0));
+    }
+
+    #[test]
+    fn contains_point_uses_strict_upper_bound() {
+        let m = monitor(0.0, 0.0, 100.0, 100.0, 100.0, 100.0);
+        // Right/bottom edges are exclusive
+        assert!(!m.contains_point(1.0, 100.0, 0.0));
+        assert!(!m.contains_point(1.0, 0.0, 100.0));
+        assert!(m.contains_point(1.0, 99.9, 99.9));
+    }
+
+    #[test]
+    fn fits_checks_full_monitor_size() {
+        let m = monitor(0.0, 0.0, 1920.0, 1080.0, 1920.0, 1040.0);
+        assert!(m.fits(1920.0, 1080.0), "full size fits");
+        assert!(m.fits(800.0, 600.0));
+        assert!(!m.fits(1921.0, 1080.0));
+        assert!(!m.fits(1920.0, 1081.0));
+    }
 }


### PR DESCRIPTION
## Summary

R4 of the Rust test-coverage plan: **behavior-preserving extraction refactors** that create testable seams in modules previously coupled to `AppHandle` / the filesystem / wall-clock time, plus +40 tests (200 → 240).

### Extractions (each original function now delegates)

- **history_store**: `search` → pure `filter_entries(entries, query, filters)`
- **updater**: duplicated sort+render logic from both fetchers → shared `format_releases_markdown`
- **qr_login**: `extract_cookies_from_response(&Response)` → `parse_set_cookie_values(&[String])` (raw Set-Cookie values, no Response dependency)
- **secure_storage**: split into `derive_key_from(host, user)` / `save_at` / `load_at`; `load()` keeps the file-existence check **before** key derivation so logged-out launches skip the ~64 MiB argon2 cost (regression caught in review and fixed)
- **window**: `MonitorRect` struct (`maximize_sized` / `contains_point` / `fits`) backing the three geometry checks
- **emits**: `std::time::Instant` → `tokio::time::Instant` (identical monotonic behavior in production; dev-only `test-util` enables paused-clock tests), `send_progress_locked` generic over `tauri::Runtime` for `mock_app` tests

### New tests

Paused-time progress emission via `tauri::test::mock_app` + `#[tokio::test(start_paused = true)]` (idle rate zeroing #534, rate recompute window, 100% cap), Firefox `profiles.ini` tempfile fixtures (Install priority, Default=1 order independence), encrypted session roundtrip incl. 0o600 permission, Set-Cookie last-wins parsing, RSA-OAEP correspond-path properties, fake-ffmpeg probe scripts, MonitorRect geometry tables.

Also pins the actual `parse_trailing_kbps` behavior for `N/A kb/s` lines (picks the preceding numeric token, contradicting its doc comment) with a Why note — fix decision deferred to a follow-up.

## Testing

`cargo test`: 240 passed / 0 failed. `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build` green. Review pass verified each extraction byte-equivalent to its original (error strings, sort stability, filter semantics, margin math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)