### PR TITLE
test: add frontend test infrastructure with coverage scoping and shared utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,13 @@ jobs:
         if: steps.cache-nm-test.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Run tests
+      - name: Run tests with coverage
+        # Why coverage run: the vitest.config.ts line threshold ratchets
+        # coverage per PR; a plain run would not enforce it
         if: hashFiles('**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx') != ''
         run: |
           if grep -q '"test"' package.json; then
-            npm test -- --run
+            npm run test:coverage
           else
             echo "No test script defined in package.json, skipping tests."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ references/
 
 # Playwright MCP artifacts
 .playwright-mcp/
+# Vitest coverage output (npm run test:coverage)
+coverage/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config([
-  globalIgnores(['dist', 'src-tauri/target', 'e2e-tests']),
+  globalIgnores(['dist', 'src-tauri/target', 'e2e-tests', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format:check": "prettier --check .",
     "test": "vitest",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-beta.2",

--- a/src/__tests__/integration/history.integration.test.ts
+++ b/src/__tests__/integration/history.integration.test.ts
@@ -1,13 +1,9 @@
 import * as historyApi from '@/features/history/api/historyApi'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
-}))
-
-import { invoke } from '@tauri-apps/api/core'
-
-const mockInvoke = invoke as unknown as ReturnType<typeof vi.fn>
+// invoke is mocked globally by src/test/setup.ts; mockInvoke is re-exported
+// by the shared test toolkit.
+import { mockInvoke } from '@/test/test-utils'
 
 describe('History Integration Tests', () => {
   beforeEach(() => {

--- a/src/features/concat/ui/ConcatForm.test.tsx
+++ b/src/features/concat/ui/ConcatForm.test.tsx
@@ -8,10 +8,6 @@ vi.mock('../hooks/useConcat', () => ({
   useConcat: vi.fn(),
 }))
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}))
-
 /**
  * Builds a `useConcat` return value with sensible defaults, overlaid with
  * the given per-test overrides. Keeps each test focused on the state it

--- a/src/features/settings/hooks/useFontSizeShortcuts.test.tsx
+++ b/src/features/settings/hooks/useFontSizeShortcuts.test.tsx
@@ -15,9 +15,10 @@ vi.mock('@/shared/ui/toast', () => ({
   toast: { info: (...args: unknown[]) => toastInfo(...args) },
 }))
 
-// i18next is not initialized in unit tests; stub `t` (and the default
-// `i18n` instance used by `@/i18n`) so we can assert the toast message
-// shape without booting the full i18n pipeline.
+// Why local i18next mock (not the centralized one): this test proves the
+// computed size REACHES `t` — the centralized identity-t returns the bare
+// key regardless of opts, which would silently pass if the hook dropped
+// the { size } argument. The `:size` suffix makes that regression fail.
 vi.mock('i18next', () => {
   const t = (key: string, opts?: Record<string, unknown>) =>
     opts && typeof opts.size === 'number' ? `${key}:${opts.size}` : key

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,16 @@
 import '@testing-library/jest-dom'
 
 // Mock Tauri APIs
-import { vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
+
+// Reset the in-memory Tauri event bus between tests: the registry is
+// module-global, and a test that discards its unlisten() would otherwise
+// leak listeners into later tests in the same file.
+import { clearTauriEvents } from './tauriEvents'
+
+afterEach(() => {
+  clearTauriEvents()
+})
 
 // Mock @tauri-apps/api/core
 vi.mock('@tauri-apps/api/core', () => ({
@@ -15,6 +24,53 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   error: vi.fn(),
   debug: vi.fn(),
   trace: vi.fn(),
+}))
+
+// Mock @tauri-apps/api/event with an in-memory event bus. The factory is
+// hoisted above imports, so the bus module is loaded lazily to keep the
+// registry shared with `emitTauriEvent` used by tests.
+vi.mock('@tauri-apps/api/event', async () => {
+  const { addTauriEventListener } = await import('./tauriEvents')
+  return {
+    listen: vi.fn(
+      async (name: string, handler: (e: { payload: unknown }) => void) =>
+        addTauriEventListener(name, handler as never),
+    ),
+    emit: vi.fn(async () => {}),
+  }
+})
+
+// Mock @tauri-apps/plugin-dialog. Defaults model "user cancelled"
+// (null/false) so tests opt in to a concrete choice explicitly.
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn().mockResolvedValue(null),
+  save: vi.fn().mockResolvedValue(null),
+  confirm: vi.fn().mockResolvedValue(false),
+  message: vi.fn().mockResolvedValue(undefined),
+  ask: vi.fn().mockResolvedValue(false),
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  writeTextFile: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+  openPath: vi.fn().mockResolvedValue(undefined),
+  revealItemInDir: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  exit: vi.fn().mockResolvedValue(undefined),
+  relaunch: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Mock @tauri-apps/api/window. useTaskbarProgress and
@@ -46,4 +102,50 @@ vi.mock('@tauri-apps/api/window', () => ({
   },
 }))
 
-console.log('Tauri APIs mocked successfully')
+// Centralized i18n mock. Identity `t` (returns the key) is the established
+// assertion style (tests assert raw keys like 'concat.concat'); `{{var}}`
+// interpolation is supported for the few components that use it. Both
+// `react-i18next` and the raw `i18next` singleton are stubbed because
+// ListenerContext calls `i18n.t` on the `@/i18n` import directly.
+const { i18nT } = vi.hoisted(() => ({
+  i18nT: (key: string, opts?: Record<string, unknown>) =>
+    Object.entries(opts ?? {}).reduce(
+      (s, [k, v]) => s.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v)),
+      key,
+    ),
+}))
+
+vi.mock('i18next', async (requireActual) => {
+  // Keep the real module shape (default export etc.) for type compat.
+  const actual = await requireActual<typeof import('i18next')>()
+  const instance = {
+    t: i18nT,
+    language: 'en',
+    isInitialized: true,
+    changeLanguage: vi.fn(),
+    use: () => ({ init: () => instance }),
+  }
+  return { ...actual, ...instance, default: instance }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: i18nT,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  I18nextProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+// happy-dom has no WAAPI; motion components call element.animate at mount.
+// ponytail: no-op polyfill; replace only if a test needs animation state.
+if (!Element.prototype.animate) {
+  Object.defineProperty(Element.prototype, 'animate', {
+    value: () => ({
+      finished: Promise.resolve(),
+      cancel: () => {},
+      commitStyles: () => {},
+    }),
+    configurable: true,
+  })
+}

--- a/src/test/tauriEvents.ts
+++ b/src/test/tauriEvents.ts
@@ -1,0 +1,49 @@
+/**
+ * In-memory event bus backing the `@tauri-apps/api/event` mock.
+ *
+ * `vi.mock` factories are hoisted above top-level imports, so the bus
+ * module must be imported lazily inside the factory (see setup.ts).
+ *
+ * Tests dispatch backend events via `emitTauriEvent` and assert listener
+ * detachment by emitting after unmount and observing no state change.
+ */
+
+export type TauriEventHandler = (event: {
+  event: string
+  payload: unknown
+  id: number
+  windowLabel: string
+}) => void
+
+const registry = new Map<string, Set<TauriEventHandler>>()
+let nextId = 0
+
+/** Dispatches a Tauri event to all registered listeners. */
+export function emitTauriEvent(name: string, payload: unknown): void {
+  const handlers = registry.get(name)
+  if (!handlers) return
+  for (const handler of handlers) {
+    handler({ event: name, payload, id: nextId++, windowLabel: 'main' })
+  }
+}
+
+/** Removes every registered listener (call in `afterEach` for isolation). */
+export function clearTauriEvents(): void {
+  registry.clear()
+}
+
+/** Registers a listener; returns its unlisten function like the real API. */
+export function addTauriEventListener(
+  name: string,
+  handler: TauriEventHandler,
+): () => void {
+  let handlers = registry.get(name)
+  if (!handlers) {
+    handlers = new Set()
+    registry.set(name, handlers)
+  }
+  handlers.add(handler)
+  return () => {
+    registry.get(name)?.delete(handler)
+  }
+}

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,0 +1,59 @@
+/**
+ * Shared render utilities for component/hook tests.
+ *
+ * Conventions established by the existing best-in-repo tests
+ * (useDownloadCompletionNotifications / useFontSizeShortcuts):
+ * - the REAL singleton store from `@/app/store` is used, seeded via
+ *   `store.dispatch(...)` and asserted via `store.getState()`
+ * - MemoryRouter is always on: 5 non-page files (shared layouts,
+ *   NavigationSidebarHeader, usePendingDownload, QRCodeDisplay) call
+ *   useNavigate/useLocation, so conditional routing is a
+ *   flag nobody would remember to set
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import { render, renderHook } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactElement, ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+import type { Mock } from 'vitest'
+
+import { store } from '@/app/store'
+
+/** The single `vi.fn` created by src/test/setup.ts — re-exported for ergonomics. */
+export const mockInvoke = invoke as unknown as Mock
+
+/** Wrapper for `renderHook` against the real singleton store. */
+export function storeWrapper({ children }: { children: ReactNode }) {
+  return <Provider store={store}>{children}</Provider>
+}
+
+/** `renderHook` + the real store, returned together for dispatch/assert. */
+export function renderHookWithStore<T>(callback: () => T) {
+  return { ...renderHook(callback, { wrapper: storeWrapper }), store }
+}
+
+type RenderOptions = { route?: string }
+
+/**
+ * Render with the real store + MemoryRouter. Returns `user` pre-configured
+ * (userEvent.setup) for interaction tests.
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = '/' }: RenderOptions = {},
+) {
+  return {
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+      </Provider>,
+    ),
+    store,
+    user: userEvent.setup(),
+  }
+}
+
+// Re-export the Tauri event helpers so a single import covers the toolkit.
+export { clearTauriEvents, emitTauriEvent } from './tauriEvents'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,32 @@ export default defineConfig({
     exclude: ['node_modules', 'dist'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json-summary', 'lcov', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        // Vendored UI kits (installed via npx shadcn, never hand-edited)
+        'src/components/**',
+        'src/shared/animate-ui/**',
+        'src/hooks/**',
+        'src/lib/**',
+        // Splash WebGL — happy-dom has no WebGL context
+        'src/features/splash/lib/createScene.ts',
+        'src/features/splash/hooks/useThreeScene.ts',
+        // App bootstrap / config (exercised via E2E)
+        'src/main.tsx',
+        'src/i18n/**',
+        // Tests themselves + vitest defaults (include/exclude are not
+        // merged when overridden, so defaults must be restated)
+        'src/**/*.test.*',
+        'src/test/**',
+        '**/node_modules/**',
+        'dist/**',
+        'coverage/**',
+        '**/*.d.ts',
+      ],
+      // Ratchet baseline; bump per PR, 100 at the end of the F-series.
+      // Lines only: v8 branch/function metrics on TSX are noisy.
+      thresholds: { lines: 15 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

F1 of the frontend test-coverage plan. **No production code touched**; all 177 existing tests keep passing.

- **Coverage scoping** (`vitest.config.ts`): app code only — vendored kits (`src/components`, `shared/animate-ui`, `hooks`, `lib`), splash WebGL, `main.tsx`, `i18n`, and test files excluded; vitest defaults restated because overridden include/exclude are not merged. Lines threshold **15** (measured 15.36 baseline) ratchets up per F-series PR to 100. Lines-only: v8 branch/function metrics on TSX are noisy
- **CI gate**: the test job now runs `npm run test:coverage`, so the threshold fails PRs that drop coverage
- **Mock surface** (`src/test/setup.ts`): in-memory Tauri event bus behind `@tauri-apps/api/event` (`emitTauriEvent`/`clearTauriEvents`, auto-reset in `afterEach`), 6 remaining plugin mocks (dialog/fs/opener/process/updater/shell), centralized i18n mocks (identity `t` with `{{var}}` interpolation, both `i18next` and `react-i18next`), `Element.animate` polyfill for happy-dom
- **Shared utils** (`src/test/test-utils.tsx`): `renderWithProviders` (real singleton store + MemoryRouter + userEvent), `renderHookWithStore`, `mockInvoke` re-export
- **Migration**: 3 existing tests drop their local mocks; the font-size test deliberately keeps its local `key:size` mock (proves the computed size reaches `t`, which the identity mock cannot)
- `coverage/` output ignored in ESLint + `.gitignore`

## Testing

`npm run test:coverage`: 177 passed / 4 skipped, threshold met (15.36% ≥ 15). `npm run lint`, `npm run typecheck`, `npm run build`, `prettier --check .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)