### PR TITLE
test: add slice, api and schema suites with locale parity gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,9 @@ npx shadcn@latest add <component>
 - **IMPORTANT**: When adding or changing a key in any language file,
   apply the same change to **all 6 languages
   (`en`/`ja`/`zh`/`ko`/`es`/`fr`)**. Adding to only some languages causes
-  runtime errors. Verify:
-
-  ```bash
-  for f in src/i18n/locales/*.json; do echo "$f: $(grep -c '":' "$f")"; done
-  ```
+  runtime errors. Enforced automatically by
+  `src/i18n/locales.test.ts` (full key-set parity vs `en.json`, reports
+  exact missing/extra keys per language) — run `npm test` to verify.
 
 - Map backend `ERR::*` error codes to translation keys (e.g.,
   `ERR::VIDEO_NOT_FOUND` → `video.video_not_found`)

--- a/src/features/concat/lib/validation.test.ts
+++ b/src/features/concat/lib/validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateConcatFiles } from './validation'
+
+describe('validateConcatFiles', () => {
+  it('rejects an empty file list', () => {
+    expect(validateConcatFiles([])).toBe('no_files')
+  })
+
+  it('rejects a single file', () => {
+    expect(validateConcatFiles(['/a.mp4'])).toBe('single_file')
+  })
+
+  it('rejects duplicate paths', () => {
+    expect(validateConcatFiles(['/a.mp4', '/b.mp4', '/a.mp4'])).toBe(
+      'duplicate_paths',
+    )
+  })
+
+  it('accepts two or more unique paths', () => {
+    expect(validateConcatFiles(['/a.mp4', '/b.mp4'])).toBeNull()
+    expect(validateConcatFiles(['/a.mp4', '/b.mp4', '/c.mp4'])).toBeNull()
+  })
+})

--- a/src/features/download-status/model/downloadStatusDialogSlice.test.ts
+++ b/src/features/download-status/model/downloadStatusDialogSlice.test.ts
@@ -1,0 +1,60 @@
+/**
+ * downloadStatusDialogSlice unit suite.
+ *
+ * Dispatches against the real singleton store and asserts on
+ * `store.getState().downloadStatusDialog`. The slice keeps
+ * `activeParentId` across close/reopen cycles so the same download
+ * status is redisplayed.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  closeDownloadStatusDialog,
+  openDownloadStatusDialog,
+  setActiveDownloadStatusParent,
+} from './downloadStatusDialogSlice'
+
+const initialState = { dialogOpen: false, activeParentId: null }
+
+function dialog() {
+  return store.getState().downloadStatusDialog
+}
+
+beforeEach(() => {
+  store.dispatch(closeDownloadStatusDialog())
+  store.dispatch(setActiveDownloadStatusParent(null))
+})
+
+describe('downloadStatusDialogSlice', () => {
+  it('opens without a payload and leaves activeParentId untouched', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    store.dispatch(openDownloadStatusDialog())
+
+    expect(dialog()).toEqual({ dialogOpen: true, activeParentId: 'parent-1' })
+  })
+
+  it('open with a payload pins the displayed parent', () => {
+    store.dispatch(openDownloadStatusDialog('parent-2'))
+    expect(dialog()).toEqual({ dialogOpen: true, activeParentId: 'parent-2' })
+  })
+
+  it('closing keeps activeParentId for the next reopen', () => {
+    store.dispatch(openDownloadStatusDialog('parent-1'))
+    store.dispatch(closeDownloadStatusDialog())
+
+    expect(dialog()).toEqual({ dialogOpen: false, activeParentId: 'parent-1' })
+
+    store.dispatch(openDownloadStatusDialog())
+    expect(dialog()).toEqual({ dialogOpen: true, activeParentId: 'parent-1' })
+  })
+
+  it('setActiveDownloadStatusParent switches or clears the target', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-9'))
+    expect(dialog().activeParentId).toBe('parent-9')
+
+    store.dispatch(setActiveDownloadStatusParent(null))
+    expect(dialog()).toEqual(initialState)
+  })
+})

--- a/src/features/download-status/model/selectors.test.ts
+++ b/src/features/download-status/model/selectors.test.ts
@@ -1,0 +1,345 @@
+/**
+ * download-status selectors unit suite.
+ *
+ * Dispatches against the real singleton store (queue + progress + dialog
+ * slices) and asserts selector output. The sibling
+ * src/__tests__/unit/downloadStatusSelectors.test.ts covers
+ * selectOverallSummary.elapsedSeconds only — this file covers parent
+ * resolution, per-part rows, and the summary counts/ratios.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { initPartInputs, resetInput } from '@/features/video/model/inputSlice'
+import { clearProgress, setProgress } from '@/shared/progress/progressSlice'
+import type { QueueItem } from '@/shared/queue/queueSlice'
+import { clearQueue, enqueue } from '@/shared/queue/queueSlice'
+import type { Progress } from '@/shared/ui/Progress'
+import { setActiveDownloadStatusParent } from './downloadStatusDialogSlice'
+import {
+  selectDownloadStatusDialogOpen,
+  selectDownloadStatusDialogState,
+  selectOverallSummary,
+  selectPartStatusRows,
+  selectResolvedParentId,
+} from './selectors'
+
+type Status = NonNullable<QueueItem['status']>
+
+function queueItem(
+  downloadId: string,
+  overrides: Partial<QueueItem> = {},
+): QueueItem {
+  return { downloadId, status: 'pending' as Status, ...overrides }
+}
+
+/** Seeds a parent and its children; children drive parent aggregation. */
+function seedFamily(
+  parentId: string,
+  children: Array<{ id: string; status: Status }>,
+) {
+  store.dispatch(enqueue(queueItem(parentId)))
+  children.forEach(({ id, status }) =>
+    store.dispatch(enqueue(queueItem(id, { parentId, status }))),
+  )
+}
+
+const baseProgress: Progress = {
+  downloadId: '',
+  deltaTime: 0,
+  filesize: 0,
+  downloaded: 0,
+  transferRate: 0,
+  percentage: 0,
+  elapsedTime: 0,
+  isComplete: false,
+}
+
+function seedProgress(overrides: Partial<Progress>) {
+  store.dispatch(setProgress({ ...baseProgress, ...overrides }))
+}
+
+beforeEach(() => {
+  store.dispatch(clearQueue())
+  store.dispatch(clearProgress())
+  store.dispatch(resetInput())
+  store.dispatch(setActiveDownloadStatusParent(null))
+})
+
+describe('dialog state selectors', () => {
+  it('expose the raw slice state and dialogOpen flag', () => {
+    expect(selectDownloadStatusDialogState(store.getState())).toEqual({
+      dialogOpen: false,
+      activeParentId: null,
+    })
+    expect(selectDownloadStatusDialogOpen(store.getState())).toBe(false)
+  })
+})
+
+describe('selectResolvedParentId', () => {
+  it('falls back to the most recently enqueued parent', () => {
+    seedFamily('parent-1', [{ id: 'parent-1-p1', status: 'done' }])
+    seedFamily('parent-2', [{ id: 'parent-2-p1', status: 'running' }])
+
+    expect(selectResolvedParentId(store.getState())).toBe('parent-2')
+  })
+
+  it('dedupes repeated parentIds across children', () => {
+    seedFamily('parent-1', [
+      { id: 'parent-1-p1', status: 'done' },
+      { id: 'parent-1-p2', status: 'running' },
+    ])
+
+    expect(selectResolvedParentId(store.getState())).toBe('parent-1')
+  })
+
+  it('respects an explicit activeParentId even when absent from the queue', () => {
+    seedFamily('parent-1', [{ id: 'parent-1-p1', status: 'done' }])
+    store.dispatch(setActiveDownloadStatusParent('ghost-parent'))
+
+    expect(selectResolvedParentId(store.getState())).toBe('ghost-parent')
+  })
+
+  it('returns null with an empty queue and no explicit parent', () => {
+    expect(selectResolvedParentId(store.getState())).toBeNull()
+  })
+})
+
+describe('selectPartStatusRows', () => {
+  it('returns an empty array when no parent can be resolved', () => {
+    expect(selectPartStatusRows(store.getState())).toEqual([])
+  })
+
+  it('sorts rows by partIndex and skips downloadIds without a -pN suffix', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    store.dispatch(enqueue(queueItem('parent-1')))
+    store.dispatch(enqueue(queueItem('parent-1-p2', { parentId: 'parent-1' })))
+    store.dispatch(enqueue(queueItem('parent-1-p1', { parentId: 'parent-1' })))
+    // Stray child of another parent and a malformed sibling id are excluded
+    store.dispatch(enqueue(queueItem('parent-2-p1', { parentId: 'parent-2' })))
+    store.dispatch(enqueue(queueItem('parent-1-px', { parentId: 'parent-1' })))
+
+    const rows = selectPartStatusRows(store.getState())
+
+    expect(rows.map((r) => r.downloadId)).toEqual([
+      'parent-1-p1',
+      'parent-1-p2',
+    ])
+    expect(rows.map((r) => r.partIndex)).toEqual([1, 2])
+  })
+
+  it('takes titles from partInputs (0-based) with Part N fallback', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    store.dispatch(
+      initPartInputs([
+        {
+          cid: 1,
+          page: 1,
+          title: 'Episode One',
+          videoQuality: '80',
+          audioQuality: '30216',
+          selected: true,
+          duration: 60,
+        },
+      ]),
+    )
+    seedFamily('parent-1', [
+      { id: 'parent-1-p1', status: 'running' },
+      { id: 'parent-1-p2', status: 'running' },
+    ])
+
+    const rows = selectPartStatusRows(store.getState())
+
+    expect(rows[0].title).toBe('Episode One')
+    expect(rows[1].title).toBe('Part 2')
+  })
+
+  it('renders zeroed rows for children without progress entries', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    store.dispatch(enqueue(queueItem('parent-1')))
+    // Undefined status must fall back to 'pending'
+    store.dispatch(enqueue({ downloadId: 'parent-1-p1', parentId: 'parent-1' }))
+
+    const [row] = selectPartStatusRows(store.getState())
+
+    expect(row).toMatchObject({
+      status: 'pending',
+      percentage: 0,
+      audio: null,
+      video: null,
+      merge: null,
+      isRetrying: false,
+      // pickStageData's empty branch omits stage entirely
+      stage: undefined,
+      isComplete: false,
+    })
+  })
+
+  it('averages audio/video/merge percentages and infers 100 for stages passed', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [{ id: 'parent-1-p1', status: 'running' }])
+    // video already finished (no live entry) while merge is at 80:
+    // videoPct falls back to 100 because merge exists.
+    seedProgress({ downloadId: 'parent-1-p1', stage: 'audio', percentage: 50 })
+    seedProgress({ downloadId: 'parent-1-p1', stage: 'merge', percentage: 80 })
+
+    const [row] = selectPartStatusRows(store.getState())
+
+    expect(row.percentage).toBeCloseTo((50 + 100 + 80) / 3)
+    expect(row.audio).toEqual({ percentage: 50, transferRate: 0 })
+    expect(row.video).toBeNull()
+    expect(row.merge).toEqual({ percentage: 80, transferRate: 0 })
+    expect(row.stage).toBe('merge')
+    expect(row.isComplete).toBe(false)
+  })
+
+  it('ORs isRetrying across the audio/video/merge stages', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [{ id: 'parent-1-p1', status: 'running' }])
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'audio',
+      percentage: 10,
+      isRetrying: false,
+    })
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'video',
+      percentage: 20,
+      isRetrying: true,
+    })
+
+    const [row] = selectPartStatusRows(store.getState())
+
+    expect(row.isRetrying).toBe(true)
+    expect(row.stage).toBe('download')
+  })
+
+  it('prefers merge over the lingering subtitle entry for the stage label', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [{ id: 'parent-1-p1', status: 'running' }])
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'subtitle',
+      percentage: 100,
+      isComplete: true,
+    })
+    seedProgress({ downloadId: 'parent-1-p1', stage: 'merge', percentage: 5 })
+
+    const [row] = selectPartStatusRows(store.getState())
+
+    // The complete subtitle entry must not win: it is never cleared, so
+    // treating it as terminal would skip the merge stage entirely.
+    expect(row.stage).toBe('merge')
+    expect(row.isComplete).toBe(false)
+  })
+
+  it('forces status done for a cancelled child whose file is complete', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    store.dispatch(enqueue(queueItem('parent-1')))
+    store.dispatch(
+      enqueue(
+        queueItem('parent-1-p1', { parentId: 'parent-1', status: 'cancelled' }),
+      ),
+    )
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'complete',
+      percentage: 100,
+      isComplete: true,
+    })
+
+    const [row] = selectPartStatusRows(store.getState())
+
+    expect(row).toMatchObject({
+      status: 'done',
+      stage: 'complete',
+      isComplete: true,
+      percentage: 100,
+    })
+  })
+})
+
+describe('selectOverallSummary counts and ratio', () => {
+  it('excludes cancelled parts from totals and reports them separately', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [
+      { id: 'parent-1-p1', status: 'running' },
+      { id: 'parent-1-p2', status: 'pending' },
+      { id: 'parent-1-p3', status: 'done' },
+      { id: 'parent-1-p4', status: 'error' },
+      { id: 'parent-1-p5', status: 'cancelled' },
+      { id: 'parent-1-p6', status: 'cancelled' },
+    ])
+
+    const summary = selectOverallSummary(store.getState())
+
+    expect(summary).toMatchObject({
+      totalParts: 4,
+      completedCount: 1,
+      errorCount: 1,
+      cancelledCount: 2,
+      activeCount: 2,
+      hasActive: true,
+    })
+  })
+
+  it('averages done as 1 and running as percentage/100 over active parts', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [
+      { id: 'parent-1-p1', status: 'done' },
+      { id: 'parent-1-p2', status: 'running' },
+      { id: 'parent-1-p3', status: 'cancelled' },
+    ])
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'complete',
+      percentage: 100,
+      isComplete: true,
+    })
+    // (0 + 0 + 0)/3 = 0 for the running part — audio/video/merge all at 0
+    seedProgress({ downloadId: 'parent-1-p2', stage: 'audio', percentage: 0 })
+
+    const summary = selectOverallSummary(store.getState())
+
+    // done=1, running=(0+0+0)/3=0 → (1 + 0) / 2 non-cancelled parts
+    expect(summary.overallRatio).toBe(0.5)
+  })
+
+  it('flags isMerging only for a running part in the merge stage', () => {
+    store.dispatch(setActiveDownloadStatusParent('parent-1'))
+    seedFamily('parent-1', [
+      { id: 'parent-1-p1', status: 'running' },
+      { id: 'parent-1-p2', status: 'running' },
+    ])
+    seedProgress({ downloadId: 'parent-1-p1', stage: 'merge', percentage: 10 })
+
+    expect(selectOverallSummary(store.getState()).isMerging).toBe(true)
+
+    // A merged-but-done part no longer blocks cancel-all
+    seedProgress({
+      downloadId: 'parent-1-p1',
+      stage: 'complete',
+      percentage: 100,
+      isComplete: true,
+    })
+    expect(selectOverallSummary(store.getState()).isMerging).toBe(false)
+  })
+
+  it('returns zeroed summary when no rows exist', () => {
+    const summary = selectOverallSummary(store.getState())
+
+    expect(summary).toMatchObject({
+      totalParts: 0,
+      completedCount: 0,
+      errorCount: 0,
+      cancelledCount: 0,
+      activeCount: 0,
+      hasActive: false,
+      isMerging: false,
+      overallRatio: 0,
+      elapsedSeconds: 0,
+    })
+  })
+})

--- a/src/features/favorite/api/favoriteApi.test.ts
+++ b/src/features/favorite/api/favoriteApi.test.ts
@@ -1,0 +1,96 @@
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchFavoriteFolders, fetchFavoriteVideos } from './favoriteApi'
+
+const mockFolders = [
+  { id: 1, title: 'Default', mediaCount: 10, upper: null },
+  {
+    id: 2,
+    title: 'Tutorial',
+    mediaCount: 3,
+    upper: { mid: 42, name: 'uploader', face: 'https://face.img' },
+  },
+]
+
+describe('fetchFavoriteFolders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with fetch_favorite_folders command and mid', async () => {
+    mockInvoke.mockResolvedValue(mockFolders)
+
+    const result = await fetchFavoriteFolders(42)
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_favorite_folders', {
+      mid: 42,
+    })
+    expect(result).toEqual(mockFolders)
+  })
+
+  it('should return empty array when user has no folders', async () => {
+    mockInvoke.mockResolvedValue([])
+
+    await expect(fetchFavoriteFolders(42)).resolves.toEqual([])
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue('ERR::UNAUTHORIZED')
+
+    await expect(fetchFavoriteFolders(42)).rejects.toBe('ERR::UNAUTHORIZED')
+  })
+})
+
+describe('fetchFavoriteVideos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with fetch_favorite_videos command and pagination args', async () => {
+    const response = {
+      videos: [
+        {
+          id: 100,
+          bvid: 'BV1xx411c7XD',
+          title: 'Fav video',
+          cover: 'https://cover.img',
+          duration: 120,
+          page: 1,
+          upper: { mid: 1, name: 'up', face: 'https://face.img' },
+          attr: 0,
+          playCount: 1000,
+          collectCount: 10,
+          link: 'https://www.bilibili.com/video/BV1xx411c7XD',
+        },
+      ],
+      hasMore: false,
+      totalCount: 1,
+    }
+    mockInvoke.mockResolvedValue(response)
+
+    const result = await fetchFavoriteVideos(2, 1, 20)
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_favorite_videos', {
+      mediaId: 2,
+      pageNum: 1,
+      pageSize: 20,
+    })
+    expect(result).toEqual(response)
+  })
+
+  it('should return empty list when folder has no videos', async () => {
+    const empty = { videos: [], hasMore: false, totalCount: 0 }
+    mockInvoke.mockResolvedValue(empty)
+
+    await expect(fetchFavoriteVideos(2, 1, 20)).resolves.toEqual(empty)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Cookie missing'))
+
+    await expect(fetchFavoriteVideos(2, 1, 20)).rejects.toThrow(
+      'Cookie missing',
+    )
+  })
+})

--- a/src/features/favorite/model/favoriteSlice.test.ts
+++ b/src/features/favorite/model/favoriteSlice.test.ts
@@ -1,0 +1,166 @@
+/**
+ * favoriteSlice unit suite.
+ *
+ * Dispatches against the real singleton store and asserts on
+ * `store.getState().favorite`. reset restores the initial state in
+ * beforeEach.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { FavoriteFolder, FavoriteVideo } from '../types'
+import {
+  appendVideos,
+  reset,
+  setCurrentPage,
+  setError,
+  setFolders,
+  setFoldersLoading,
+  setLoading,
+  setSelectedFolder,
+  setVideos,
+} from './favoriteSlice'
+
+const initialState = {
+  folders: [],
+  selectedFolderId: null,
+  videos: [],
+  hasMore: false,
+  totalCount: 0,
+  currentPage: 1,
+  loading: false,
+  foldersLoading: false,
+  error: null,
+}
+
+const folder = (id: number, title: string): FavoriteFolder => ({
+  id,
+  title,
+  mediaCount: id,
+})
+
+const video = (id: number, bvid: string): FavoriteVideo => ({
+  id,
+  bvid,
+  title: `Video ${id}`,
+  cover: `https://example.com/${bvid}.jpg`,
+  duration: 60,
+  page: 1,
+  upper: { mid: 1, name: 'upper', face: 'https://example.com/face.jpg' },
+  attr: 0,
+  playCount: 100,
+  collectCount: 10,
+  link: `https://www.bilibili.com/video/${bvid}`,
+})
+
+function favorite() {
+  return store.getState().favorite
+}
+
+beforeEach(() => {
+  store.dispatch(reset())
+})
+
+describe('folders', () => {
+  it('setFolders stores the list and clears foldersLoading', () => {
+    store.dispatch(setFoldersLoading(true))
+    store.dispatch(setFolders([folder(1, 'Default'), folder(2, 'Later')]))
+
+    expect(favorite()).toMatchObject({
+      folders: [folder(1, 'Default'), folder(2, 'Later')],
+      foldersLoading: false,
+    })
+  })
+})
+
+describe('setSelectedFolder', () => {
+  it('resets pagination state and starts loading the new folder', () => {
+    store.dispatch(
+      setVideos({ videos: [video(1, 'BV1')], hasMore: true, totalCount: 30 }),
+    )
+    store.dispatch(setCurrentPage(3))
+
+    store.dispatch(setSelectedFolder(2))
+
+    expect(favorite()).toMatchObject({
+      selectedFolderId: 2,
+      videos: [],
+      currentPage: 1,
+      hasMore: false,
+      loading: true,
+    })
+  })
+})
+
+describe('video pagination', () => {
+  it('setVideos replaces the list and finishes loading', () => {
+    store.dispatch(setLoading(true))
+    store.dispatch(
+      setVideos({ videos: [video(1, 'BV1')], hasMore: true, totalCount: 30 }),
+    )
+
+    expect(favorite()).toMatchObject({
+      videos: [video(1, 'BV1')],
+      hasMore: true,
+      totalCount: 30,
+      loading: false,
+    })
+  })
+
+  it('appendVideos extends the list in order and advances the page', () => {
+    store.dispatch(
+      setVideos({ videos: [video(1, 'BV1')], hasMore: true, totalCount: 30 }),
+    )
+    store.dispatch(setLoading(true))
+
+    store.dispatch(
+      appendVideos({
+        videos: [video(2, 'BV2'), video(3, 'BV3')],
+        hasMore: false,
+        totalCount: 30,
+      }),
+    )
+
+    expect(favorite().videos.map((v) => v.id)).toEqual([1, 2, 3])
+    expect(favorite()).toMatchObject({
+      currentPage: 2,
+      hasMore: false,
+      loading: false,
+    })
+  })
+
+  it('setCurrentPage and setLoading are independent toggles', () => {
+    store.dispatch(setCurrentPage(5))
+    store.dispatch(setLoading(true))
+    expect(favorite()).toMatchObject({ currentPage: 5, loading: true })
+  })
+})
+
+describe('setError', () => {
+  it('records the error and clears both loading flags', () => {
+    store.dispatch(setLoading(true))
+    store.dispatch(setFoldersLoading(true))
+
+    store.dispatch(setError('ERR::NETWORK'))
+
+    expect(favorite()).toMatchObject({
+      error: 'ERR::NETWORK',
+      loading: false,
+      foldersLoading: false,
+    })
+  })
+})
+
+describe('reset', () => {
+  it('restores the initial state after browsing', () => {
+    store.dispatch(setFolders([folder(1, 'Default')]))
+    store.dispatch(setSelectedFolder(1))
+    store.dispatch(
+      setVideos({ videos: [video(1, 'BV1')], hasMore: true, totalCount: 1 }),
+    )
+    store.dispatch(reset())
+
+    expect(favorite()).toEqual(initialState)
+  })
+})

--- a/src/features/history/api/historyApi.test.ts
+++ b/src/features/history/api/historyApi.test.ts
@@ -74,6 +74,14 @@ describe('historyApi', () => {
         'Failed to retrieve history: Database error',
       )
     })
+
+    it('should stringify non-Error rejections into the prefixed message', async () => {
+      mockInvoke.mockRejectedValue('ERR::DB_LOCKED')
+
+      await expect(getHistory()).rejects.toThrow(
+        'Failed to retrieve history: ERR::DB_LOCKED',
+      )
+    })
   })
 
   describe('addHistoryEntry', () => {

--- a/src/features/init/model/initSlice.test.ts
+++ b/src/features/init/model/initSlice.test.ts
@@ -1,0 +1,43 @@
+/**
+ * initSlice minimal roundtrip suite.
+ *
+ * The slice is two plain setters, so coverage is a set/restore roundtrip
+ * against the real singleton store.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { setInitiated, setProcessingFnc } from './initSlice'
+
+const initialState = { initiated: false, processingFnc: '' }
+
+function initState() {
+  return store.getState().init
+}
+
+describe('initSlice', () => {
+  beforeEach(() => {
+    store.dispatch(setInitiated(false))
+    store.dispatch(setProcessingFnc(''))
+  })
+
+  it('setInitiated flips the completion flag', () => {
+    store.dispatch(setInitiated(true))
+    expect(initState().initiated).toBe(true)
+  })
+
+  it('setProcessingFnc updates the status message', () => {
+    store.dispatch(setProcessingFnc('Checking ffmpeg...'))
+    expect(initState().processingFnc).toBe('Checking ffmpeg...')
+  })
+
+  it('restores the initial state after the startup sequence', () => {
+    store.dispatch(setProcessingFnc('Loading settings...'))
+    store.dispatch(setInitiated(true))
+    store.dispatch(setProcessingFnc(''))
+    store.dispatch(setInitiated(false))
+
+    expect(initState()).toEqual(initialState)
+  })
+})

--- a/src/features/login/api/loginApi.test.ts
+++ b/src/features/login/api/loginApi.test.ts
@@ -1,0 +1,208 @@
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  checkCookieRefresh,
+  generateQrCode,
+  getLoginMethod,
+  getLoginState,
+  loadQrSession,
+  pollQrStatus,
+  qrLogout,
+  refreshCookie,
+  setLoginMethod,
+} from './loginApi'
+
+// Shared by every describe below; mockInvoke must not leak between tests.
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('generateQrCode', () => {
+  it('should call invoke with generate_qr_code command', async () => {
+    const qr = { qrCodeImage: 'data:image/png;base64,abc', qrcodeKey: 'key1' }
+    mockInvoke.mockResolvedValue(qr)
+
+    const result = await generateQrCode()
+
+    expect(mockInvoke).toHaveBeenCalledWith('generate_qr_code')
+    expect(result).toEqual(qr)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Network error'))
+
+    await expect(generateQrCode()).rejects.toThrow('Network error')
+  })
+})
+
+describe('pollQrStatus', () => {
+  it('should call invoke with poll_qr_status command and qrcodeKey', async () => {
+    const poll = {
+      status: 'scannedWaitingConfirm' as const,
+      message: 'Confirm on your phone',
+      session: null,
+    }
+    mockInvoke.mockResolvedValue(poll)
+
+    const result = await pollQrStatus('key1')
+
+    expect(mockInvoke).toHaveBeenCalledWith('poll_qr_status', {
+      qrcodeKey: 'key1',
+    })
+    expect(result).toEqual(poll)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Poll failed'))
+
+    await expect(pollQrStatus('key1')).rejects.toThrow('Poll failed')
+  })
+})
+
+describe('qrLogout', () => {
+  it('should call invoke with qr_logout command', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+
+    await qrLogout()
+
+    expect(mockInvoke).toHaveBeenCalledWith('qr_logout')
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Logout failed'))
+
+    await expect(qrLogout()).rejects.toThrow('Logout failed')
+  })
+})
+
+describe('setLoginMethod', () => {
+  it('should call invoke with set_login_method command and method', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+
+    await setLoginMethod('qrCode')
+
+    expect(mockInvoke).toHaveBeenCalledWith('set_login_method', {
+      method: 'qrCode',
+    })
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Persist failed'))
+
+    await expect(setLoginMethod('firefox')).rejects.toThrow('Persist failed')
+  })
+})
+
+describe('getLoginMethod', () => {
+  it('should call invoke with get_login_method command', async () => {
+    mockInvoke.mockResolvedValue('firefox')
+
+    const result = await getLoginMethod()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_login_method')
+    expect(result).toBe('firefox')
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Read failed'))
+
+    await expect(getLoginMethod()).rejects.toThrow('Read failed')
+  })
+})
+
+describe('getLoginState', () => {
+  it('should call invoke with get_login_state command', async () => {
+    const state = {
+      method: 'qrCode' as const,
+      session: {
+        sessdata: 'sess',
+        biliJct: 'jct',
+        dedeUserId: '42',
+        dedeUserIdCkMd5: 'md5',
+        refreshToken: 'rt',
+        timestamp: 1700000000000,
+        uname: 'user',
+      },
+    }
+    mockInvoke.mockResolvedValue(state)
+
+    const result = await getLoginState()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_login_state')
+    expect(result).toEqual(state)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('State unavailable'))
+
+    await expect(getLoginState()).rejects.toThrow('State unavailable')
+  })
+})
+
+describe('loadQrSession', () => {
+  it('should call invoke with load_qr_session command and return restored flag', async () => {
+    mockInvoke.mockResolvedValue(true)
+
+    const result = await loadQrSession()
+
+    expect(mockInvoke).toHaveBeenCalledWith('load_qr_session')
+    expect(result).toBe(true)
+  })
+
+  it('should return false when no session was stored', async () => {
+    mockInvoke.mockResolvedValue(false)
+
+    await expect(loadQrSession()).resolves.toBe(false)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Keyring error'))
+
+    await expect(loadQrSession()).rejects.toThrow('Keyring error')
+  })
+})
+
+describe('checkCookieRefresh', () => {
+  it('should call invoke with check_cookie_refresh command', async () => {
+    const info = { refresh: true, timestamp: 1700000000000 }
+    mockInvoke.mockResolvedValue(info)
+
+    const result = await checkCookieRefresh()
+
+    expect(mockInvoke).toHaveBeenCalledWith('check_cookie_refresh')
+    expect(result).toEqual(info)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Check failed'))
+
+    await expect(checkCookieRefresh()).rejects.toThrow('Check failed')
+  })
+})
+
+describe('refreshCookie', () => {
+  it('should call invoke with refresh_cookie command', async () => {
+    const session = {
+      sessdata: 'new-sess',
+      biliJct: 'new-jct',
+      dedeUserId: '42',
+      dedeUserIdCkMd5: 'md5',
+      refreshToken: 'new-rt',
+      timestamp: 1700000000000,
+      uname: 'user',
+    }
+    mockInvoke.mockResolvedValue(session)
+
+    const result = await refreshCookie()
+
+    expect(mockInvoke).toHaveBeenCalledWith('refresh_cookie')
+    expect(result).toEqual(session)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Refresh token expired'))
+
+    await expect(refreshCookie()).rejects.toThrow('Refresh token expired')
+  })
+})

--- a/src/features/login/model/loginSlice.test.ts
+++ b/src/features/login/model/loginSlice.test.ts
@@ -1,0 +1,137 @@
+/**
+ * loginSlice unit suite.
+ *
+ * Dispatches against the real singleton store and asserts on
+ * `store.getState().login`. resetLogin restores the initial state in
+ * beforeEach.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { QrCodeStatus, Session } from '../api/loginApi'
+import {
+  clearQrCode,
+  resetLogin,
+  setError,
+  setLoginMethod,
+  setQrCode,
+  setQrLoading,
+  setQrStatus,
+  setSession,
+} from './loginSlice'
+
+const initialState = {
+  qrStatus: null,
+  qrCodeImage: null,
+  qrcodeKey: null,
+  statusMessage: '',
+  loginMethod: 'firefox',
+  session: null,
+  isQrLoading: false,
+  error: null,
+}
+
+const session: Session = {
+  sessdata: 'sess-data',
+  biliJct: 'bili-jct',
+  dedeUserId: '42',
+  dedeUserIdCkMd5: 'md5',
+  refreshToken: 'refresh',
+  timestamp: 1_700_000_000_000,
+  uname: 'tester',
+}
+
+function login() {
+  return store.getState().login
+}
+
+beforeEach(() => {
+  store.dispatch(resetLogin())
+})
+
+describe('setQrCode', () => {
+  it('stores image/key and resets poll state to a clean waitingForScan', () => {
+    // A regenerated QR must not show the previous poll's message/error.
+    store.dispatch(setQrStatus({ status: 'expired', message: 'expired!' }))
+    store.dispatch(setError('old error'))
+    store.dispatch(setQrLoading(true))
+
+    store.dispatch(setQrCode({ image: 'data:image/png;base64,abc', key: 'k1' }))
+
+    expect(login()).toMatchObject({
+      qrCodeImage: 'data:image/png;base64,abc',
+      qrcodeKey: 'k1',
+      qrStatus: 'waitingForScan',
+      statusMessage: '',
+      error: null,
+    })
+    // setQrCode deliberately leaves isQrLoading alone — only clearQrCode
+    // and setError reset it.
+    expect(login().isQrLoading).toBe(true)
+  })
+})
+
+describe('setQrStatus', () => {
+  // Typed const instead of an angle-bracket assertion (erasableSyntaxOnly).
+  const rows: [QrCodeStatus, string][] = [
+    ['scannedWaitingConfirm', 'confirm on your phone'],
+    ['success', 'logged in'],
+    ['expired', 'QR code expired'],
+    ['error', 'poll failed'],
+  ]
+
+  it.each(rows)('stores status %s with its message', (status, message) => {
+    store.dispatch(setQrStatus({ status, message }))
+    expect(login()).toMatchObject({ qrStatus: status, statusMessage: message })
+  })
+})
+
+describe('setLoginMethod / setSession / setQrLoading', () => {
+  it('switches the preferred login method', () => {
+    store.dispatch(setLoginMethod('qrCode'))
+    expect(login().loginMethod).toBe('qrCode')
+  })
+
+  it('stores and clears the session without touching qrStatus', () => {
+    store.dispatch(setQrStatus({ status: 'success', message: 'ok' }))
+    store.dispatch(setSession(session))
+    expect(login().session).toEqual(session)
+    expect(login().qrStatus).toBe('success')
+
+    store.dispatch(setSession(null))
+    expect(login().session).toBeNull()
+  })
+
+  it('tracks QR loading state', () => {
+    store.dispatch(setQrLoading(true))
+    expect(login().isQrLoading).toBe(true)
+  })
+})
+
+describe('setError', () => {
+  it('sets the error and resets the QR loading spinner', () => {
+    store.dispatch(setQrLoading(true))
+    store.dispatch(setError('QR generation failed'))
+    expect(login()).toMatchObject({
+      error: 'QR generation failed',
+      isQrLoading: false,
+    })
+  })
+})
+
+describe('clearQrCode', () => {
+  it('clears QR/session state but preserves the chosen login method', () => {
+    store.dispatch(setLoginMethod('qrCode'))
+    store.dispatch(setQrCode({ image: 'data:image/png;base64,abc', key: 'k1' }))
+    store.dispatch(
+      setQrStatus({ status: 'scannedWaitingConfirm', message: 'confirm' }),
+    )
+    store.dispatch(setQrLoading(true))
+    store.dispatch(setSession(session))
+
+    store.dispatch(clearQrCode())
+
+    expect(login()).toEqual({ ...initialState, loginMethod: 'qrCode' })
+  })
+})

--- a/src/features/resolution/lib/resolution.test.ts
+++ b/src/features/resolution/lib/resolution.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_TARGET_HEIGHT,
+  MIN_TARGET_HEIGHT,
+  RESOLUTION_HEIGHT_PRESETS,
+  getEnabledResolutions,
+  selectBestEffortResolution,
+} from './resolution'
+
+describe('getEnabledResolutions', () => {
+  it('returns all presets when the source height is unknown', () => {
+    expect(getEnabledResolutions(null)).toEqual(RESOLUTION_HEIGHT_PRESETS)
+  })
+
+  it('excludes presets taller than the source', () => {
+    expect(getEnabledResolutions(600)).toEqual([480, 360])
+  })
+
+  it('keeps the floor preset even when the source is shorter', () => {
+    expect(getEnabledResolutions(240)).toEqual([360])
+  })
+
+  it('includes all presets up to the source height', () => {
+    expect(getEnabledResolutions(720)).toEqual([720, 480, 360])
+  })
+
+  it('includes every preset when the source is very tall', () => {
+    expect(getEnabledResolutions(2160)).toEqual(RESOLUTION_HEIGHT_PRESETS)
+  })
+})
+
+describe('selectBestEffortResolution', () => {
+  it('returns the default when the source height is unknown', () => {
+    expect(selectBestEffortResolution(null)).toBe(DEFAULT_TARGET_HEIGHT)
+  })
+
+  // Why exact-match cases: a previous reverse() scan returned the SMALLEST
+  // preset instead (360 for a 4K source) — fixed to the documented
+  // "largest preset not exceeding the source" semantics.
+  it('returns the largest preset not exceeding the source height', () => {
+    expect(selectBestEffortResolution(2160)).toBe(1080)
+    expect(selectBestEffortResolution(1080)).toBe(1080)
+    expect(selectBestEffortResolution(1000)).toBe(720)
+    expect(selectBestEffortResolution(600)).toBe(480)
+  })
+
+  it('falls back to the floor when the source is shorter than every preset', () => {
+    expect(selectBestEffortResolution(240)).toBe(MIN_TARGET_HEIGHT)
+  })
+})

--- a/src/features/resolution/lib/resolution.ts
+++ b/src/features/resolution/lib/resolution.ts
@@ -65,7 +65,9 @@ export function selectBestEffortResolution(
   sourceHeight: number | null,
 ): ResolutionHeightPreset {
   if (sourceHeight === null) return DEFAULT_TARGET_HEIGHT
-  for (const preset of [...RESOLUTION_HEIGHT_PRESETS].reverse()) {
+  // Presets are stored descending, so the first preset <= sourceHeight is
+  // the largest one that does not up-scale the source.
+  for (const preset of RESOLUTION_HEIGHT_PRESETS) {
     if (preset <= sourceHeight) return preset
   }
   return MIN_TARGET_HEIGHT

--- a/src/features/settings/api/settingApi.test.ts
+++ b/src/features/settings/api/settingApi.test.ts
@@ -1,0 +1,101 @@
+import type { Settings } from '@/features/settings/type'
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  callGetCurrentLibPath,
+  callGetSettings,
+  callSetSettings,
+  callUpdateLibPath,
+} from './settingApi'
+
+const mockSettings: Settings = {
+  dlOutputPath: '/downloads',
+  language: 'en',
+}
+
+describe('callGetSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with get_settings command', async () => {
+    mockInvoke.mockResolvedValue(mockSettings)
+
+    const result = await callGetSettings()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_settings')
+    expect(result).toEqual(mockSettings)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Settings file corrupted'))
+
+    await expect(callGetSettings()).rejects.toThrow('Settings file corrupted')
+  })
+})
+
+describe('callSetSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with set_settings command and settings', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+
+    await callSetSettings(mockSettings)
+
+    expect(mockInvoke).toHaveBeenCalledWith('set_settings', {
+      settings: mockSettings,
+    })
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Disk full'))
+
+    await expect(callSetSettings(mockSettings)).rejects.toThrow('Disk full')
+  })
+})
+
+describe('callUpdateLibPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with update_lib_path command and newPath', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+
+    await callUpdateLibPath('/Volumes/ExternalDrive/MyLib')
+
+    expect(mockInvoke).toHaveBeenCalledWith('update_lib_path', {
+      newPath: '/Volumes/ExternalDrive/MyLib',
+    })
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Move failed'))
+
+    await expect(callUpdateLibPath('/bad/path')).rejects.toThrow('Move failed')
+  })
+})
+
+describe('callGetCurrentLibPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with get_current_lib_path command', async () => {
+    mockInvoke.mockResolvedValue('/app/data/lib')
+
+    const result = await callGetCurrentLibPath()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_current_lib_path')
+    expect(result).toBe('/app/data/lib')
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('No lib path'))
+
+    await expect(callGetCurrentLibPath()).rejects.toThrow('No lib path')
+  })
+})

--- a/src/features/settings/dialog/formSchema.test.ts
+++ b/src/features/settings/dialog/formSchema.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSettingsFormSchema } from './formSchema'
+
+const t = ((key: string) => key) as never
+const schema = buildSettingsFormSchema(t)
+
+const parsePath = (dlOutputPath: string) =>
+  schema.safeParse({ dlOutputPath, language: 'en' })
+
+const issueKeys = (result: ReturnType<typeof parsePath>) =>
+  result.success ? [] : result.error.issues.map((i) => i.message)
+
+describe('buildSettingsFormSchema — dlOutputPath', () => {
+  describe('valid paths', () => {
+    it.each([
+      ['/downloads'],
+      ['/home/user/Videos'],
+      ['C:\\Users\\me\\Videos'],
+      ['D:'],
+      ['relative/path'],
+    ])('accepts %s', (path) => {
+      expect(parsePath(path).success).toBe(true)
+    })
+  })
+
+  it('rejects an empty path as required', () => {
+    const result = parsePath('')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.path.required')
+  })
+
+  it('rejects paths longer than 1024 characters as too_long', () => {
+    const result = parsePath(`/${'a'.repeat(1024)}`)
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.path.too_long')
+  })
+
+  it('accepts a path of exactly 1024 characters', () => {
+    expect(parsePath(`/${'a'.repeat(1023)}`).success).toBe(true)
+  })
+
+  it('rejects control characters', () => {
+    const result = parsePath('/a\x01b')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.path.control_chars')
+  })
+
+  describe('Windows-specific rules', () => {
+    it('rejects a colon outside the drive-letter position', () => {
+      const result = parsePath('C:\\Users\\be:st')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain('validation.path.windows.colon')
+    })
+
+    it('rejects invalid Windows characters', () => {
+      const result = parsePath('C:\\Users\\me<Videos')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain(
+        'validation.path.windows.invalid_chars',
+      )
+    })
+
+    it('rejects a segment ending with a space', () => {
+      const result = parsePath('C:\\folder \\videos')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain(
+        'validation.path.windows.segment_trailing',
+      )
+    })
+
+    it('rejects a path ending with a space', () => {
+      const result = parsePath('C:\\Users\\me ')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain(
+        'validation.path.windows.path_trailing',
+      )
+    })
+
+    it('rejects a path ending with a dot', () => {
+      const result = parsePath('C:\\Users\\me.')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain(
+        'validation.path.windows.path_trailing',
+      )
+    })
+
+    it.each(['CON', 'PRN', 'AUX', 'NUL', 'COM1', 'LPT9'])(
+      'rejects the reserved device name %s as a segment',
+      (reserved) => {
+        const result = parsePath(`C:\\data\\${reserved}`)
+        expect(result.success).toBe(false)
+        expect(issueKeys(result)).toContain('validation.path.windows.reserved')
+      },
+    )
+
+    it('matches reserved names case-insensitively', () => {
+      const result = parsePath('C:\\data\\con')
+      expect(result.success).toBe(false)
+      expect(issueKeys(result)).toContain('validation.path.windows.reserved')
+    })
+
+    it('does not treat a longer name containing a reserved word as reserved', () => {
+      expect(parsePath('C:\\data\\console').success).toBe(true)
+    })
+  })
+
+  it('rejects invalid characters in a non-Windows, non-POSIX path', () => {
+    const result = parsePath('my<file')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.path.invalid_chars')
+  })
+})
+
+describe('buildSettingsFormSchema — language', () => {
+  it('accepts all supported languages', () => {
+    for (const language of ['en', 'ja', 'fr', 'es', 'zh', 'ko']) {
+      expect(
+        schema.safeParse({ dlOutputPath: '/downloads', language }).success,
+      ).toBe(true)
+    }
+  })
+
+  it('rejects an unsupported language', () => {
+    const result = schema.safeParse({
+      dlOutputPath: '/downloads',
+      language: 'xx',
+    })
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.language.required')
+  })
+})
+
+describe('buildSettingsFormSchema — libPath', () => {
+  it('is optional', () => {
+    expect(
+      schema.safeParse({ dlOutputPath: '/downloads', language: 'en' }).success,
+    ).toBe(true)
+  })
+
+  it('validates libPath with the same path rules when provided', () => {
+    const result = schema.safeParse({
+      dlOutputPath: '/downloads',
+      language: 'en',
+      libPath: '/lib\x01bad',
+    })
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.path.control_chars')
+  })
+})

--- a/src/features/sidebar/model/sidebarSlice.test.ts
+++ b/src/features/sidebar/model/sidebarSlice.test.ts
@@ -1,0 +1,29 @@
+/**
+ * sidebarSlice minimal roundtrip suite.
+ *
+ * The slice is a single boolean setter, so coverage is a toggle/restore
+ * roundtrip against the real singleton store.
+ */
+
+import { store } from '@/app/store'
+import { describe, expect, it } from 'vitest'
+
+import { setSidebarOpen } from './sidebarSlice'
+
+function sidebar() {
+  return store.getState().sidebar
+}
+
+describe('sidebarSlice', () => {
+  it('defaults to open', () => {
+    expect(sidebar()).toEqual({ sidebarOpen: true })
+  })
+
+  it('closes and reopens via setSidebarOpen', () => {
+    store.dispatch(setSidebarOpen(false))
+    expect(sidebar().sidebarOpen).toBe(false)
+
+    store.dispatch(setSidebarOpen(true))
+    expect(sidebar().sidebarOpen).toBe(true)
+  })
+})

--- a/src/features/updater/model/updaterSlice.test.ts
+++ b/src/features/updater/model/updaterSlice.test.ts
@@ -1,0 +1,135 @@
+/**
+ * updaterSlice unit suite.
+ *
+ * Dispatches against the real singleton store and asserts on
+ * `store.getState().updater`. resetUpdater restores the initial state
+ * in beforeEach.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  resetUpdater,
+  setDownloadProgress,
+  setError,
+  setIsDownloading,
+  setIsUpdateReady,
+  setReleaseNotes,
+  setShowDialog,
+  setUpdateAvailable,
+} from './updaterSlice'
+
+const initialState = {
+  updateAvailable: false,
+  latestVersion: null,
+  currentVersion: null,
+  releaseNotes: null,
+  downloadProgress: 0,
+  isDownloading: false,
+  isUpdateReady: false,
+  error: null,
+  showDialog: false,
+}
+
+function updater() {
+  return store.getState().updater
+}
+
+beforeEach(() => {
+  store.dispatch(resetUpdater())
+})
+
+describe('setUpdateAvailable', () => {
+  it('shows the dialog only when an update is available', () => {
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: 'v1.2.1',
+        currentVersion: 'v1.2.0',
+      }),
+    )
+    expect(updater()).toMatchObject({
+      updateAvailable: true,
+      latestVersion: 'v1.2.1',
+      currentVersion: 'v1.2.0',
+      showDialog: true,
+    })
+
+    store.dispatch(
+      setUpdateAvailable({
+        available: false,
+        latestVersion: null,
+        currentVersion: 'v1.2.0',
+      }),
+    )
+    expect(updater()).toMatchObject({
+      updateAvailable: false,
+      showDialog: false,
+    })
+  })
+})
+
+describe('update lifecycle setters', () => {
+  it('tracks download progress and flags', () => {
+    store.dispatch(setIsDownloading(true))
+    store.dispatch(setDownloadProgress(42.5))
+    expect(updater()).toMatchObject({
+      isDownloading: true,
+      downloadProgress: 42.5,
+    })
+
+    store.dispatch(setIsDownloading(false))
+    store.dispatch(setIsUpdateReady(true))
+    expect(updater()).toMatchObject({
+      isDownloading: false,
+      isUpdateReady: true,
+    })
+  })
+
+  it('stores release notes and error independently', () => {
+    store.dispatch(setReleaseNotes('# Changelog'))
+    expect(updater().releaseNotes).toBe('# Changelog')
+
+    store.dispatch(setError('network unreachable'))
+    expect(updater().error).toBe('network unreachable')
+
+    store.dispatch(setError(null))
+    expect(updater().error).toBeNull()
+  })
+
+  it('setShowDialog controls visibility without touching availability', () => {
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: 'v1.2.1',
+        currentVersion: 'v1.2.0',
+      }),
+    )
+    store.dispatch(setShowDialog(false))
+
+    expect(updater()).toMatchObject({
+      showDialog: false,
+      updateAvailable: true,
+    })
+  })
+})
+
+describe('resetUpdater', () => {
+  it('restores the initial state after a full update flow', () => {
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: 'v1.2.1',
+        currentVersion: 'v1.2.0',
+      }),
+    )
+    store.dispatch(setReleaseNotes('# Changelog'))
+    store.dispatch(setIsDownloading(true))
+    store.dispatch(setDownloadProgress(99))
+    store.dispatch(setError('boom'))
+    store.dispatch(resetUpdater())
+
+    expect(updater()).toEqual(initialState)
+  })
+})

--- a/src/features/user/api/fetchUser.test.ts
+++ b/src/features/user/api/fetchUser.test.ts
@@ -1,0 +1,53 @@
+import type { User } from '@/features/user/types'
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchUser } from './fetchUser'
+
+const mockUser: User = {
+  code: 0,
+  message: '0',
+  ttl: 1,
+  data: {
+    mid: 42,
+    uname: 'TestUser',
+    isLogin: true,
+    wbiImg: { imgUrl: '', subUrl: '' },
+  },
+  hasCookie: true,
+}
+
+describe('fetchUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with fetch_user command', async () => {
+    mockInvoke.mockResolvedValue(mockUser)
+
+    const result = await fetchUser()
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_user')
+    expect(result).toEqual(mockUser)
+  })
+
+  it('should return logged-out user object when cookies are unavailable', async () => {
+    const loggedOut: User = {
+      ...mockUser,
+      hasCookie: false,
+      data: { ...mockUser.data, isLogin: false, mid: undefined },
+    }
+    mockInvoke.mockResolvedValue(loggedOut)
+
+    const result = await fetchUser()
+
+    expect(result.hasCookie).toBe(false)
+    expect(result.data.isLogin).toBe(false)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue('ERR::UNAUTHORIZED')
+
+    await expect(fetchUser()).rejects.toBe('ERR::UNAUTHORIZED')
+  })
+})

--- a/src/features/video/api/downloadVideo.test.ts
+++ b/src/features/video/api/downloadVideo.test.ts
@@ -1,0 +1,184 @@
+import { store } from '@/app/store'
+import { clearQueue, enqueue } from '@/shared/queue/queueSlice'
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { downloadVideo } from './downloadVideo'
+
+const findItem = (downloadId: string) =>
+  store.getState().queue.find((q) => q.downloadId === downloadId)
+
+describe('downloadVideo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(clearQueue())
+  })
+
+  it('should enqueue, invoke download_video with full options, and mark done', async () => {
+    mockInvoke.mockResolvedValue('/downloads/My Video.mp4')
+
+    await downloadVideo(
+      'BV1xx411c7XD',
+      123456,
+      'My Video',
+      80,
+      30216,
+      'BV1xx411c7XD-1234567890-p1',
+      'BV1xx411c7XD-1234567890',
+      360,
+      'https://thumb.img',
+      1,
+      undefined,
+      undefined,
+      42,
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('download_video', {
+      options: {
+        bvid: 'BV1xx411c7XD',
+        cid: 123456,
+        filename: 'My Video',
+        quality: 80,
+        audioQuality: 30216,
+        downloadId: 'BV1xx411c7XD-1234567890-p1',
+        parentId: 'BV1xx411c7XD-1234567890',
+        durationSeconds: 360,
+        thumbnailUrl: 'https://thumb.img',
+        page: 1,
+        epId: 42,
+        subtitle: null,
+      },
+    })
+
+    const item = findItem('BV1xx411c7XD-1234567890-p1')
+    expect(item).toMatchObject({
+      outputPath: '/downloads/My Video.mp4',
+      title: 'My Video',
+      status: 'done',
+    })
+  })
+
+  it('should default optional fields when omitted', async () => {
+    mockInvoke.mockResolvedValue('/out.mp4')
+
+    await downloadVideo('BV1', 1, 'name', null, null, 'BV1-1-p1')
+
+    expect(mockInvoke).toHaveBeenCalledWith('download_video', {
+      options: {
+        bvid: 'BV1',
+        cid: 1,
+        filename: 'name',
+        quality: null,
+        audioQuality: null,
+        downloadId: 'BV1-1-p1',
+        parentId: null,
+        durationSeconds: 0,
+        thumbnailUrl: null,
+        page: null,
+        epId: null,
+        subtitle: null,
+      },
+    })
+  })
+
+  it('should filter subtitles down to the selected languages', async () => {
+    mockInvoke.mockResolvedValue('/out.mp4')
+
+    await downloadVideo(
+      'BV1',
+      1,
+      'name',
+      80,
+      30216,
+      'id-1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        mode: 'soft',
+        selectedLans: ['zh-CN'],
+      },
+      [
+        {
+          lan: 'zh-CN',
+          lanDoc: '中文',
+          subtitleUrl: 'https://s/zh.json',
+          isAi: false,
+        },
+        {
+          lan: 'en',
+          lanDoc: 'English',
+          subtitleUrl: 'https://s/en.json',
+          isAi: true,
+        },
+      ],
+    )
+
+    const options = mockInvoke.mock.calls[0][1].options
+    expect(options.subtitle).toEqual({
+      mode: 'soft',
+      selectedLans: ['zh-CN'],
+      subtitles: [
+        {
+          lan: 'zh-CN',
+          lanDoc: '中文',
+          subtitleUrl: 'https://s/zh.json',
+          isAi: false,
+        },
+      ],
+    })
+  })
+
+  it('should mark the queue item as error and rethrow on failure', async () => {
+    mockInvoke.mockRejectedValue(new Error('ERR::DISK_FULL'))
+
+    await expect(
+      downloadVideo('BV1', 1, 'name', 80, null, 'id-err'),
+    ).rejects.toThrow('ERR::DISK_FULL')
+
+    expect(findItem('id-err')).toMatchObject({
+      status: 'error',
+      errorMessage: 'ERR::DISK_FULL',
+    })
+  })
+
+  it('should not mark as error when the rejection is cancel-induced', async () => {
+    mockInvoke.mockRejectedValue('ERR::CANCELLED')
+
+    await expect(
+      downloadVideo('BV1', 1, 'name', 80, null, 'id-cancel'),
+    ).rejects.toBe('ERR::CANCELLED')
+
+    expect(findItem('id-cancel')?.status).toBe('pending')
+    expect(findItem('id-cancel')?.errorMessage).toBeUndefined()
+  })
+
+  it('should not mark child as error while its parent is cancelling', async () => {
+    // A cancelling sibling keeps the aggregated parent status 'cancelling'
+    // even after downloadVideo enqueues the child under test as pending.
+    store.dispatch(
+      enqueue({
+        downloadId: 'parent-1',
+        filename: 'parent',
+        status: 'pending',
+      }),
+    )
+    store.dispatch(
+      enqueue({
+        downloadId: 'sibling-1',
+        parentId: 'parent-1',
+        filename: 'sibling',
+        status: 'cancelling',
+      }),
+    )
+    mockInvoke.mockRejectedValue(new Error('ERR::DISK_FULL'))
+
+    await expect(
+      downloadVideo('BV1', 1, 'child', 80, null, 'child-1', 'parent-1'),
+    ).rejects.toThrow('ERR::DISK_FULL')
+
+    expect(findItem('parent-1')?.status).toBe('cancelling')
+    expect(findItem('child-1')?.status).toBe('pending')
+  })
+})

--- a/src/features/video/api/expandShortUrl.test.ts
+++ b/src/features/video/api/expandShortUrl.test.ts
@@ -1,0 +1,29 @@
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { expandShortUrl } from './expandShortUrl'
+
+describe('expandShortUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with expand_short_url command and url', async () => {
+    mockInvoke.mockResolvedValue('https://www.bilibili.com/video/BV1xx411c7XD')
+
+    const result = await expandShortUrl('https://b23.tv/BV1xx411c7XD')
+
+    expect(mockInvoke).toHaveBeenCalledWith('expand_short_url', {
+      url: 'https://b23.tv/BV1xx411c7XD',
+    })
+    expect(result).toBe('https://www.bilibili.com/video/BV1xx411c7XD')
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Redirect limit exceeded'))
+
+    await expect(expandShortUrl('https://b23.tv/invalid')).rejects.toThrow(
+      'Redirect limit exceeded',
+    )
+  })
+})

--- a/src/features/video/api/videoApi.test.ts
+++ b/src/features/video/api/videoApi.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+// Load the store before videoApi: videoApi -> tauriBaseQuery -> store/index
+// -> videoApi is a cycle that only resolves when store/index is entered
+// first (tauriBaseQuery references `store` lazily at call time).
+import '@/app/store'
+
+import { fetchContentFromUrl } from './videoApi'
+
+describe('fetchContentFromUrl', () => {
+  it('maps a video URL to video args', () => {
+    expect(
+      fetchContentFromUrl('https://www.bilibili.com/video/BV1xx411c7XD'),
+    ).toEqual({ type: 'video', id: 'BV1xx411c7XD' })
+  })
+
+  it('maps a bangumi URL to bangumi args with numeric epId', () => {
+    expect(
+      fetchContentFromUrl('https://www.bilibili.com/bangumi/play/ep3051843'),
+    ).toEqual({ type: 'bangumi', epId: 3051843 })
+  })
+
+  it('keeps the page query out of the extracted video id', () => {
+    expect(
+      fetchContentFromUrl('https://www.bilibili.com/video/BV1xx411c7XD?p=2'),
+    ).toEqual({ type: 'video', id: 'BV1xx411c7XD' })
+  })
+
+  it('returns null for a URL without video/bangumi path segments', () => {
+    expect(fetchContentFromUrl('https://example.com/watch/12345')).toBe(null)
+  })
+
+  it('returns null for a bilibili URL without a recognized content path', () => {
+    expect(fetchContentFromUrl('https://www.bilibili.com/space/12345')).toBe(
+      null,
+    )
+  })
+
+  it('returns null for an invalid URL string', () => {
+    expect(fetchContentFromUrl('not-a-url')).toBe(null)
+  })
+})

--- a/src/features/video/lib/concurrency.test.ts
+++ b/src/features/video/lib/concurrency.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { createConcurrencyLimiter } from './concurrency'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('createConcurrencyLimiter', () => {
+  it('never exceeds the configured concurrency', async () => {
+    const limiter = createConcurrencyLimiter(2)
+    let active = 0
+    let peak = 0
+
+    const tasks = Array.from({ length: 6 }, (_, i) =>
+      limiter.run(async () => {
+        active++
+        peak = Math.max(peak, active)
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        expect(active).toBeLessThanOrEqual(2)
+        active--
+        return i
+      }),
+    )
+
+    const results = await Promise.all(tasks)
+    expect(peak).toBe(2)
+    expect(results).toEqual([0, 1, 2, 3, 4, 5])
+  })
+
+  it('runs tasks sequentially with a limit of 1', async () => {
+    const limiter = createConcurrencyLimiter(1)
+    const order: number[] = []
+
+    await Promise.all(
+      Array.from({ length: 3 }, (_, i) =>
+        limiter.run(async () => {
+          order.push(i)
+        }),
+      ),
+    )
+
+    expect(order).toEqual([0, 1, 2])
+  })
+
+  it('releases the slot when a task rejects', async () => {
+    const limiter = createConcurrencyLimiter(1)
+
+    const first = limiter.run(async () => {
+      throw new Error('boom')
+    })
+    // Second task can only start once the first releases its slot.
+    const second = limiter.run(async () => 'ok')
+
+    await expect(first).rejects.toThrow('boom')
+    await expect(second).resolves.toBe('ok')
+  })
+
+  it('starts queued tasks as slots free up', async () => {
+    const limiter = createConcurrencyLimiter(1)
+    const gate = deferred<void>()
+
+    const first = limiter.run(() => gate.promise)
+    let secondStarted = false
+    const second = limiter.run(async () => {
+      secondStarted = true
+    })
+
+    await Promise.resolve()
+    expect(secondStarted).toBe(false)
+
+    gate.resolve()
+    await first
+    await second
+    expect(secondStarted).toBe(true)
+  })
+})

--- a/src/features/video/lib/formSchema.test.ts
+++ b/src/features/video/lib/formSchema.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The invalid-filename pattern is initialized once per module instance from
+// the detected OS, so schema-2 tests re-import the module per OS scenario.
+// The hoisted vi.fn survives vi.resetModules(), unlike module-level state.
+const { mockGetOs } = vi.hoisted(() => ({ mockGetOs: vi.fn() }))
+vi.mock('@/shared/os/api/getOs', () => ({ getOs: mockGetOs }))
+
+import { buildVideoFormSchema1 } from './formSchema'
+
+const t = ((key: string) => key) as never
+
+async function importFormSchema() {
+  vi.resetModules()
+  const mod = await import('./formSchema')
+  // Let the module-load initInvalidPattern() promise settle
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return mod
+}
+
+const parseUrl = (url: string) => buildVideoFormSchema1(t).safeParse({ url })
+
+const issueKeys = (result: ReturnType<typeof parseUrl>) =>
+  result.success ? [] : result.error.issues.map((i) => i.message)
+
+describe('buildVideoFormSchema1 — url', () => {
+  it.each([
+    ['https://www.bilibili.com/video/BV1xx411c7XD'],
+    ['https://www.bilibili.com/video/BV1xx411c7Xd?p=2'],
+    ['https://www.bilibili.com/bangumi/play/ep3051843'],
+    ['https://b23.tv/BV1xx411c7XD'],
+  ])('accepts %s', (url) => {
+    expect(parseUrl(url).success).toBe(true)
+  })
+
+  it('rejects a url shorter than 2 characters', () => {
+    const result = parseUrl('a')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.video.url.min')
+  })
+
+  it('rejects a url longer than 1000 characters', () => {
+    const result = parseUrl(
+      `https://www.bilibili.com/video/${'a'.repeat(1000)}`,
+    )
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.video.url.max')
+  })
+
+  it('rejects a non-URL string', () => {
+    const result = parseUrl('not-a-url')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.video.url.invalid')
+  })
+
+  it('rejects a non-bilibili domain', () => {
+    const result = parseUrl('https://example.com/video/BV1xx411c7XD')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.video.url.domain')
+  })
+
+  it('rejects a bilibili path that is neither video nor bangumi', () => {
+    const result = parseUrl('https://www.bilibili.com/space/12345')
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain('validation.video.url.format')
+  })
+
+  it.each([
+    ['https://space.bilibili.com/12345', 'validation.video.url.space'],
+    ['https://member.bilibili.com/2', 'validation.video.url.member'],
+    ['https://live.bilibili.com/6', 'validation.video.url.live'],
+    ['https://au.bilibili.com/123', 'validation.video.url.audio'],
+  ])('rejects unsupported hostname %s with a specific key', (url, key) => {
+    const result = parseUrl(url)
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain(key)
+  })
+
+  it.each([
+    [
+      'https://www.bilibili.com/bangumi/media/md123',
+      'validation.video.url.bangumi_list',
+    ],
+    ['https://www.bilibili.com/cheese/play/ep1', 'validation.video.url.cheese'],
+    ['https://www.bilibili.com/audio/au123', 'validation.video.url.audio'],
+    ['https://www.bilibili.com/read/cv123', 'validation.video.url.article'],
+  ])('rejects unsupported pathname %s with a specific key', (url, key) => {
+    const result = parseUrl(url)
+    expect(result.success).toBe(false)
+    expect(issueKeys(result)).toContain(key)
+  })
+})
+
+describe('buildVideoFormSchema2 — title (windows)', () => {
+  beforeEach(() => {
+    mockGetOs.mockReset().mockResolvedValue('windows')
+  })
+
+  async function parseTitle(title: string) {
+    const { buildVideoFormSchema2 } = await importFormSchema()
+    return buildVideoFormSchema2(t).safeParse({
+      title,
+      videoQuality: '',
+      audioQuality: '',
+    })
+  }
+
+  it('accepts a plain title', async () => {
+    expect((await parseTitle('My Video')).success).toBe(true)
+  })
+
+  it('rejects a title shorter than 2 characters', async () => {
+    const result = await parseTitle('a')
+    expect(result.success).toBe(false)
+    expect(
+      result.success ? [] : result.error.issues.map((i) => i.message),
+    ).toContain('validation.video.title.min')
+  })
+
+  it('rejects a title longer than 100 characters', async () => {
+    const result = await parseTitle('a'.repeat(101))
+    expect(result.success).toBe(false)
+    expect(
+      result.success ? [] : result.error.issues.map((i) => i.message),
+    ).toContain('validation.video.title.max')
+  })
+
+  it.each(['My:Video', 'My<Video', 'My*Video', 'My?Video', 'My|Video'])(
+    'rejects the Windows-forbidden character in %s',
+    async (title) => {
+      const result = await parseTitle(title)
+      expect(result.success).toBe(false)
+      expect(
+        result.success ? [] : result.error.issues.map((i) => i.message),
+      ).toContain('validation.video.title.invalid_chars')
+    },
+  )
+
+  it.each(['My Video.', 'My Video '])(
+    'rejects the Windows trailing dot/space in %s',
+    async (title) => {
+      const result = await parseTitle(title)
+      expect(result.success).toBe(false)
+    },
+  )
+})
+
+describe('buildVideoFormSchema2 — title (non-windows)', () => {
+  beforeEach(() => {
+    mockGetOs.mockReset().mockResolvedValue('macos')
+  })
+
+  async function parseTitle(title: string) {
+    const { buildVideoFormSchema2 } = await importFormSchema()
+    return buildVideoFormSchema2(t).safeParse({
+      title,
+      videoQuality: '',
+      audioQuality: '',
+    })
+  }
+
+  it('accepts characters that are only invalid on Windows', async () => {
+    expect((await parseTitle('My:Video')).success).toBe(true)
+    expect((await parseTitle('My Video.')).success).toBe(true)
+  })
+
+  it('still rejects a forward slash', async () => {
+    const result = await parseTitle('My/Video')
+    expect(result.success).toBe(false)
+    expect(
+      result.success ? [] : result.error.issues.map((i) => i.message),
+    ).toContain('validation.video.title.invalid_chars')
+  })
+})

--- a/src/features/video/lib/utils.test.ts
+++ b/src/features/video/lib/utils.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildVideoUrl,
+  extractContentId,
+  extractVideoId,
+  normalizeFilename,
+} from './utils'
+
+describe('extractContentId', () => {
+  it('extracts a bvid from a video URL', () => {
+    expect(
+      extractContentId('https://www.bilibili.com/video/BV1xx411c7XD'),
+    ).toEqual({ type: 'video', id: 'BV1xx411c7XD' })
+  })
+
+  it('ignores query parameters when extracting the video id', () => {
+    expect(
+      extractContentId('https://www.bilibili.com/video/BV1xx411c7XD?p=2&t=10'),
+    ).toEqual({ type: 'video', id: 'BV1xx411c7XD' })
+  })
+
+  it('extracts a numeric epId from a bangumi URL', () => {
+    expect(
+      extractContentId('https://www.bilibili.com/bangumi/play/ep3051843'),
+    ).toEqual({ type: 'bangumi', epId: '3051843' })
+  })
+
+  it('prefers the bangumi match over the video match', () => {
+    expect(
+      extractContentId('https://www.bilibili.com/bangumi/play/ep1/video/x'),
+    ).toEqual({ type: 'bangumi', epId: '1' })
+  })
+
+  it('matches regardless of hostname (pathname-only matching)', () => {
+    expect(extractContentId('https://example.com/video/BV1xx411c7XD')).toEqual({
+      type: 'video',
+      id: 'BV1xx411c7XD',
+    })
+  })
+
+  it('returns null for a URL without video/bangumi segments', () => {
+    expect(extractContentId('https://www.bilibili.com/space/12345')).toBeNull()
+  })
+
+  it('returns null for an invalid URL string', () => {
+    expect(extractContentId('not-a-url')).toBeNull()
+    expect(extractContentId('')).toBeNull()
+  })
+})
+
+describe('extractVideoId', () => {
+  it('extracts the id after /video/', () => {
+    expect(extractVideoId('https://www.bilibili.com/video/BV1xx411c7XD')).toBe(
+      'BV1xx411c7XD',
+    )
+  })
+
+  it('returns null when there is no /video/ segment', () => {
+    expect(
+      extractVideoId('https://www.bilibili.com/bangumi/play/ep1'),
+    ).toBeNull()
+  })
+
+  it('is a plain regex over the string (no URL parsing)', () => {
+    expect(extractVideoId('/video/BV1abc')).toBe('BV1abc')
+  })
+})
+
+describe('normalizeFilename', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeFilename('  My Video ')).toBe('my video')
+  })
+
+  it('strips every forbidden character', () => {
+    expect(normalizeFilename('My:Video<Part>1?')).toBe('myvideopart1')
+  })
+
+  it('strips backslashes and forward slashes', () => {
+    expect(normalizeFilename('a\\b/c')).toBe('abc')
+  })
+})
+
+describe('buildVideoUrl', () => {
+  it('omits the page query for page 1', () => {
+    expect(buildVideoUrl('BV1xx411c7XD', 1)).toBe(
+      'https://www.bilibili.com/video/BV1xx411c7XD',
+    )
+  })
+
+  it('appends ?p=N for pages after the first', () => {
+    expect(buildVideoUrl('BV1xx411c7XD', 3)).toBe(
+      'https://www.bilibili.com/video/BV1xx411c7XD?p=3',
+    )
+  })
+})

--- a/src/features/video/model/inputSlice.reducers.test.ts
+++ b/src/features/video/model/inputSlice.reducers.test.ts
@@ -1,0 +1,339 @@
+/**
+ * inputSlice reducer suite — gaps not covered by inputSlice.test.ts.
+ *
+ * The sibling inputSlice.test.ts covers subtitle config, lazy-loaded
+ * subtitles/qualities, resetInput and homePage. This file covers the
+ * selection reducers, whole-state replacement, resolved-info reducers,
+ * accordion state, and pendingDownload, against the real singleton
+ * store (the established convention).
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { PendingDownload } from '@/features/video/types'
+import {
+  clearPendingDownload,
+  clearResolvedInfo,
+  closeAllAccordions,
+  deselectAll,
+  deselectPageAll,
+  initPartInputs,
+  resetInput,
+  selectAll,
+  selectHasSelectedParts,
+  selectPageAll,
+  setAccordionOpen,
+  setInput,
+  setPartQualities,
+  setPendingDownload,
+  setResolvedQuality,
+  setResolvedSubtitle,
+  setUrl,
+  updatePartInputByIndex,
+  updatePartSelected,
+} from './inputSlice'
+
+function input() {
+  return store.getState().input
+}
+
+/** Seeds three parts; index 1 starts deselected for selection tests. */
+function seedParts() {
+  store.dispatch(
+    initPartInputs([
+      {
+        cid: 1,
+        page: 1,
+        title: 'Part 1',
+        videoQuality: '80',
+        audioQuality: '30216',
+        selected: true,
+        duration: 60,
+      },
+      {
+        cid: 2,
+        page: 2,
+        title: 'Part 2',
+        videoQuality: '80',
+        audioQuality: '30216',
+        selected: false,
+        duration: 70,
+      },
+      {
+        cid: 3,
+        page: 3,
+        title: 'Part 3',
+        videoQuality: '80',
+        audioQuality: '30216',
+        selected: true,
+        duration: 80,
+      },
+    ]),
+  )
+}
+
+beforeEach(() => {
+  store.dispatch(resetInput())
+})
+
+describe('whole-state replacement', () => {
+  it('setInput replaces the entire input state', () => {
+    const next = {
+      url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+      partInputs: [],
+      pendingDownload: { bvid: 'BV1', cid: 1, page: 1 } as PendingDownload,
+      homePage: 4,
+    }
+
+    store.dispatch(setInput(next))
+    expect(input()).toEqual(next)
+  })
+
+  it('setUrl only touches the url field', () => {
+    seedParts()
+    store.dispatch(setUrl('https://www.bilibili.com/video/BV1'))
+    expect(input().url).toBe('https://www.bilibili.com/video/BV1')
+    expect(input().partInputs).toHaveLength(3)
+  })
+})
+
+describe('part field updates', () => {
+  it('updatePartInputByIndex applies only the provided fields', () => {
+    seedParts()
+    store.dispatch(updatePartInputByIndex({ index: 0, title: 'Renamed' }))
+    store.dispatch(updatePartInputByIndex({ index: 0, videoQuality: '116' }))
+
+    expect(input().partInputs[0]).toMatchObject({
+      title: 'Renamed',
+      videoQuality: '116',
+      audioQuality: '30216', // untouched
+    })
+  })
+
+  it('updatePartInputByIndex ignores out-of-bounds indices', () => {
+    seedParts()
+    store.dispatch(updatePartInputByIndex({ index: 99, title: 'Ghost' }))
+    expect(input().partInputs).toHaveLength(3)
+    expect(input().partInputs.every((p) => p.title !== 'Ghost')).toBe(true)
+  })
+
+  it('setPartQualities applies the isPreview flag only when provided', () => {
+    seedParts()
+    store.dispatch(
+      setPartQualities({
+        index: 0,
+        videoQualities: [{ quality: '1080p', id: 80 }],
+        audioQualities: [{ quality: '64K', id: 30216 }],
+      }),
+    )
+    expect(input().partInputs[0].isPreview).toBeUndefined()
+
+    store.dispatch(
+      setPartQualities({
+        index: 0,
+        videoQualities: [{ quality: '1080p', id: 80 }],
+        audioQualities: [{ quality: '64K', id: 30216 }],
+        isPreview: true,
+      }),
+    )
+    expect(input().partInputs[0].isPreview).toBe(true)
+  })
+})
+
+describe('selection reducers', () => {
+  it('updatePartSelected toggles one part', () => {
+    seedParts()
+    store.dispatch(updatePartSelected({ index: 1, selected: true }))
+    store.dispatch(updatePartSelected({ index: 0, selected: false }))
+
+    expect(input().partInputs.map((p) => p.selected)).toEqual([
+      false,
+      true,
+      true,
+    ])
+  })
+
+  it('selectAll and deselectAll flip every part', () => {
+    seedParts()
+    store.dispatch(deselectAll())
+    expect(input().partInputs.every((p) => !p.selected)).toBe(true)
+
+    store.dispatch(selectAll())
+    expect(input().partInputs.every((p) => p.selected)).toBe(true)
+  })
+
+  it('selectPageAll/deselectPageAll apply to the inclusive range only', () => {
+    seedParts()
+    store.dispatch(deselectAll())
+    store.dispatch(selectPageAll({ startIndex: 1, endIndex: 2 }))
+    expect(input().partInputs.map((p) => p.selected)).toEqual([
+      false,
+      true,
+      true,
+    ])
+
+    store.dispatch(deselectPageAll({ startIndex: 1, endIndex: 2 }))
+    expect(input().partInputs.map((p) => p.selected)).toEqual([
+      false,
+      false,
+      false,
+    ])
+  })
+
+  it('page range reducers skip out-of-bounds indices without throwing', () => {
+    seedParts()
+    const selectedBefore = input().partInputs.map((p) => p.selected)
+
+    store.dispatch(selectPageAll({ startIndex: 5, endIndex: 9 }))
+    store.dispatch(deselectPageAll({ startIndex: 99, endIndex: 200 }))
+
+    expect(input().partInputs.map((p) => p.selected)).toEqual(selectedBefore)
+    expect(input().partInputs).toHaveLength(3)
+  })
+
+  it('selectHasSelectedParts reflects the current selection', () => {
+    expect(selectHasSelectedParts(store.getState())).toBe(false)
+
+    seedParts()
+    expect(selectHasSelectedParts(store.getState())).toBe(true)
+
+    store.dispatch(deselectAll())
+    expect(selectHasSelectedParts(store.getState())).toBe(false)
+  })
+})
+
+describe('pendingDownload', () => {
+  it('round-trips a pending download from watch history navigation', () => {
+    const pending: PendingDownload = { bvid: 'BV1xx411c7XD', cid: 123, page: 2 }
+    store.dispatch(setPendingDownload(pending))
+    expect(input().pendingDownload).toEqual(pending)
+
+    store.dispatch(clearPendingDownload())
+    expect(input().pendingDownload).toBeNull()
+  })
+})
+
+describe('accordion state', () => {
+  it('persists per-part open state and closes all at once', () => {
+    seedParts()
+    store.dispatch(setAccordionOpen({ index: 0, open: true }))
+    store.dispatch(setAccordionOpen({ index: 2, open: true }))
+
+    expect(input().partInputs.map((p) => p.accordionOpen)).toEqual([
+      true,
+      undefined,
+      true,
+    ])
+
+    store.dispatch(closeAllAccordions())
+    expect(input().partInputs.every((p) => p.accordionOpen === false)).toBe(
+      true,
+    )
+  })
+})
+
+describe('resolved info reducers', () => {
+  it('setResolvedQuality maps page (1-based) to index and stores the rest', () => {
+    seedParts()
+    store.dispatch(
+      setResolvedQuality({
+        page: 2,
+        videoQuality: 80,
+        videoQualityFallback: true,
+        videoCodecid: 7,
+        videoCodecFallback: false,
+        audioQuality: 30216,
+        audioQualityFallback: false,
+        isPreview: null,
+      }),
+    )
+
+    expect(input().partInputs[1].resolvedQuality).toEqual({
+      videoQuality: 80,
+      videoQualityFallback: true,
+      videoCodecid: 7,
+      videoCodecFallback: false,
+      audioQuality: 30216,
+      audioQualityFallback: false,
+      isPreview: null,
+    })
+    expect(input().partInputs[1].isPreview).toBeUndefined()
+  })
+
+  it('setResolvedQuality applies isPreview only when non-null', () => {
+    seedParts()
+    store.dispatch(
+      setResolvedQuality({
+        page: 1,
+        videoQuality: 80,
+        videoQualityFallback: false,
+        videoCodecid: 7,
+        videoCodecFallback: false,
+        audioQuality: null,
+        audioQualityFallback: false,
+        isPreview: true,
+      }),
+    )
+    expect(input().partInputs[0].isPreview).toBe(true)
+  })
+
+  it('setResolvedQuality ignores unknown pages', () => {
+    seedParts()
+    store.dispatch(
+      setResolvedQuality({
+        page: 99,
+        videoQuality: 80,
+        videoQualityFallback: false,
+        videoCodecid: 7,
+        videoCodecFallback: false,
+        audioQuality: null,
+        audioQualityFallback: false,
+        isPreview: false,
+      }),
+    )
+    expect(
+      input().partInputs.every((p) => p.resolvedQuality === undefined),
+    ).toBe(true)
+  })
+
+  it('setResolvedSubtitle stores mode and labels without the page', () => {
+    seedParts()
+    store.dispatch(
+      setResolvedSubtitle({
+        page: 3,
+        subtitleMode: 'soft',
+        subtitleLanguageLabels: ['zh-CN', 'en'],
+      }),
+    )
+
+    expect(input().partInputs[2].resolvedSubtitle).toEqual({
+      subtitleMode: 'soft',
+      subtitleLanguageLabels: ['zh-CN', 'en'],
+    })
+  })
+
+  it('clearResolvedInfo clears only the selected parts', () => {
+    seedParts()
+    // index 1 is deselected in the fixture — its info must survive
+    const pages = [1, 2, 3]
+    pages.forEach((page) => {
+      store.dispatch(
+        setResolvedSubtitle({
+          page,
+          subtitleMode: 'off',
+          subtitleLanguageLabels: [],
+        }),
+      )
+    })
+
+    store.dispatch(clearResolvedInfo())
+
+    expect(input().partInputs[0].resolvedSubtitle).toBeUndefined()
+    expect(input().partInputs[2].resolvedSubtitle).toBeUndefined()
+    expect(input().partInputs[1].resolvedSubtitle).toEqual({
+      subtitleMode: 'off',
+      subtitleLanguageLabels: [],
+    })
+  })
+})

--- a/src/features/video/model/selectors.test.ts
+++ b/src/features/video/model/selectors.test.ts
@@ -1,0 +1,243 @@
+/**
+ * video feature selectors unit suite.
+ *
+ * Dispatches against the real singleton store (input / settings /
+ * progress slices) and asserts selector output. `tFn` is the identity
+ * translation function — schema messages never affect pass/fail.
+ */
+
+import { store } from '@/app/store'
+import type { TFunction } from 'i18next'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { setSettings } from '@/features/settings/settingsSlice'
+import { clearProgress, setProgress } from '@/shared/progress/progressSlice'
+import type { Progress } from '@/shared/ui/Progress'
+import {
+  initPartInputs,
+  resetInput,
+  setUrl,
+  updatePartSelected,
+} from './inputSlice'
+import {
+  selectAllPartValid,
+  selectDuplicateIndices,
+  selectHasDuplicates,
+  selectIsAllValid,
+  selectIsForm1Valid,
+  selectNormalizedTitles,
+  selectParentProgress,
+} from './selectors'
+
+const t = ((key: string) => key) as TFunction
+
+function seedTitles(titles: string[], selected = true) {
+  store.dispatch(
+    initPartInputs(
+      titles.map((title, i) => ({
+        cid: i + 1,
+        page: i + 1,
+        title,
+        videoQuality: '80',
+        audioQuality: '30216',
+        selected,
+        duration: 60,
+      })),
+    ),
+  )
+}
+
+const baseProgress: Progress = {
+  downloadId: 'parent',
+  deltaTime: 0,
+  filesize: 100,
+  downloaded: 0,
+  transferRate: 0,
+  percentage: 0,
+  elapsedTime: 0,
+  isComplete: false,
+  stage: 'audio',
+}
+
+/** setSettings takes a full Settings object; spread the live one to flip a flag. */
+function setAutoRenameDuplicates(value: boolean) {
+  store.dispatch(
+    setSettings({ ...store.getState().settings, autoRenameDuplicates: value }),
+  )
+}
+
+beforeEach(() => {
+  store.dispatch(resetInput())
+  store.dispatch(clearProgress())
+  setAutoRenameDuplicates(true)
+})
+
+describe('selectNormalizedTitles', () => {
+  it('trims, lowercases and strips forbidden filename characters', () => {
+    seedTitles(['  My Video: Part 1 ', 'Test/File?'])
+    expect(selectNormalizedTitles(store.getState())).toEqual([
+      'my video part 1',
+      'testfile',
+    ])
+  })
+})
+
+describe('selectDuplicateIndices', () => {
+  it('flags every index of a duplicated group, flattened', () => {
+    seedTitles(['Intro', 'Outro', 'intro', 'OUTRO'])
+    expect(selectDuplicateIndices(store.getState()).sort()).toEqual([
+      0, 1, 2, 3,
+    ])
+  })
+
+  it('ignores unselected parts so their titles cannot block download', () => {
+    seedTitles(['Intro', 'intro', 'solo'])
+    store.dispatch(updatePartSelected({ index: 1, selected: false }))
+
+    expect(selectDuplicateIndices(store.getState())).toEqual([])
+  })
+
+  it('returns nothing when all titles are unique', () => {
+    seedTitles(['One', 'Two', 'Three'])
+    expect(selectDuplicateIndices(store.getState())).toEqual([])
+  })
+
+  it('selectHasDuplicates mirrors the index list emptiness', () => {
+    seedTitles(['A', 'a'])
+    expect(selectHasDuplicates(store.getState())).toBe(true)
+
+    store.dispatch(updatePartSelected({ index: 1, selected: false }))
+    expect(selectHasDuplicates(store.getState())).toBe(false)
+  })
+})
+
+describe('selectIsForm1Valid', () => {
+  const urlRows: [string, boolean][] = [
+    ['https://www.bilibili.com/video/BV1xx411c7XD', true],
+    ['https://www.bilibili.com/bangumi/play/ep3051843', true],
+    // b23.tv short links are expanded later in VideoForm1, so they pass here
+    ['https://b23.tv/abc123', true],
+    ['https://youtube.com/watch?v=x', false],
+    ['https://live.bilibili.com/1234', false],
+    ['not a url', false],
+    ['', false],
+  ]
+
+  it.each(urlRows)('%j validates to %s', (url, expected) => {
+    store.dispatch(setUrl(url))
+    expect(selectIsForm1Valid(t)(store.getState())).toBe(expected)
+  })
+})
+
+describe('selectAllPartValid', () => {
+  it('passes when every selected part has a valid title', () => {
+    seedTitles(['Part One', 'Part Two'])
+    expect(selectAllPartValid(t)(store.getState())).toBe(true)
+  })
+
+  it('fails when nothing is selected', () => {
+    seedTitles(['Part One'], false)
+    expect(selectAllPartValid(t)(store.getState())).toBe(false)
+  })
+
+  it('skips unselected parts — an invalid title there does not block', () => {
+    seedTitles(['Part One', 'x'])
+    store.dispatch(updatePartSelected({ index: 1, selected: false }))
+    expect(selectAllPartValid(t)(store.getState())).toBe(true)
+  })
+
+  const titleRows: [string, boolean][] = [
+    ['x', false], // below the 2-char minimum
+    ['ab/cd', false], // forbidden filename character (all platforms)
+    ['Part One', true],
+  ]
+
+  it.each(titleRows)('title %j validates to %s', (title, expected) => {
+    seedTitles([title])
+    expect(selectAllPartValid(t)(store.getState())).toBe(expected)
+  })
+})
+
+describe('selectIsAllValid', () => {
+  it('passes with unique valid titles', () => {
+    seedTitles(['Part One', 'Part Two'])
+    expect(selectIsAllValid(t)(store.getState())).toBe(true)
+  })
+
+  it('allows duplicates while autoRenameDuplicates is on (default)', () => {
+    seedTitles(['Same Title', 'same title'])
+    expect(selectIsAllValid(t)(store.getState())).toBe(true)
+  })
+
+  it('blocks duplicates when autoRenameDuplicates is off', () => {
+    seedTitles(['Same Title', 'same title'])
+    store.dispatch(
+      setSettings({
+        ...store.getState().settings,
+        autoRenameDuplicates: false,
+      }),
+    )
+    expect(selectIsAllValid(t)(store.getState())).toBe(false)
+  })
+
+  it('still blocks invalid parts regardless of auto-rename', () => {
+    seedTitles(['Part One', 'x'])
+    expect(selectIsAllValid(t)(store.getState())).toBe(false)
+  })
+})
+
+describe('selectParentProgress', () => {
+  /** Entry without byte counts; omit percentage for the stage-weight fallback. */
+  const bareEntry = (stage: string, percentage?: number) =>
+    ({
+      downloadId: 'parent',
+      stage,
+      percentage,
+      deltaTime: 0,
+      transferRate: 0,
+      elapsedTime: 0,
+      isComplete: false,
+    }) as Progress
+
+  it('weights by filesize when downloaded/filesize are numbers', () => {
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', downloaded: 30 }),
+    )
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'video', downloaded: 60 }),
+    )
+
+    // (30 + 60) / (100 + 100)
+    expect(selectParentProgress('parent')(store.getState())).toBeCloseTo(0.45)
+  })
+
+  it('falls back to the average percentage without byte counts', () => {
+    store.dispatch(setProgress(bareEntry('audio', 50)))
+    store.dispatch(setProgress(bareEntry('video', 100)))
+
+    // (50 + 100) / 2 / 100
+    expect(selectParentProgress('parent')(store.getState())).toBeCloseTo(0.75)
+  })
+
+  it('falls back to stage weights without percentage or bytes', () => {
+    // Stage-only entries: no numeric downloaded/filesize/percentage, so
+    // the coarse audio/video weighting (0.33 each) kicks in.
+    store.dispatch(setProgress(bareEntry('audio')))
+    store.dispatch(setProgress(bareEntry('video')))
+
+    // (0.33 + 0.33) / 2
+    expect(selectParentProgress('parent')(store.getState())).toBeCloseTo(0.33)
+  })
+
+  it('clamps the ratio into 0..1 and ignores other downloads', () => {
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', downloaded: 200 }),
+    )
+    store.dispatch(
+      setProgress({ ...baseProgress, downloadId: 'other', stage: 'audio' }),
+    )
+
+    expect(selectParentProgress('parent')(store.getState())).toBe(1)
+    expect(selectParentProgress('other')(store.getState())).toBe(0)
+  })
+})

--- a/src/features/video/model/videoSlice.test.ts
+++ b/src/features/video/model/videoSlice.test.ts
@@ -1,0 +1,59 @@
+/**
+ * videoSlice minimal roundtrip suite.
+ *
+ * The slice is two whole-state replacement reducers (setVideo/resetVideo),
+ * so the only meaningful coverage is a set/replace/reset roundtrip against
+ * the real singleton store.
+ */
+
+import { store } from '@/app/store'
+import { describe, expect, it } from 'vitest'
+
+import type { Video } from '@/features/video/types'
+import { resetVideo, setVideo } from './videoSlice'
+
+const video: Video = {
+  title: 'Test Video',
+  bvid: 'BV1xx411c7XD',
+  parts: [
+    {
+      part: 'Part 1',
+      page: 1,
+      cid: 123,
+      duration: 120,
+      videoQualities: [{ quality: '1080p', id: 80 }],
+      audioQualities: [{ quality: '64K', id: 30216 }],
+      thumbnail: { url: 'https://example.com/thumb.jpg' },
+      subtitles: [],
+    },
+  ],
+  isLimitedQuality: true,
+  contentType: 'bangumi',
+  epId: 3051843,
+  seasonTitle: 'Season 1',
+}
+
+function videoState() {
+  return store.getState().video
+}
+
+describe('videoSlice', () => {
+  it('setVideo replaces the whole state including optional bangumi fields', () => {
+    store.dispatch(setVideo(video))
+
+    expect(videoState()).toEqual(video)
+  })
+
+  it('resetVideo restores the initial empty state', () => {
+    store.dispatch(setVideo(video))
+    store.dispatch(resetVideo())
+
+    expect(videoState()).toEqual({
+      title: '',
+      bvid: '',
+      parts: [],
+      isLimitedQuality: false,
+      contentType: 'video',
+    })
+  })
+})

--- a/src/features/watch-history/api/fetchWatchHistory.test.ts
+++ b/src/features/watch-history/api/fetchWatchHistory.test.ts
@@ -1,0 +1,61 @@
+import type {
+  WatchHistoryCursor,
+  WatchHistoryEntry,
+} from '@/features/watch-history/types'
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchWatchHistory } from './fetchWatchHistory'
+
+const mockEntry: WatchHistoryEntry = {
+  title: 'Watched video',
+  cover: 'https://cover.img',
+  bvid: 'BV1xx411c7XD',
+  cid: 123456,
+  page: 1,
+  viewAt: 1700000000,
+  duration: 300,
+  progress: 120,
+  url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+}
+
+const mockCursor: WatchHistoryCursor = {
+  viewAt: 1700000000,
+  max: 25,
+  isEnd: false,
+}
+
+describe('fetchWatchHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with fetch_watch_history command and default pagination', async () => {
+    mockInvoke.mockResolvedValue({ entries: [mockEntry], cursor: mockCursor })
+
+    const result = await fetchWatchHistory()
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_watch_history', {
+      max: 0,
+      viewAt: 0,
+    })
+    expect(result).toEqual({ entries: [mockEntry], cursor: mockCursor })
+  })
+
+  it('should pass cursor values through for pagination', async () => {
+    mockInvoke.mockResolvedValue({ entries: [], cursor: null })
+
+    await fetchWatchHistory(25, 1700000000)
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_watch_history', {
+      max: 25,
+      viewAt: 1700000000,
+    })
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue('ERR::UNAUTHORIZED')
+
+    await expect(fetchWatchHistory(0, 0)).rejects.toBe('ERR::UNAUTHORIZED')
+  })
+})

--- a/src/features/watch-history/model/selectors.dateFilter.test.ts
+++ b/src/features/watch-history/model/selectors.dateFilter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * watch-history selectors — date filter gaps.
+ *
+ * The sibling selectors.test.ts covers live-stream exclusion and search
+ * matching. This file covers the date range filter (today/week/month),
+ * which is clock-dependent, against the real singleton store with a
+ * frozen system time.
+ */
+
+import { store } from '@/app/store'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { selectFilteredEntries } from './selectors'
+import {
+  reset,
+  setDateFilter,
+  setEntries,
+  setSearchQuery,
+} from './watchHistorySlice'
+
+/** Fixed "now" so cutoff math is deterministic: 2026-08-27T12:00:00Z */
+const NOW_MS = Date.UTC(2026, 7, 27, 12, 0, 0)
+const nowSec = NOW_MS / 1000
+
+/** viewAt offset in seconds relative to NOW (negative = past). */
+const entry = (title: string, offsetSec: number) => ({
+  title,
+  cover: 'https://example.com/c.jpg',
+  bvid: `BV-${title}`,
+  cid: 1,
+  page: 1,
+  viewAt: nowSec + offsetSec,
+  duration: 100,
+  progress: 10,
+  url: 'https://www.bilibili.com/video/BV1',
+})
+
+const HOUR = 3600
+const DAY = 24 * HOUR
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW_MS)
+  store.dispatch(reset())
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('selectFilteredEntries date filter', () => {
+  it('all keeps every non-live entry regardless of age', () => {
+    store.dispatch(
+      setEntries([entry('Recent', -HOUR), entry('Ancient', -400 * DAY)]),
+    )
+
+    expect(selectFilteredEntries(store.getState())).toHaveLength(2)
+  })
+
+  // [filter, includedOffsetSec, excludedOffsetSec]
+  const dateRows: ['today' | 'week' | 'month', number, number][] = [
+    ['today', -HOUR, -25 * HOUR],
+    ['week', -3 * DAY, -8 * DAY],
+    ['month', -20 * DAY, -40 * DAY],
+  ]
+
+  it.each(dateRows)(
+    '%s includes %is-ago and excludes %is-ago',
+    (filter, included, excluded) => {
+      store.dispatch(
+        setEntries([entry('Inside', included), entry('Outside', excluded)]),
+      )
+      store.dispatch(setDateFilter(filter))
+
+      const result = selectFilteredEntries(store.getState())
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('Inside')
+    },
+  )
+
+  it('today cutoff lands at local midnight, not a rolling 24h window', () => {
+    // Viewed yesterday 23:00 (13h before the frozen noon "now"): older than
+    // 0h but still before today 00:00, so 'today' must exclude it while
+    // 'all' keeps it.
+    const yesterdayLate = new Date(NOW_MS)
+    yesterdayLate.setHours(23, 0, 0, 0)
+    yesterdayLate.setDate(yesterdayLate.getDate() - 1)
+    const viewAt = Math.floor(yesterdayLate.getTime() / 1000)
+
+    store.dispatch(setEntries([{ ...entry('LateNight', 0), viewAt }]))
+
+    store.dispatch(setDateFilter('today'))
+    expect(selectFilteredEntries(store.getState())).toHaveLength(0)
+
+    store.dispatch(setDateFilter('all'))
+    expect(selectFilteredEntries(store.getState())).toHaveLength(1)
+  })
+
+  it('combines date filter with search and live exclusion', () => {
+    store.dispatch(
+      setEntries([
+        entry('Rust Today', -HOUR),
+        entry('Rust Long Ago', -30 * DAY),
+        { ...entry('Live Now', -HOUR), bvid: '' },
+      ]),
+    )
+    store.dispatch(setDateFilter('week'))
+    store.dispatch(setSearchQuery('rust'))
+
+    const result = selectFilteredEntries(store.getState())
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Rust Today')
+  })
+})

--- a/src/features/watch-history/model/watchHistorySlice.test.ts
+++ b/src/features/watch-history/model/watchHistorySlice.test.ts
@@ -1,0 +1,130 @@
+/**
+ * watchHistorySlice unit suite.
+ *
+ * Dispatches against the real singleton store and asserts on
+ * `store.getState().watchHistory`. reset restores the initial state in
+ * beforeEach.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { WatchHistoryEntry } from '../types'
+import {
+  appendEntries,
+  reset,
+  setCursor,
+  setDateFilter,
+  setEntries,
+  setError,
+  setLoading,
+  setLoadingMore,
+  setSearchQuery,
+} from './watchHistorySlice'
+
+const initialState = {
+  entries: [],
+  cursor: null,
+  loading: false,
+  loadingMore: false,
+  error: null,
+  searchQuery: '',
+  dateFilter: 'all',
+}
+
+const entry = (bvid: string): WatchHistoryEntry => ({
+  title: `Video ${bvid}`,
+  cover: `https://example.com/${bvid}.jpg`,
+  bvid,
+  cid: 1,
+  page: 1,
+  viewAt: 1_700_000_000,
+  duration: 100,
+  progress: 50,
+  url: `https://www.bilibili.com/video/${bvid}`,
+})
+
+function history() {
+  return store.getState().watchHistory
+}
+
+beforeEach(() => {
+  store.dispatch(reset())
+})
+
+describe('entries', () => {
+  it('setEntries replaces the list', () => {
+    store.dispatch(setEntries([entry('BV1'), entry('BV2')]))
+    store.dispatch(setEntries([entry('BV3')]))
+    expect(history().entries).toEqual([entry('BV3')])
+  })
+
+  it('appendEntries extends the list preserving order', () => {
+    store.dispatch(setEntries([entry('BV1')]))
+    store.dispatch(appendEntries([entry('BV2'), entry('BV3')]))
+    expect(history().entries.map((e) => e.bvid)).toEqual(['BV1', 'BV2', 'BV3'])
+  })
+
+  it('setCursor stores the pagination cursor or null', () => {
+    const cursor = { viewAt: 1_699_000_000, max: 1_700_000_000, isEnd: false }
+    store.dispatch(setCursor(cursor))
+    expect(history().cursor).toEqual(cursor)
+
+    store.dispatch(setCursor(null))
+    expect(history().cursor).toBeNull()
+  })
+})
+
+describe('loading and error flags', () => {
+  it('loading and loadingMore are independent flags', () => {
+    store.dispatch(setLoading(true))
+    store.dispatch(setLoadingMore(true))
+    expect(history()).toMatchObject({ loading: true, loadingMore: true })
+
+    store.dispatch(setLoading(false))
+    expect(history().loading).toBe(false)
+    expect(history().loadingMore).toBe(true)
+  })
+
+  it('setError stores and clears the error message', () => {
+    store.dispatch(setError('ERR::HISTORY_FETCH_FAILED'))
+    expect(history().error).toBe('ERR::HISTORY_FETCH_FAILED')
+
+    store.dispatch(setError(null))
+    expect(history().error).toBeNull()
+  })
+})
+
+describe('filters', () => {
+  it('setSearchQuery updates the query', () => {
+    store.dispatch(setSearchQuery('rust tutorial'))
+    expect(history().searchQuery).toBe('rust tutorial')
+  })
+
+  const dateFilters: ['all' | 'today' | 'week' | 'month'][] = [
+    ['all'],
+    ['today'],
+    ['week'],
+    ['month'],
+  ]
+
+  it.each(dateFilters)('setDateFilter accepts %s', (filter) => {
+    store.dispatch(setDateFilter(filter))
+    expect(history().dateFilter).toBe(filter)
+  })
+})
+
+describe('reset', () => {
+  it('restores the initial state after browsing', () => {
+    store.dispatch(setEntries([entry('BV1')]))
+    store.dispatch(setCursor({ viewAt: 1, max: 2, isEnd: true }))
+    store.dispatch(setLoading(true))
+    store.dispatch(setError('boom'))
+    store.dispatch(setSearchQuery('q'))
+    store.dispatch(setDateFilter('week'))
+
+    store.dispatch(reset())
+
+    expect(history()).toEqual(initialState)
+  })
+})

--- a/src/i18n/locales.test.ts
+++ b/src/i18n/locales.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Locale key-parity test.
+ *
+ * Replaces the manual bash loop documented in CLAUDE.md ("for f in
+ * src/i18n/locales/*.json; do grep -c ..."). That check only compared
+ * key COUNTS, so a locale could pass with a renamed key while missing
+ * another. This test compares the full key SET against en and reports
+ * the exact missing/extra keys per language.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import en from './locales/en.json'
+import es from './locales/es.json'
+import fr from './locales/fr.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import zh from './locales/zh.json'
+
+const locales: Record<string, object> = { ja, zh, ko, es, fr }
+
+/** Flattens nested JSON into dotted key paths ("video.part.select"). */
+function flatKeys(obj: object, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([k, v]) =>
+    typeof v === 'object' && v !== null
+      ? flatKeys(v, `${prefix}${k}.`)
+      : [`${prefix}${k}`],
+  )
+}
+
+const baseKeys = new Set(flatKeys(en))
+
+describe('locale key parity', () => {
+  it.each(Object.keys(locales))(
+    '%s.json has the same keys as en.json',
+    (lang) => {
+      const targetKeys = new Set(flatKeys(locales[lang]))
+      const missing = [...baseKeys].filter((k) => !targetKeys.has(k))
+      const extra = [...targetKeys].filter((k) => !baseKeys.has(k))
+
+      expect(
+        { missing, extra },
+        `${lang}.json is out of sync with en.json — missing keys must be added ` +
+          `to all 6 languages (see CLAUDE.md i18n rule)`,
+      ).toEqual({ missing: [], extra: [] })
+    },
+  )
+
+  it('every locale file on disk is covered by this suite', () => {
+    // Guard the guard: enumerate from the filesystem so a future locale
+    // file that someone forgets to register in `locales` above FAILS here
+    // instead of silently skipping parity.
+    const onDisk = Object.keys(import.meta.glob('./locales/*.json'))
+      .map((p) => p.match(/\.\/locales\/(.*)\.json$/)![1])
+      .filter((name) => name !== 'en')
+      .sort()
+    expect(onDisk).toEqual(Object.keys(locales).sort())
+  })
+})

--- a/src/shared/lib/githubStarsCache.test.ts
+++ b/src/shared/lib/githubStarsCache.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearCachedStars,
+  getCachedStars,
+  isCacheValid,
+  setCachedStars,
+} from './githubStarsCache'
+
+const KEY = 'github_stars_owner_repo'
+
+describe('githubStarsCache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('setCachedStars / getCachedStars', () => {
+    it('round-trips a star count', () => {
+      setCachedStars('owner', 'repo', 1234)
+
+      expect(getCachedStars('owner', 'repo')).toBe(1234)
+    })
+
+    it('returns null when nothing is cached', () => {
+      expect(getCachedStars('owner', 'repo')).toBeNull()
+    })
+
+    it('overwrites a previous entry', () => {
+      setCachedStars('owner', 'repo', 1)
+      setCachedStars('owner', 'repo', 2)
+
+      expect(getCachedStars('owner', 'repo')).toBe(2)
+    })
+
+    it('keys the cache per owner/repo pair', () => {
+      setCachedStars('owner', 'repo', 1)
+      setCachedStars('owner', 'other', 2)
+
+      expect(getCachedStars('owner', 'repo')).toBe(1)
+      expect(getCachedStars('owner', 'other')).toBe(2)
+    })
+  })
+
+  describe('cache expiry', () => {
+    it('returns the count within the 1-hour TTL', () => {
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({ count: 7, timestamp: Date.now() - 60 * 60 * 1000 }),
+      )
+
+      expect(getCachedStars('owner', 'repo')).toBe(7)
+    })
+
+    it('returns null and removes the entry after the TTL', () => {
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({
+          count: 7,
+          timestamp: Date.now() - 60 * 60 * 1000 - 1,
+        }),
+      )
+
+      expect(getCachedStars('owner', 'repo')).toBeNull()
+      expect(localStorage.getItem(KEY)).toBeNull()
+    })
+
+    it('returns null and removes the entry on corrupt JSON', () => {
+      localStorage.setItem(KEY, '{not json')
+
+      expect(getCachedStars('owner', 'repo')).toBeNull()
+      expect(localStorage.getItem(KEY)).toBeNull()
+    })
+  })
+
+  describe('isCacheValid', () => {
+    it('is true for a fresh entry and false when absent', () => {
+      expect(isCacheValid('owner', 'repo')).toBe(false)
+
+      setCachedStars('owner', 'repo', 5)
+
+      expect(isCacheValid('owner', 'repo')).toBe(true)
+    })
+  })
+
+  describe('clearCachedStars', () => {
+    it('removes the entry', () => {
+      setCachedStars('owner', 'repo', 5)
+      clearCachedStars('owner', 'repo')
+
+      expect(getCachedStars('owner', 'repo')).toBeNull()
+    })
+
+    it('is a no-op when nothing is cached', () => {
+      expect(() => clearCachedStars('owner', 'repo')).not.toThrow()
+    })
+  })
+})

--- a/src/shared/os/api/getOs.test.ts
+++ b/src/shared/os/api/getOs.test.ts
@@ -1,0 +1,68 @@
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `cached` is module-scoped, so each test re-imports a fresh module via
+// `vi.resetModules()` + dynamic import to control the cache lifetime.
+async function importGetOs() {
+  vi.resetModules()
+  return import('./getOs')
+}
+
+describe('getOs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('should call invoke with get_os command and return the raw value', async () => {
+    mockInvoke.mockResolvedValue('macos')
+    const { getOs } = await importGetOs()
+
+    const result = await getOs()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_os')
+    expect(result).toBe('macos')
+  })
+
+  it.each([
+    'windows',
+    'linux',
+    'android',
+    'ios',
+    'freebsd',
+    'dragonfly',
+    'netbsd',
+    'openbsd',
+    'solaris',
+    'unknown',
+  ] as const)('should pass through known OS %s', async (os) => {
+    mockInvoke.mockResolvedValue(os)
+    const { getOs } = await importGetOs()
+
+    await expect(getOs()).resolves.toBe(os)
+  })
+
+  it('should normalize unexpected backend values to unknown', async () => {
+    mockInvoke.mockResolvedValue('Windows_NT')
+    const { getOs } = await importGetOs()
+
+    await expect(getOs()).resolves.toBe('unknown')
+  })
+
+  it('should return unknown when invoke rejects', async () => {
+    mockInvoke.mockRejectedValue(new Error('IPC failure'))
+    const { getOs } = await importGetOs()
+
+    await expect(getOs()).resolves.toBe('unknown')
+  })
+
+  it('should cache the result and skip invoke on subsequent calls', async () => {
+    mockInvoke.mockResolvedValue('windows')
+    const { getOs } = await importGetOs()
+
+    await getOs()
+    await getOs()
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/shared/progress/progressSlice.test.ts
+++ b/src/shared/progress/progressSlice.test.ts
@@ -1,0 +1,151 @@
+/**
+ * progressSlice unit suite — identity/upsert gaps.
+ *
+ * The sibling src/__tests__/unit/progressSlice.test.ts covers the
+ * monotonic clamp, stage transitions, complete-replaces-merge, and
+ * setRetrying. This file covers internalId computation, entry identity
+ * (parentId forced to downloadId), in-place replacement, and the
+ * by-download selector, against the real singleton store.
+ */
+
+import { store } from '@/app/store'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { Progress } from '@/shared/ui/Progress'
+import {
+  clearProgress,
+  selectProgressEntriesByDownloadId,
+  setProgress,
+} from './progressSlice'
+
+const baseProgress: Progress = {
+  downloadId: 'dl-1',
+  deltaTime: 0,
+  filesize: 100,
+  downloaded: 0,
+  transferRate: 1024,
+  percentage: 0,
+  elapsedTime: 0,
+  isComplete: false,
+  stage: 'audio',
+}
+
+beforeEach(() => {
+  store.dispatch(clearProgress())
+})
+
+describe('setProgress entry identity', () => {
+  it('stores internalId as downloadId:stage and forces parentId to downloadId', () => {
+    store.dispatch(setProgress(baseProgress))
+
+    const [entry] = store.getState().progress
+    expect(entry.internalId).toBe('dl-1:audio')
+    // The slice overwrites whatever parentId the event carried so entries
+    // group by their own download; the real parent linkage lives in queue.
+    expect(entry.parentId).toBe('dl-1')
+  })
+
+  it('falls back to the bare downloadId when stage is undefined', () => {
+    store.dispatch(setProgress({ ...baseProgress, stage: undefined }))
+
+    const entries = store.getState().progress
+    expect(entries).toHaveLength(1)
+    expect(entries[0].internalId).toBe('dl-1')
+  })
+
+  it('keeps one entry per stage and replaces in place, preserving order', () => {
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', percentage: 10 }),
+    )
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'video', percentage: 20 }),
+    )
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', percentage: 30 }),
+    )
+
+    const entries = store.getState().progress
+    expect(entries.map((p) => p.internalId)).toEqual([
+      'dl-1:audio',
+      'dl-1:video',
+    ])
+    expect(entries[0].percentage).toBe(30)
+  })
+
+  it('gives complete its own entry when no merge entry exists', () => {
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', percentage: 100 }),
+    )
+    store.dispatch(
+      setProgress({
+        ...baseProgress,
+        stage: 'complete',
+        percentage: 100,
+        isComplete: true,
+      }),
+    )
+
+    const entries = store.getState().progress
+    expect(entries.map((p) => p.internalId)).toEqual([
+      'dl-1:audio',
+      'dl-1:complete',
+    ])
+  })
+
+  it('keeps downloads independent via distinct internalIds', () => {
+    store.dispatch(
+      setProgress({ ...baseProgress, stage: 'audio', percentage: 10 }),
+    )
+    store.dispatch(
+      setProgress({
+        ...baseProgress,
+        downloadId: 'dl-2',
+        stage: 'audio',
+        percentage: 90,
+      }),
+    )
+
+    const byId = Object.fromEntries(
+      store.getState().progress.map((p) => [p.downloadId, p.percentage]),
+    )
+    expect(byId).toEqual({ 'dl-1': 10, 'dl-2': 90 })
+  })
+
+  it('clamps regression even when both filesizes are undefined', () => {
+    // Stage-less events (no filesize field) still satisfy the
+    // prev.filesize === payload.filesize guard via undefined === undefined,
+    // so the monotonic clamp applies to them too.
+    // Literal omits filesize/downloaded so both compare as undefined.
+    const stageless = (percentage: number) =>
+      ({
+        downloadId: 'dl-1',
+        deltaTime: 0,
+        transferRate: 0,
+        percentage,
+        elapsedTime: 0,
+        isComplete: false,
+      }) as Progress
+    store.dispatch(setProgress(stageless(50)))
+    store.dispatch(setProgress(stageless(20)))
+
+    expect(store.getState().progress[0].percentage).toBe(50)
+  })
+})
+
+describe('selectProgressEntriesByDownloadId', () => {
+  it('returns only the entries of the requested download', () => {
+    store.dispatch(setProgress({ ...baseProgress, stage: 'audio' }))
+    store.dispatch(setProgress({ ...baseProgress, stage: 'video' }))
+    store.dispatch(
+      setProgress({ ...baseProgress, downloadId: 'dl-2', stage: 'audio' }),
+    )
+
+    const entries = selectProgressEntriesByDownloadId('dl-1')(store.getState())
+
+    expect(entries).toHaveLength(2)
+    expect(entries.every((p) => p.downloadId === 'dl-1')).toBe(true)
+    expect(
+      selectProgressEntriesByDownloadId('missing')(store.getState()),
+    ).toEqual([])
+  })
+})

--- a/src/shared/queue/api/cancelApi.test.ts
+++ b/src/shared/queue/api/cancelApi.test.ts
@@ -1,0 +1,35 @@
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callCancelDownload } from './cancelApi'
+
+describe('callCancelDownload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call invoke with cancel_download command and downloadId', async () => {
+    mockInvoke.mockResolvedValue(true)
+
+    const result = await callCancelDownload('BV1234567890-p1')
+
+    expect(mockInvoke).toHaveBeenCalledWith('cancel_download', {
+      downloadId: 'BV1234567890-p1',
+    })
+    expect(result).toBe(true)
+  })
+
+  it('should return false when the download was not found', async () => {
+    mockInvoke.mockResolvedValue(false)
+
+    const result = await callCancelDownload('already-completed-id')
+
+    expect(result).toBe(false)
+  })
+
+  it('should propagate errors from backend', async () => {
+    mockInvoke.mockRejectedValue(new Error('Cancel failed'))
+
+    await expect(callCancelDownload('BV1-p1')).rejects.toThrow('Cancel failed')
+  })
+})

--- a/src/shared/queue/queueSlice.test.ts
+++ b/src/shared/queue/queueSlice.test.ts
@@ -1,0 +1,320 @@
+/**
+ * queueSlice unit suite.
+ *
+ * Dispatches against the REAL singleton store (established convention —
+ * see useDownloadCompletionNotifications.test.tsx) and asserts on
+ * `store.getState().queue`. The slice under test imports callCancelDownload,
+ * which routes through the globally mocked invoke — tests only need
+ * mockInvoke.mockResolvedValueOnce.
+ */
+
+import { store } from '@/app/store'
+import { mockInvoke } from '@/test/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callCancelAllDownloads } from './api/cancelApi'
+import type { QueueItem } from './queueSlice'
+import {
+  cancelAllDownloads,
+  cancelDownload,
+  clearQueue,
+  clearQueueItem,
+  enqueue,
+  findCompletedItemForPart,
+  selectDownloadIdByPartIndex,
+  selectHasActiveDownloads,
+  selectHasCancellingDownloads,
+  updateQueueStatus,
+} from './queueSlice'
+
+function queue() {
+  return store.getState().queue
+}
+
+type Status = NonNullable<QueueItem['status']>
+
+function item(downloadId: string, overrides: Partial<QueueItem> = {}) {
+  return { downloadId, status: 'pending' as Status, ...overrides }
+}
+
+function seedParentWithChildren(
+  childStatuses: Status[],
+  parentStatus: Status = 'pending',
+) {
+  store.dispatch(enqueue(item('parent', { status: parentStatus })))
+  childStatuses.forEach((status, i) => {
+    store.dispatch(
+      enqueue(item(`parent-p${i + 1}`, { parentId: 'parent', status })),
+    )
+  })
+}
+
+beforeEach(() => {
+  store.dispatch(clearQueue())
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  // Restore the real clock even when a fake-timer test fails mid-way,
+  // so the leak does not cascade into every later test in this file.
+  vi.useRealTimers()
+})
+
+describe('enqueue', () => {
+  it('defaults missing status to pending', () => {
+    store.dispatch(enqueue({ downloadId: 'a' }))
+    expect(queue()[0].status).toBe('pending')
+  })
+
+  it('skips duplicate downloadId', () => {
+    store.dispatch(enqueue(item('a', { title: 'first' })))
+    store.dispatch(enqueue(item('a', { title: 'second' })))
+    expect(queue()).toHaveLength(1)
+    expect(queue()[0].title).toBe('first')
+  })
+})
+
+describe('aggregateParentStatuses (via updateQueueStatus)', () => {
+  const aggregateRows: [Status[], Status][] = [
+    [['done', 'done'], 'done'],
+    [['error', 'done'], 'error'],
+    [['cancelling', 'done'], 'cancelling'],
+    [['running', 'cancelled'], 'running'],
+    // Documented regression guard: a cancelled sibling must not abort the
+    // remaining pending parts — parent stays pending.
+    [['pending', 'cancelled'], 'pending'],
+    [['done', 'cancelled'], 'cancelled'],
+  ]
+  it.each(aggregateRows)(
+    'children %j aggregate parent to %s',
+    (children, expected) => {
+      seedParentWithChildren(children)
+      expect(queue().find((i) => i.downloadId === 'parent')!.status).toBe(
+        expected,
+      )
+    },
+  )
+
+  it('removes a childless parent unless it is cancelling', () => {
+    store.dispatch(enqueue(item('lonely')))
+    store.dispatch(clearQueueItem('lonely'))
+    expect(queue()).toHaveLength(0)
+
+    // Parent is cancelling because its (last) child is cancelling; removing
+    // that child leaves the parent childless WHILE cancelling — kept.
+    store.dispatch(enqueue(item('cp')))
+    store.dispatch(enqueue(item('c', { parentId: 'cp', status: 'cancelling' })))
+    store.dispatch(clearQueueItem('c'))
+    expect(queue().find((i) => i.downloadId === 'cp')!.status).toBe(
+      'cancelling',
+    )
+  })
+
+  it('sets startedAtMs only on the first running transition', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    seedParentWithChildren(['running'])
+    const parent = queue().find((i) => i.downloadId === 'parent')!
+    expect(parent.startedAtMs).toBe(1000)
+
+    vi.setSystemTime(5000)
+    // Part 2 starts after part 1 finishes — parent re-aggregates to running
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'parent-p1', status: 'done' }),
+    )
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'parent-p2', status: 'running' }),
+    )
+    expect(queue().find((i) => i.downloadId === 'parent')!.startedAtMs).toBe(
+      1000,
+    )
+    vi.useRealTimers()
+  })
+
+  it('records completedAtMs on done and error, never resets it', () => {
+    vi.useFakeTimers()
+    seedParentWithChildren(['running'])
+    vi.setSystemTime(2000)
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'parent-p1', status: 'error' }),
+    )
+    expect(queue().find((i) => i.downloadId === 'parent')!.completedAtMs).toBe(
+      2000,
+    )
+
+    vi.setSystemTime(9000)
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'parent-p1', status: 'running' }),
+    )
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'parent-p1', status: 'done' }),
+    )
+    expect(queue().find((i) => i.downloadId === 'parent')!.completedAtMs).toBe(
+      2000,
+    )
+    vi.useRealTimers()
+  })
+})
+
+describe('updateQueueStatus protected-status matrix', () => {
+  const protectedRows: [Status, Status, Status][] = [
+    // [from, to, expectedFinal] — protected states reject downgrades
+    ['done', 'running', 'done'],
+    ['error', 'pending', 'error'],
+    ['cancelling', 'running', 'cancelling'],
+    ['cancelled', 'running', 'cancelled'],
+    // done-while-cancelling races keep the cancelled state
+    ['cancelling', 'done', 'cancelling'],
+    ['cancelled', 'done', 'cancelled'],
+    // forward transitions still apply
+    ['running', 'done', 'done'],
+    ['pending', 'error', 'error'],
+  ]
+  it.each(protectedRows)('%s -> %s keeps %s', (from, to, expected) => {
+    store.dispatch(enqueue(item('x', { status: from })))
+    store.dispatch(updateQueueStatus({ downloadId: 'x', status: to }))
+    expect(queue()[0].status).toBe(expected)
+  })
+
+  it('persists errorMessage on error', () => {
+    store.dispatch(enqueue(item('x', { status: 'running' })))
+    store.dispatch(
+      updateQueueStatus({
+        downloadId: 'x',
+        status: 'error',
+        errorMessage: 'ERR::DISK_FULL',
+      }),
+    )
+    expect(queue()[0].errorMessage).toBe('ERR::DISK_FULL')
+  })
+
+  it('unknown id is a no-op', () => {
+    store.dispatch(enqueue(item('a')))
+    store.dispatch(updateQueueStatus({ downloadId: 'ghost', status: 'done' }))
+    expect(queue()).toHaveLength(1)
+  })
+})
+
+describe('cancelDownload thunk', () => {
+  it('running item goes cancelling then cancelled on confirmed backend call', async () => {
+    store.dispatch(enqueue(item('d1', { status: 'running' })))
+    mockInvoke.mockResolvedValueOnce(true)
+
+    await store.dispatch(cancelDownload('d1') as never)
+
+    expect(mockInvoke).toHaveBeenCalledWith('cancel_download', {
+      downloadId: 'd1',
+    })
+    expect(queue()[0].status).toBe('cancelled')
+  })
+
+  it('pending item finalizes straight to cancelled without cancelling hop', async () => {
+    store.dispatch(enqueue(item('d1', { status: 'pending' })))
+    mockInvoke.mockResolvedValueOnce(true)
+
+    await store.dispatch(cancelDownload('d1') as never)
+    expect(queue()[0].status).toBe('cancelled')
+  })
+
+  it('race to completion: wasCancelled=false settles to done', async () => {
+    store.dispatch(enqueue(item('d1', { status: 'running' })))
+    mockInvoke.mockResolvedValueOnce(false)
+
+    await store.dispatch(cancelDownload('d1') as never)
+    expect(queue()[0].status).toBe('done')
+  })
+
+  it('backend rejection still finalizes to cancelled', async () => {
+    store.dispatch(enqueue(item('d1', { status: 'running' })))
+    mockInvoke.mockRejectedValueOnce(new Error('ipc gone'))
+
+    await store.dispatch(cancelDownload('d1') as never)
+    expect(queue()[0].status).toBe('cancelled')
+  })
+
+  it('condition guard rejects done items without invoking the backend', async () => {
+    store.dispatch(enqueue(item('d1', { status: 'done' })))
+
+    await store.dispatch(cancelDownload('d1') as never)
+
+    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(queue()[0].status).toBe('done')
+  })
+})
+
+describe('cancelAllDownloads thunk', () => {
+  it('flips pending/running to cancelling then finalizes all', async () => {
+    ;['p', 'r'].forEach((id, i) =>
+      store.dispatch(enqueue(item(id, { status: i ? 'running' : 'pending' }))),
+    )
+    store.dispatch(enqueue(item('done', { status: 'done' })))
+    mockInvoke.mockResolvedValueOnce(2)
+
+    const result = (await store.dispatch(cancelAllDownloads() as never)) as {
+      payload: { count: number; downloadIds: string[] }
+    }
+
+    expect(mockInvoke).toHaveBeenCalledWith('cancel_all_downloads', {
+      downloadIds: ['p', 'r'],
+    })
+    expect(result.payload).toEqual({ count: 2, downloadIds: ['p', 'r'] })
+    const statuses = Object.fromEntries(
+      queue().map((i) => [i.downloadId, i.status]),
+    )
+    expect(statuses).toEqual({ p: 'cancelled', r: 'cancelled', done: 'done' })
+  })
+
+  it('empty queue returns count 0 without calling the backend', async () => {
+    const result = (await store.dispatch(cancelAllDownloads() as never)) as {
+      payload: { count: number; downloadIds: string[] }
+    }
+    expect(result.payload).toEqual({ count: 0, downloadIds: [] })
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('selectors', () => {
+  it('selectDownloadIdByPartIndex: most recently enqueued part wins', () => {
+    store.dispatch(
+      enqueue(item('old-p1', { parentId: 'x', status: 'cancelled' })),
+    )
+    store.dispatch(
+      enqueue(item('new-p1', { parentId: 'x', status: 'running' })),
+    )
+    expect(selectDownloadIdByPartIndex(store.getState(), 0)).toBe('new-p1')
+    expect(selectDownloadIdByPartIndex(store.getState(), 5)).toBeUndefined()
+  })
+
+  it('findCompletedItemForPart matches only done items', () => {
+    store.dispatch(enqueue(item('a-p3', { status: 'running' })))
+    store.dispatch(enqueue(item('b-p3', { status: 'done' })))
+    expect(findCompletedItemForPart(store.getState(), 3)!.downloadId).toBe(
+      'b-p3',
+    )
+    expect(findCompletedItemForPart(store.getState(), 1)).toBeUndefined()
+  })
+
+  it('selectHasActiveDownloads: standalone pending does not count, parent pending with children does, cancelling counts', () => {
+    store.dispatch(enqueue(item('standalone', { status: 'pending' })))
+    expect(selectHasActiveDownloads(store.getState())).toBe(false)
+
+    seedParentWithChildren(['running'])
+    expect(selectHasActiveDownloads(store.getState())).toBe(true)
+  })
+
+  it('selectHasCancellingDownloads tracks any cancelling item', () => {
+    expect(selectHasCancellingDownloads(store.getState())).toBe(false)
+    store.dispatch(enqueue(item('c', { status: 'cancelling' })))
+    expect(selectHasCancellingDownloads(store.getState())).toBe(true)
+  })
+})
+
+describe('callCancelAllDownloads api wrapper', () => {
+  it('invokes cancel_all_downloads with the id list', async () => {
+    mockInvoke.mockResolvedValueOnce(3)
+    await expect(callCancelAllDownloads(['a', 'b', 'c'])).resolves.toBe(3)
+    expect(mockInvoke).toHaveBeenCalledWith('cancel_all_downloads', {
+      downloadIds: ['a', 'b', 'c'],
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       ],
       // Ratchet baseline; bump per PR, 100 at the end of the F-series.
       // Lines only: v8 branch/function metrics on TSX are noisy.
-      thresholds: { lines: 15 },
+      thresholds: { lines: 28 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

F2 of the frontend test-coverage plan. **177 → 501 tests (+324)**, coverage threshold 15 → 28 (measured 28.15).

- **Locale parity gate**: new `src/i18n/locales.test.ts` compares the full key SET of all 6 locales against `en.json` (reports exact missing/extra keys per language — the old bash loop only compared key counts), plus an `import.meta.glob` guard so a locale file forgotten in the suite registry fails. CLAUDE.md now points at this test instead of the manual loop
- **queueSlice full suite**: aggregate-status priority ladder (incl. the documented pending+cancelled-sibling regression), protected-status downgrade matrix, `cancelDownload`/`cancelAllDownloads` thunk lifecycles (race-to-completion, condition guard, pending finalize), selectors
- **13 slice/selector suites**: input reducers, video selectors (`selectParentProgress` branches), favorite/login/updater/watch-history (incl. date-filter midnight semantics)/download-status rows+summary/progress gaps; trivial slices get minimal roundtrips
- **API wrappers**: invoke command/args + error mapping asserted across settings/login/favorite/user/watch-history/video/expandShortUrl/downloadVideo/cancelApi/getOs
- **Pure functions**: settings + video `formSchema` (Windows reserved names, drive-letter colons, control chars, OS branching via hoisted `getOs` mock), video lib utils/concurrency, `githubStarsCache` TTL
- **fix(resolution)**: `selectBestEffortResolution` scanned presets in reverse, pre-selecting the **smallest** preset (360p for a 4K source) instead of the documented largest — the resolution tab's auto-default now matches the source as closely as possible without upscaling

## Testing

`npm run test:coverage`: 501 passed / 4 skipped, threshold met. typecheck / lint / prettier / build green. Review pass verified the production fix against its JSDoc and sole UI caller, and spot-checked the headline suites for tautological assertions (none found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)