### PR TITLE
test: add provider and hook suites covering Tauri event wiring

### DIFF
--- a/src/app/providers/ListenerContext.test.tsx
+++ b/src/app/providers/ListenerContext.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * ListenerContext suite.
+ *
+ * The provider wires 7 Tauri events into the real singleton store. Tests
+ * drive the globally mocked `@tauri-apps/api/event` through the in-memory
+ * bus (emitTauriEvent) and assert Redux state; toast content is asserted
+ * via a local toast spy.
+ */
+
+import { store } from '@/app/store'
+import { clearHistory } from '@/features/history/model/historySlice'
+import { initPartInputs, resetInput } from '@/features/video/model/inputSlice'
+import {
+  clearProgress,
+  selectProgressEntriesByDownloadId,
+} from '@/shared/progress/progressSlice'
+import { clearQueue, enqueue } from '@/shared/queue/queueSlice'
+import { toast } from '@/shared/ui/toast'
+import { clearTauriEvents, emitTauriEvent } from '@/test/tauriEvents'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ListenerProvider } from './ListenerContext'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+// i18n: the provider calls the raw i18n.t on the @/i18n singleton; the
+// centralized setup mock provides identity t with {{var}} interpolation.
+const progressBase = {
+  downloadId: 'd1',
+  filesize: 10,
+  downloaded: 1,
+  transferRate: 1024,
+  percentage: 10,
+  deltaTime: 0.5,
+  elapsedTime: 1,
+  isComplete: false,
+}
+
+function queue() {
+  return store.getState().queue
+}
+
+async function mount() {
+  const utils = render(<ListenerProvider>probe</ListenerProvider>)
+  // setupListeners is async: wait until the bus registered all handlers
+  await waitFor(() => {
+    emitTauriEvent('download-retrying', {
+      downloadId: 'noop',
+      isRetrying: false,
+    })
+  })
+  return utils
+}
+
+beforeEach(async () => {
+  // Unmount any provider still mounted from the previous test BEFORE
+  // clearing state, so its listeners stop firing into the fresh state.
+  cleanup()
+  clearTauriEvents()
+  store.dispatch(clearQueue())
+  store.dispatch(clearProgress())
+  store.dispatch(resetInput())
+  store.dispatch(clearHistory())
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearTauriEvents()
+})
+
+describe('progress event', () => {
+  it('dispatches setProgress and marks running on download stages', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'pending' }))
+
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'audio' })
+    })
+
+    expect(
+      selectProgressEntriesByDownloadId('d1')(store.getState()),
+    ).toHaveLength(1)
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('running')
+  })
+
+  it('marks done on complete stage', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'running' }))
+
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'complete' })
+    })
+
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('done')
+  })
+
+  it('unknown stage leaves queue status untouched', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'pending' }))
+
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'finalize' })
+    })
+
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('pending')
+  })
+
+  it('merge-fallback stage shows the audio-merge-fallback toast', async () => {
+    await mount()
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'merge-fallback' })
+    })
+    expect(toast.info).toHaveBeenCalledWith('video.audio_merge_fallback', {
+      duration: 6000,
+    })
+  })
+
+  it.each(['warn-video-quality-fallback', 'warn-audio-quality-fallback'])(
+    '%s shows the matching warning toast',
+    async (stage) => {
+      await mount()
+      act(() => {
+        emitTauriEvent('progress', { ...progressBase, stage })
+      })
+      expect(toast.warning).toHaveBeenCalledWith(
+        stage.startsWith('warn-video')
+          ? 'video.video_quality_fallback'
+          : 'video.audio_quality_fallback',
+        { duration: 6000 },
+      )
+    },
+  )
+})
+
+describe('history:entry_added', () => {
+  it('adds the entry to the history slice', async () => {
+    await mount()
+    act(() => {
+      emitTauriEvent('history:entry_added', {
+        id: 'h1',
+        title: 'T',
+        url: 'u',
+        downloadedAt: '2026-01-01T00:00:00Z',
+        status: 'completed',
+        version: '1.0',
+      })
+    })
+    expect(store.getState().history.entries[0].id).toBe('h1')
+  })
+})
+
+describe('download_cancelled', () => {
+  it('marks cancelled, clears progress, and toasts', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'running' }))
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'audio' })
+    })
+
+    act(() => {
+      emitTauriEvent('download_cancelled', { downloadId: 'd1' })
+    })
+
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('cancelled')
+    expect(
+      selectProgressEntriesByDownloadId('d1')(store.getState()),
+    ).toHaveLength(0)
+    expect(toast.info).toHaveBeenCalledWith('video.download_cancelled')
+  })
+
+  it('keeps done items (late cancel race)', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'done' }))
+
+    act(() => {
+      emitTauriEvent('download_cancelled', { downloadId: 'd1' })
+    })
+
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('done')
+    expect(toast.info).not.toHaveBeenCalled()
+  })
+
+  it('keeps error items too', async () => {
+    await mount()
+    store.dispatch(enqueue({ downloadId: 'd1', status: 'error' }))
+
+    act(() => {
+      emitTauriEvent('download_cancelled', { downloadId: 'd1' })
+    })
+
+    expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('error')
+  })
+})
+
+describe('quality/subtitle resolved events', () => {
+  it('download-quality-resolved updates resolved quality and closes accordions', async () => {
+    await mount()
+    store.dispatch(
+      initPartInputs([
+        {
+          cid: 1,
+          page: 1,
+          title: 'P1',
+          videoQuality: '1080P',
+          audioQuality: 'high',
+          selected: true,
+          duration: 60,
+        },
+      ]),
+    )
+    act(() => {
+      emitTauriEvent('download-quality-resolved', {
+        page: 1,
+        videoQuality: 80,
+        videoQualityFallback: false,
+        videoCodecid: 7,
+        videoCodecFallback: false,
+        audioQuality: 30216,
+        audioQualityFallback: false,
+        isPreview: null,
+      })
+    })
+    const part = store.getState().input.partInputs[0]
+    expect(part.resolvedQuality?.videoQuality).toBe(80)
+    expect(part.accordionOpen).toBe(false)
+  })
+
+  it('download-subtitle-resolved stores mode and labels', async () => {
+    await mount()
+    store.dispatch(
+      initPartInputs([
+        {
+          cid: 1,
+          page: 1,
+          title: 'P1',
+          videoQuality: '1080P',
+          audioQuality: 'high',
+          selected: true,
+          duration: 60,
+        },
+        {
+          cid: 2,
+          page: 2,
+          title: 'P2',
+          videoQuality: '1080P',
+          audioQuality: 'high',
+          selected: true,
+          duration: 60,
+        },
+      ]),
+    )
+    act(() => {
+      emitTauriEvent('download-subtitle-resolved', {
+        page: 2,
+        subtitleMode: 'soft',
+        subtitleLanguageLabels: ['日本語', 'English'],
+      })
+    })
+    const sub = store.getState().input.partInputs[1]?.resolvedSubtitle
+    expect(sub?.subtitleMode).toBe('soft')
+    expect(sub?.subtitleLanguageLabels).toEqual(['日本語', 'English'])
+  })
+})
+
+describe('download-subtitle-warning', () => {
+  it('warns with the joined language list', async () => {
+    await mount()
+    act(() => {
+      emitTauriEvent('download-subtitle-warning', {
+        failedLanguages: ['日本語', 'Español'],
+      })
+    })
+    expect(toast.warning).toHaveBeenCalledWith(
+      'video.subtitle_download_failed',
+      { duration: 6000 },
+    )
+  })
+})
+
+describe('download-retrying', () => {
+  it('sets retrying on the matching progress entry', async () => {
+    await mount()
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'video' })
+      emitTauriEvent('download-retrying', {
+        downloadId: 'd1',
+        stage: 'video',
+        isRetrying: true,
+      })
+    })
+    const entry = selectProgressEntriesByDownloadId('d1')(
+      store.getState(),
+    ).find((e) => e.stage === 'video')
+    expect(entry?.isRetrying).toBe(true)
+  })
+})
+
+describe('unmount', () => {
+  it('detaches all listeners', async () => {
+    const { unmount } = await mount()
+    unmount()
+
+    // Emit every wired event; none may touch state or toasts.
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'complete' })
+      emitTauriEvent('history:entry_added', {
+        id: 'x',
+        title: 't',
+        url: 'u',
+        downloadedAt: 'now',
+        status: 'completed',
+        version: '1.0',
+      })
+      emitTauriEvent('download_cancelled', { downloadId: 'd1' })
+      emitTauriEvent('download-subtitle-warning', { failedLanguages: ['a'] })
+    })
+
+    expect(store.getState().history.entries).toHaveLength(0)
+    expect(toast.info).not.toHaveBeenCalled()
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/providers/UpdaterProvider.test.tsx
+++ b/src/app/providers/UpdaterProvider.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * UpdaterProvider suite.
+ *
+ * The provider early-returns when import.meta.env.DEV is true (the Vitest
+ * default), so each test stubs DEV false via vi.stubEnv to exercise the
+ * production update-check path.
+ */
+
+import { store } from '@/app/store'
+import { resetUpdater } from '@/features/updater/model/updaterSlice'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { check } from '@tauri-apps/plugin-updater'
+import { waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UpdaterProvider } from './UpdaterProvider'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Why stubEnv: UpdaterProvider early-returns when import.meta.env.DEV is
+  // true (Vitest default); stub to false so the production check path runs.
+  vi.stubEnv('DEV', false)
+  mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+  store.dispatch(resetUpdater())
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function updater() {
+  return store.getState().updater
+}
+
+describe('UpdaterProvider', () => {
+  it('dispatches updateAvailable with versions when an update exists', async () => {
+    vi.mocked(check).mockResolvedValue({
+      version: '9.9.9',
+      currentVersion: '1.0.0',
+    } as never)
+    mockInvoke.mockResolvedValueOnce('## release notes')
+
+    renderWithProviders(<UpdaterProvider>child</UpdaterProvider>)
+
+    await waitFor(() => expect(updater().updateAvailable).toBe(true))
+    expect(updater().latestVersion).toBe('9.9.9')
+    expect(updater().currentVersion).toBe('1.0.0')
+  })
+
+  it('fetches release notes via get_release_notes and stores them', async () => {
+    vi.mocked(check).mockResolvedValue({
+      version: '2.0.0',
+      currentVersion: '1.5.0',
+    } as never)
+    mockInvoke.mockResolvedValueOnce('## v2.0.0 notes')
+
+    renderWithProviders(<UpdaterProvider>child</UpdaterProvider>)
+
+    await waitFor(() => expect(updater().releaseNotes).toBe('## v2.0.0 notes'))
+    expect(mockInvoke).toHaveBeenCalledWith('get_release_notes', {
+      owner: 'j4rviscmd',
+      repo: 'bilibili-downloader-gui',
+      currentVersion: '1.5.0',
+    })
+  })
+
+  it('no update leaves state untouched', async () => {
+    vi.mocked(check).mockResolvedValue(null)
+    renderWithProviders(<UpdaterProvider>child</UpdaterProvider>)
+    await waitFor(() => expect(check).toHaveBeenCalled())
+    expect(updater().updateAvailable).toBe(false)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('release-notes failure stores the fallback message', async () => {
+    vi.mocked(check).mockResolvedValue({
+      version: '2.0.0',
+      currentVersion: '1.5.0',
+    } as never)
+    mockInvoke.mockRejectedValueOnce(new Error('github down'))
+
+    renderWithProviders(<UpdaterProvider>child</UpdaterProvider>)
+
+    await waitFor(() =>
+      expect(updater().releaseNotes).toBe('updater.no_release_notes'),
+    )
+    expect(updater().updateAvailable).toBe(true)
+  })
+
+  it('update check failure is swallowed (no crash, no state change)', async () => {
+    vi.mocked(check).mockRejectedValue(new Error('offline'))
+    renderWithProviders(<UpdaterProvider>child</UpdaterProvider>)
+    await waitFor(() => expect(check).toHaveBeenCalled())
+    expect(updater().updateAvailable).toBe(false)
+  })
+})

--- a/src/features/audio/hooks/useAudio.test.tsx
+++ b/src/features/audio/hooks/useAudio.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * useAudio suite: probe-driven bitrate auto-select, format persistence,
+ * extract lifecycle, progress event via the in-memory bus, reveal, reset.
+ */
+
+import { store } from '@/app/store'
+import { setSettings } from '@/features/settings/settingsSlice'
+import { toast } from '@/shared/ui/toast'
+import { emitTauriEvent } from '@/test/tauriEvents'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAudio } from './useAudio'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Why: the global invoke mock (src/test/setup.ts) has no default
+  // implementation and the hook chains .catch on raw invoke returns
+  // (probe_audio_bitrate / reveal_in_folder), so an unmocked call throws;
+  // clearAllMocks() drops calls, not a prior test's implementation.
+  mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+  // Why reset audioFormat: format local-state initializes from settings, and
+  // the singleton store persists across tests in this file.
+  store.dispatch(
+    setSettings({ dlOutputPath: '/tmp', language: 'en', audioFormat: 'mp3' }),
+  )
+})
+
+async function setup(inputBitrateKbps: number | null = 320) {
+  vi.mocked(open).mockResolvedValue('/in/movie.mp4')
+  vi.mocked(save).mockResolvedValue('/out/song.mp3')
+  mockInvoke.mockImplementation((cmd: string) =>
+    cmd === 'probe_audio_bitrate'
+      ? Promise.resolve(inputBitrateKbps)
+      : Promise.resolve(undefined),
+  )
+  const { result } = renderHookWithStore(() => useAudio())
+  await act(async () => {
+    await result.current.handleBrowse()
+  })
+  await act(async () => {
+    await result.current.handleChooseOutput()
+  })
+  return result
+}
+
+describe('useAudio', () => {
+  it('browse probes the source bitrate and auto-selects best-effort', async () => {
+    const result = await setup(128)
+    // 128kbps source → presets above it are disabled, best-effort = 128
+    expect(mockInvoke).toHaveBeenCalledWith('probe_audio_bitrate', {
+      inputPath: '/in/movie.mp4',
+    })
+    expect(result.current.bitrateKbps).toBe(128)
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('probe failure falls back to null bitrate and default presets', async () => {
+    // Rejection (not null resolve) exercises the .catch branch
+    vi.mocked(open).mockResolvedValue('/in/movie.mp4')
+    mockInvoke.mockImplementation((cmd: string) =>
+      cmd === 'probe_audio_bitrate'
+        ? Promise.reject(new Error('ffprobe missing'))
+        : Promise.resolve(undefined),
+    )
+    const { result } = renderHookWithStore(() => useAudio())
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+    expect(result.current.bitrateKbps).toBe(192)
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('setFormat persists to settings and clears the output path', async () => {
+    const result = await setup()
+    await act(async () => {
+      result.current.setFormat('m4a')
+    })
+    expect(store.getState().settings.audioFormat).toBe('m4a')
+    expect(result.current.outputPath).toBeNull()
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'set_settings',
+      expect.objectContaining({
+        settings: expect.objectContaining({ audioFormat: 'm4a' }),
+      }),
+    )
+  })
+
+  it('extract invokes extract_audio with the form values and succeeds', async () => {
+    const result = await setup(320)
+    await act(async () => {
+      await result.current.handleExtract()
+    })
+    expect(result.current.status).toBe('success')
+    const calls = mockInvoke.mock.calls
+    expect(calls[calls.length - 1]).toEqual([
+      'extract_audio',
+      {
+        options: {
+          inputPath: '/in/movie.mp4',
+          outputPath: '/out/song.mp3',
+          format: 'mp3',
+          bitrateKbps: 320,
+        },
+      },
+    ])
+  })
+
+  it('extract failure sets error and toasts', async () => {
+    const result = await setup(320)
+    mockInvoke.mockImplementation((cmd: string) =>
+      cmd === 'probe_audio_bitrate'
+        ? Promise.resolve(320)
+        : Promise.reject(new Error('boom')),
+    )
+    await act(async () => {
+      await result.current.handleExtract()
+    })
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+  })
+
+  it('audio://progress events update progress while mounted', async () => {
+    const result = await setup(320)
+    act(() => {
+      emitTauriEvent('audio://progress', {
+        progress: 42,
+        currentTimeSec: 10,
+        totalDurationSec: 24,
+      })
+    })
+    await waitFor(() => expect(result.current.progress?.progress).toBe(42))
+  })
+
+  it('handleReveal invokes reveal_in_folder', async () => {
+    const result = await setup()
+    await act(async () => {
+      await result.current.handleReveal()
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_in_folder', {
+      path: '/out/song.mp3',
+    })
+  })
+
+  it('reset returns to pristine state', async () => {
+    const result = await setup()
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.inputPath).toBeNull()
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/src/features/concat/hooks/useConcat.test.tsx
+++ b/src/features/concat/hooks/useConcat.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * useConcat suite: file add/remove/reorder, client-side validation gates,
+ * concat lifecycle (success + fallback toast + progress events), reveal.
+ */
+
+import { toast } from '@/shared/ui/toast'
+import { emitTauriEvent } from '@/test/tauriEvents'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useConcat } from './useConcat'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+})
+
+async function addFiles(paths: string[]) {
+  vi.mocked(open).mockResolvedValue(paths)
+  const { result } = renderHookWithStore(() => useConcat())
+  await act(async () => {
+    await result.current.handleAddFiles()
+  })
+  return result
+}
+
+async function setupValid() {
+  const result = await addFiles(['/a.mp4', '/b.mp4'])
+  vi.mocked(save).mockResolvedValue('/out/concat.mp4')
+  await act(async () => {
+    await result.current.handleChooseOutput()
+  })
+  return result
+}
+
+describe('useConcat file management', () => {
+  it('adds selected files and keeps existing ones', async () => {
+    const result = await addFiles(['/a.mp4'])
+    vi.mocked(open).mockResolvedValue(['/b.mp4'])
+    await act(async () => {
+      await result.current.handleAddFiles()
+    })
+    expect(result.current.files).toEqual(['/a.mp4', '/b.mp4'])
+  })
+
+  it('canceling the dialog leaves files unchanged', async () => {
+    const result = await addFiles(['/a.mp4'])
+    vi.mocked(open).mockResolvedValue(null)
+    await act(async () => {
+      await result.current.handleAddFiles()
+    })
+    expect(result.current.files).toEqual(['/a.mp4'])
+  })
+
+  it('removes and reorders files', async () => {
+    const result = await addFiles(['/a.mp4', '/b.mp4', '/c.mp4'])
+    act(() => {
+      result.current.handleRemoveFile(1)
+    })
+    expect(result.current.files).toEqual(['/a.mp4', '/c.mp4'])
+    act(() => {
+      result.current.handleReorderFiles(1, 0)
+    })
+    expect(result.current.files).toEqual(['/c.mp4', '/a.mp4'])
+  })
+})
+
+describe('handleConcat validation gates', () => {
+  it('rejects with no files', async () => {
+    const result = renderHookWithStore(() => useConcat()).result
+    await act(async () => {
+      await result.current.handleConcat()
+    })
+    expect(result.current.validationError).toBe('no_files')
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      'concat_videos',
+      expect.anything(),
+    )
+  })
+
+  it('rejects with a single file', async () => {
+    const result = await addFiles(['/a.mp4'])
+    await act(async () => {
+      await result.current.handleConcat()
+    })
+    expect(result.current.validationError).toBe('single_file')
+  })
+
+  it('rejects duplicate paths', async () => {
+    const result = await addFiles(['/a.mp4', '/a.mp4'])
+    await act(async () => {
+      await result.current.handleConcat()
+    })
+    expect(result.current.validationError).toBe('duplicate_paths')
+  })
+})
+
+describe('handleConcat lifecycle', () => {
+  it('concatenates with the file list and output path', async () => {
+    const result = await setupValid()
+    await act(async () => {
+      await result.current.handleConcat()
+    })
+    expect(result.current.status).toBe('success')
+    expect(mockInvoke).toHaveBeenCalledWith('concat_videos', {
+      options: {
+        inputPaths: ['/a.mp4', '/b.mp4'],
+        outputPath: '/out/concat.mp4',
+      },
+    })
+    expect(toast.success).toHaveBeenCalledWith(
+      'concat.success',
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'concat.openFolder' }),
+      }),
+    )
+  })
+
+  it('failure sets error status and maps the message', async () => {
+    const result = await setupValid()
+    mockInvoke.mockRejectedValueOnce('ERR::SOME_FAILURE')
+    await act(async () => {
+      await result.current.handleConcat()
+    })
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(toast.error).toHaveBeenCalledWith(
+      'concat.failed',
+      expect.objectContaining({ description: expect.any(String) }),
+    )
+  })
+
+  it('concat://progress events update progress', async () => {
+    const result = await setupValid()
+    act(() => {
+      emitTauriEvent('concat://progress', {
+        progress: 50,
+        currentTimeSec: 5,
+        totalDurationSec: 10,
+      })
+    })
+    await waitFor(() => expect(result.current.progress?.progress).toBe(50))
+  })
+
+  it('concat://fallback resets progress and toasts the notice', async () => {
+    const result = await setupValid()
+    act(() => {
+      emitTauriEvent('concat://fallback', undefined)
+    })
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith('concat.fallbackNotice'),
+    )
+    expect(result.current.progress).toBeNull()
+  })
+})
+
+describe('misc', () => {
+  it('handleReveal invokes reveal_in_folder', async () => {
+    const result = await setupValid()
+    await act(async () => {
+      await result.current.handleReveal()
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_in_folder', {
+      path: '/out/concat.mp4',
+    })
+  })
+
+  it('reset clears everything', async () => {
+    const result = await setupValid()
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.files).toEqual([])
+    expect(result.current.outputPath).toBeNull()
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/src/features/favorite/hooks/useFavorite.test.tsx
+++ b/src/features/favorite/hooks/useFavorite.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * useFavorite suite.
+ *
+ * Drives the fetch_favorite_folders / fetch_favorite_videos commands via
+ * mockInvoke against the real store, covering the mount-time folder load,
+ * auto-selection, pagination, refresh fallback, and the error path.
+ */
+
+import { store } from '@/app/store'
+import { useFavorite } from '@/features/favorite/hooks/useFavorite'
+import {
+  reset as resetFavorite,
+  setFolders as seedFolders,
+  setSelectedFolder,
+} from '@/features/favorite/model/favoriteSlice'
+import type {
+  FavoriteFolder,
+  FavoriteVideo,
+  FavoriteVideoListResponse,
+} from '@/features/favorite/types'
+import { toast } from '@/shared/ui/toast'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { act, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const toastError = toast.error as unknown as Mock
+
+const folderA: FavoriteFolder = { id: 10, title: 'Folder A', mediaCount: 1 }
+const folderB: FavoriteFolder = { id: 20, title: 'Folder B', mediaCount: 2 }
+
+const videoOf = (id: number): FavoriteVideo => ({
+  id,
+  bvid: `BV${id}`,
+  title: `Video ${id}`,
+  cover: 'cover',
+  duration: 60,
+  page: 1,
+  upper: { mid: 1, name: 'upper', face: 'face' },
+  attr: 0,
+  playCount: 1,
+  collectCount: 1,
+  link: 'link',
+})
+
+const pageOf = (ids: number[], hasMore = false): FavoriteVideoListResponse => ({
+  videos: ids.map(videoOf),
+  hasMore,
+  totalCount: ids.length,
+})
+
+type Handler = unknown | ((args: Record<string, unknown>) => unknown)
+
+function mockCommands(handlers: Record<string, Handler>) {
+  mockInvoke.mockImplementation(
+    (cmd: string, args: Record<string, unknown>) => {
+      const handler = handlers[cmd]
+      const value = typeof handler === 'function' ? handler(args) : handler
+      if (value instanceof Error) return Promise.reject(value)
+      if (value !== undefined) return Promise.resolve(value)
+      return Promise.resolve(undefined)
+    },
+  )
+}
+
+describe('useFavorite', () => {
+  beforeEach(() => {
+    store.dispatch(resetFavorite())
+    vi.clearAllMocks()
+    mockCommands({})
+  })
+
+  it('resets the slice when mid is null (logged out)', () => {
+    store.dispatch(seedFolders([folderA]))
+
+    renderHookWithStore(() => useFavorite(null))
+
+    expect(store.getState().favorite.folders).toHaveLength(0)
+    expect(store.getState().favorite.selectedFolderId).toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('loads folders on mount, auto-selects the first, and fetches videos', async () => {
+    mockCommands({
+      fetch_favorite_folders: [folderA, folderB],
+      fetch_favorite_videos: pageOf([1, 2]),
+    })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+
+    await waitFor(() => {
+      expect(result.current.folders).toHaveLength(2)
+    })
+    await waitFor(() => {
+      expect(result.current.selectedFolderId).toBe(10)
+    })
+    await waitFor(() => {
+      expect(result.current.videos).toHaveLength(2)
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_favorite_folders', {
+      mid: 42,
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_favorite_videos', {
+      mediaId: 10,
+      pageNum: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('skips the folder fetch when folders are already cached', async () => {
+    store.dispatch(seedFolders([folderA]))
+    store.dispatch(setSelectedFolder(10))
+    mockCommands({ fetch_favorite_videos: pageOf([1]) })
+
+    renderHookWithStore(() => useFavorite(42))
+
+    await waitFor(() => {
+      expect(store.getState().favorite.videos).toHaveLength(1)
+    })
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      'fetch_favorite_folders',
+      expect.anything(),
+    )
+  })
+
+  it('selectFolder clears videos and refetches for the new folder', async () => {
+    mockCommands({
+      fetch_favorite_folders: [folderA, folderB],
+      fetch_favorite_videos: pageOf([1]),
+    })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+    await waitFor(() => {
+      expect(result.current.videos).toHaveLength(1)
+    })
+
+    await act(async () => {
+      await result.current.selectFolder(20)
+    })
+
+    expect(mockInvoke).toHaveBeenLastCalledWith('fetch_favorite_videos', {
+      mediaId: 20,
+      pageNum: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('loadMore appends the next page and increments currentPage', async () => {
+    store.dispatch(seedFolders([folderA]))
+    store.dispatch(setSelectedFolder(10))
+    mockCommands({
+      fetch_favorite_videos: (args: Record<string, unknown>) =>
+        args.pageNum === 1 ? pageOf([1], true) : pageOf([2, 3]),
+    })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+    await waitFor(() => {
+      expect(result.current.videos.map((v) => v.id)).toEqual([1])
+      expect(result.current.hasMore).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.loadMore()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_favorite_videos', {
+      mediaId: 10,
+      pageNum: 2,
+      pageSize: 20,
+    })
+    expect(result.current.videos.map((v) => v.id)).toEqual([1, 2, 3])
+    expect(result.current.currentPage).toBe(2)
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('loadMore is a no-op without a selected folder, hasMore, or while loading', async () => {
+    // No selected folder (cached folders keep the mount effect idle).
+    store.dispatch(seedFolders([folderA]))
+    const first = renderHookWithStore(() => useFavorite(42))
+    await act(async () => {
+      await first.result.current.loadMore()
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+    first.unmount()
+
+    // Selected but hasMore false (the mount fetch returns the last page).
+    store.dispatch(seedFolders([folderA]))
+    store.dispatch(setSelectedFolder(10))
+    mockCommands({ fetch_favorite_videos: pageOf([1], false) })
+    const second = renderHookWithStore(() => useFavorite(42))
+    await waitFor(() => {
+      expect(second.result.current.hasMore).toBe(false)
+    })
+    await act(async () => {
+      await second.result.current.loadMore()
+    })
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    second.unmount()
+  })
+
+  it('refresh re-selects the first folder when the current one disappeared', async () => {
+    store.dispatch(seedFolders([folderA]))
+    store.dispatch(setSelectedFolder(10))
+    mockCommands({
+      fetch_favorite_folders: [folderB],
+      fetch_favorite_videos: pageOf([5]),
+    })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(store.getState().favorite.selectedFolderId).toBe(20)
+    expect(mockInvoke).toHaveBeenLastCalledWith('fetch_favorite_videos', {
+      mediaId: 20,
+      pageNum: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('refresh resets the slice when no folders remain', async () => {
+    store.dispatch(seedFolders([folderA]))
+    store.dispatch(setSelectedFolder(10))
+    mockCommands({ fetch_favorite_folders: [] })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(store.getState().favorite.selectedFolderId).toBeNull()
+    expect(store.getState().favorite.folders).toHaveLength(0)
+  })
+
+  it('sets the error slice and toasts when the folder fetch fails', async () => {
+    mockCommands({ fetch_favorite_folders: new Error('ERR::NO_COOKIE') })
+    const { result } = renderHookWithStore(() => useFavorite(42))
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('ERR::NO_COOKIE')
+    })
+    expect(toastError).toHaveBeenCalledWith('ERR::NO_COOKIE')
+    expect(result.current.foldersLoading).toBe(false)
+  })
+})

--- a/src/features/history/hooks/useHistory.test.tsx
+++ b/src/features/history/hooks/useHistory.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * useHistory suite.
+ *
+ * Covers the mount-time get_history load, client-side filtering/searching,
+ * CRUD operations (asserting invoke command + args), export, and the
+ * withLoading error path (error slice + toast).
+ */
+
+import { store } from '@/app/store'
+import { useHistory } from '@/features/history/hooks/useHistory'
+import type { HistoryEntry } from '@/features/history/model/historySlice'
+import {
+  clearHistory,
+  setEntries,
+  setError,
+  setFilters,
+  setLoading,
+  setSearchQuery,
+} from '@/features/history/model/historySlice'
+import { toast } from '@/shared/ui/toast'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { act, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const toastSuccess = toast.success as unknown as Mock
+const toastError = toast.error as unknown as Mock
+
+const entryCompleted: HistoryEntry = {
+  id: 'a',
+  title: 'Alpha Video',
+  url: 'https://b23.tv/alpha',
+  filename: 'alpha.mp4',
+  downloadedAt: '2026-01-01T00:00:00Z',
+  status: 'completed',
+}
+
+const entryFailed: HistoryEntry = {
+  id: 'b',
+  title: 'Beta video',
+  url: 'https://b23.tv/beta',
+  downloadedAt: '2026-01-02T00:00:00Z',
+  status: 'failed',
+  errorMessage: 'boom',
+}
+
+const entryNew: HistoryEntry = {
+  id: 'c',
+  title: 'Gamma',
+  url: 'https://b23.tv/gamma',
+  downloadedAt: '2026-01-03T00:00:00Z',
+  status: 'completed',
+}
+
+function mockCommands(handlers: Record<string, unknown>) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    // Default get_history to [] so the mount effect never dispatches
+    // setEntries(undefined) when a test only mocks its own command.
+    const handler = handlers[cmd] ?? (cmd === 'get_history' ? [] : undefined)
+    if (handler instanceof Error) return Promise.reject(handler)
+    if (handler !== undefined) return Promise.resolve(handler)
+    return Promise.resolve(undefined)
+  })
+}
+
+describe('useHistory', () => {
+  beforeEach(() => {
+    store.dispatch(clearHistory())
+    store.dispatch(setEntries([]))
+    store.dispatch(setFilters({}))
+    store.dispatch(setSearchQuery(''))
+    store.dispatch(setError(null))
+    store.dispatch(setLoading(false))
+    vi.clearAllMocks()
+    // Default: mount effect's get_history resolves to an empty list.
+    mockCommands({ get_history: [] })
+  })
+
+  it('loads entries from the backend on mount', async () => {
+    mockCommands({ get_history: [entryCompleted, entryFailed] })
+    const { result } = renderHookWithStore(() => useHistory())
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(2)
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('get_history', {})
+    expect(store.getState().history.loading).toBe(false)
+  })
+
+  it('filters by status', async () => {
+    mockCommands({ get_history: [entryCompleted, entryFailed] })
+    const { result } = renderHookWithStore(() => useHistory())
+    await waitFor(() => expect(result.current.entries).toHaveLength(2))
+
+    act(() => result.current.updateFilters({ status: 'failed' }))
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([entryFailed])
+    })
+
+    act(() => result.current.updateFilters({ status: 'all' }))
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(2)
+    })
+  })
+
+  it('searches title, url, and filename case-insensitively', async () => {
+    mockCommands({ get_history: [entryCompleted, entryFailed] })
+    const { result } = renderHookWithStore(() => useHistory())
+    await waitFor(() => expect(result.current.entries).toHaveLength(2))
+
+    act(() => result.current.setSearch('ALPHA'))
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([entryCompleted])
+    })
+
+    act(() => result.current.setSearch('B23.TV/BETA'))
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([entryFailed])
+    })
+
+    act(() => result.current.setSearch('alpha.mp4'))
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([entryCompleted])
+    })
+
+    act(() => result.current.setSearch('no-such-video'))
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(0)
+    })
+  })
+
+  it('adds an entry via add_history_entry, unshifts it, and toasts', async () => {
+    mockCommands({ add_history_entry: undefined })
+    const { result } = renderHookWithStore(() => useHistory())
+
+    await act(async () => {
+      await result.current.add(entryNew)
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('add_history_entry', {
+      entry: entryNew,
+    })
+    expect(result.current.entries[0]!.id).toBe('c')
+    expect(toastSuccess).toHaveBeenCalledWith('history.entryAdded')
+  })
+
+  it('sets the error slice and toasts when add fails', async () => {
+    mockCommands({
+      get_history: [entryCompleted],
+      add_history_entry: new Error('disk full'),
+    })
+    const { result } = renderHookWithStore(() => useHistory())
+    // Let the mount load settle first: its success path resets the error.
+    await waitFor(() => expect(result.current.entries).toHaveLength(1))
+
+    await act(async () => {
+      await expect(result.current.add(entryNew)).rejects.toThrow(
+        'Failed to add history entry: disk full',
+      )
+    })
+
+    expect(result.current.error).toBe('Failed to add history entry: disk full')
+    expect(toastError).toHaveBeenCalledWith(
+      'Failed to add history entry: disk full',
+    )
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('removes an entry via remove_history_entry', async () => {
+    mockCommands({
+      get_history: [entryCompleted, entryFailed],
+      remove_history_entry: undefined,
+    })
+    const { result } = renderHookWithStore(() => useHistory())
+    await waitFor(() => expect(result.current.entries).toHaveLength(2))
+
+    await act(async () => {
+      await result.current.remove('a')
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('remove_history_entry', { id: 'a' })
+    expect(result.current.entries.map((e) => e.id)).toEqual(['b'])
+    expect(toastSuccess).toHaveBeenCalledWith('history.entryRemoved')
+  })
+
+  it('clears all entries via clear_history', async () => {
+    mockCommands({
+      get_history: [entryCompleted],
+      clear_history: undefined,
+    })
+    const { result } = renderHookWithStore(() => useHistory())
+    await waitFor(() => expect(result.current.entries).toHaveLength(1))
+
+    await act(async () => {
+      await result.current.clear()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('clear_history', {})
+    expect(result.current.entries).toHaveLength(0)
+    expect(toastSuccess).toHaveBeenCalledWith('history.cleared')
+  })
+
+  it('exports as json and csv with the matching toast', async () => {
+    mockCommands({ export_history: '/out/history.json' })
+    const { result } = renderHookWithStore(() => useHistory())
+
+    let jsonPath = ''
+    await act(async () => {
+      jsonPath = await result.current.exportData('json')
+    })
+
+    expect(jsonPath).toBe('/out/history.json')
+    expect(mockInvoke).toHaveBeenCalledWith('export_history', {
+      format: 'json',
+    })
+    expect(toastSuccess).toHaveBeenCalledWith('history.exportedAsJson')
+
+    mockCommands({ export_history: '/out/history.csv' })
+    await act(async () => {
+      await result.current.exportData('csv')
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('export_history', { format: 'csv' })
+    expect(toastSuccess).toHaveBeenCalledWith('history.exportedAsCsv')
+  })
+})

--- a/src/features/init/hooks/useInit.test.tsx
+++ b/src/features/init/hooks/useInit.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * useInit suite.
+ *
+ * initApp reads the backend `initialize` / `get_init_result` commands via
+ * mockInvoke and applies the frontend-specific bits (settings slice, font
+ * size, sidebar, user slice, i18n language). The i18next singleton is the
+ * centralized setup mock, so changeLanguage is observable as a vi.fn.
+ */
+
+import { store } from '@/app/store'
+import { useInit, type InitResult } from '@/features/init/hooks/useInit'
+import { setInitiated } from '@/features/init/model/initSlice'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { mockInvoke } from '@/test/test-utils'
+import { exit } from '@tauri-apps/plugin-process'
+import { renderHook } from '@testing-library/react'
+import i18next from 'i18next'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const mockExit = exit as unknown as Mock
+const mockChangeLanguage = i18next.changeLanguage as unknown as Mock
+
+const baseline: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const loggedOutUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: { uname: '', isLogin: false, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: false,
+}
+
+const loggedInUser: User = {
+  code: 0,
+  message: '',
+  ttl: 1,
+  data: { uname: 'tester', isLogin: true, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: true,
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+function mockCommands(handlers: Record<string, unknown>) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    const handler = handlers[cmd]
+    if (handler instanceof Error) return Promise.reject(handler)
+    if (handler !== undefined) return Promise.resolve(handler)
+    return Promise.resolve(undefined)
+  })
+}
+
+describe('useInit', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baseline))
+    store.dispatch(setInitiated(false))
+    store.dispatch(setUser(loggedOutUser))
+    document.documentElement.style.fontSize = ''
+    vi.clearAllMocks()
+  })
+
+  it('applies settings, font size, sidebar, user, and language on success', async () => {
+    const result: InitResult = {
+      settings: {
+        dlOutputPath: '/downloads',
+        language: 'ja',
+        fontSize: 16,
+        sidebarExpanded: false,
+      },
+      user: loggedInUser,
+      ffmpegSuccess: true,
+    }
+    mockCommands({
+      get_os: 'macos',
+      get_init_result: result,
+    })
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    const code = await hook.current.initApp()
+
+    expect(code).toEqual({ code: 0 })
+    expect(mockInvoke).toHaveBeenCalledWith('initialize')
+    expect(mockInvoke).toHaveBeenCalledWith('get_init_result')
+    expect(store.getState().settings.dlOutputPath).toBe('/downloads')
+    expect(document.documentElement.style.fontSize).toBe('16px')
+    expect(store.getState().sidebar.sidebarOpen).toBe(false)
+    expect(store.getState().user.data.uname).toBe('tester')
+    expect(store.getState().init.initiated).toBe(true)
+    expect(mockChangeLanguage).toHaveBeenCalledWith('ja')
+  })
+
+  it('does not change language when it already matches i18n', async () => {
+    const result: InitResult = {
+      settings: { ...baseline, language: 'en' },
+      user: undefined,
+      ffmpegSuccess: true,
+    }
+    mockCommands({ get_init_result: result })
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    // The mocked i18n reports language 'en', so no changeLanguage call.
+    await hook.current.initApp()
+
+    expect(mockChangeLanguage).not.toHaveBeenCalled()
+  })
+
+  it('returns code 1 when ffmpeg failed to validate', async () => {
+    const result: InitResult = {
+      settings: undefined,
+      user: undefined,
+      userError: 'ERR::UNAUTHORIZED',
+      ffmpegSuccess: false,
+    }
+    mockCommands({ get_init_result: result })
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    const code = await hook.current.initApp()
+
+    expect(code).toEqual({ code: 1 })
+    // Still marked initiated, and the userError interception is skipped
+    // (early return before interceptInvokeError).
+    expect(store.getState().init.initiated).toBe(true)
+  })
+
+  it('falls back to defaults when get_init_result rejects', async () => {
+    mockCommands({
+      get_init_result: new Error('command not registered'),
+    })
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    const code = await hook.current.initApp()
+
+    expect(code).toEqual({ code: 1 })
+    expect(store.getState().settings.dlOutputPath).toBe('')
+    // parseFontSize(undefined) applies the 14px default.
+    expect(document.documentElement.style.fontSize).toBe('14px')
+    expect(store.getState().init.initiated).toBe(true)
+    expect(store.getState().user.data.uname).toBe('')
+  })
+
+  it('intercepts a non-unauthorized userError and still returns code 0', async () => {
+    const result: InitResult = {
+      settings: undefined,
+      user: undefined,
+      userError: 'ERR::NETWORK',
+      ffmpegSuccess: true,
+    }
+    mockCommands({ get_init_result: result })
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    const code = await hook.current.initApp()
+
+    expect(code).toEqual({ code: 0 })
+  })
+
+  it('setInitiated dispatches to the init slice', () => {
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    hook.current.setInitiated(true)
+    expect(store.getState().init.initiated).toBe(true)
+
+    hook.current.setInitiated(false)
+    expect(store.getState().init.initiated).toBe(false)
+  })
+
+  it('quitApp exits the process', async () => {
+    const { result: hook } = renderHook(() => useInit(), { wrapper })
+
+    await hook.current.quitApp()
+
+    expect(mockExit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/rotation/hooks/useRotation.test.tsx
+++ b/src/features/rotation/hooks/useRotation.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * useRotation suite: dialog picks, settings persistence on angle/mode
+ * change, rotate lifecycle (success + error), reveal, default output name.
+ */
+
+import { store } from '@/app/store'
+import { setSettings } from '@/features/settings/settingsSlice'
+import { toast } from '@/shared/ui/toast'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useRotation } from './useRotation'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const baseSettings = {
+  dlOutputPath: '/tmp',
+  language: 'en',
+  rotationAngle: 90,
+  rotationMode: 'copy' as const,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Why: the global invoke mock has no default implementation, so any
+  // unhanded call resolves undefined and .catch on it throws inside hooks.
+  mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+  store.dispatch(setSettings({ ...baseSettings } as never))
+})
+
+async function setupWithPaths() {
+  vi.mocked(open).mockResolvedValue('/in/movie.mp4')
+  vi.mocked(save).mockResolvedValue('/out/movie_rotated.mp4')
+  const { result } = renderHookWithStore(() => useRotation())
+  await act(async () => {
+    await result.current.handleBrowse()
+  })
+  await act(async () => {
+    await result.current.handleChooseOutput()
+  })
+  return result
+}
+
+describe('useRotation', () => {
+  it('browse picks input and resets output (wrong-file overwrite guard)', async () => {
+    const { result } = renderHookWithStore(() => useRotation())
+    expect(result.current.inputPath).toBeNull()
+
+    vi.mocked(open).mockResolvedValue('/in/a.mp4')
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+    expect(result.current.inputPath).toBe('/in/a.mp4')
+    expect(result.current.outputPath).toBeNull()
+  })
+
+  it('choose output derives a _rotated default name from the input', async () => {
+    const { result } = renderHookWithStore(() => useRotation())
+    vi.mocked(open).mockResolvedValue('/in/movie.mp4')
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+    await act(async () => {
+      await result.current.handleChooseOutput()
+    })
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: 'movie_rotated.mp4' }),
+    )
+  })
+
+  it('canceling either dialog leaves state untouched', async () => {
+    const { result } = renderHookWithStore(() => useRotation())
+    vi.mocked(open).mockResolvedValue(null)
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+    expect(result.current.inputPath).toBeNull()
+  })
+
+  it('setAngle persists to settings via set_settings', async () => {
+    const { result } = renderHookWithStore(() => useRotation())
+    await act(async () => {
+      result.current.setAngle(180)
+    })
+    expect(store.getState().settings.rotationAngle).toBe(180)
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'set_settings',
+      expect.objectContaining({
+        settings: expect.objectContaining({ rotationAngle: 180 }),
+      }),
+    )
+  })
+
+  it('handleRotate succeeds and invokes rotate_video with the form values', async () => {
+    const result = await setupWithPaths()
+    mockInvoke.mockResolvedValueOnce(undefined)
+
+    await act(async () => {
+      await result.current.handleRotate()
+    })
+
+    expect(result.current.status).toBe('success')
+    expect(mockInvoke).toHaveBeenCalledWith('rotate_video', {
+      options: {
+        inputPath: '/in/movie.mp4',
+        outputPath: '/out/movie_rotated.mp4',
+        angle: 90,
+        mode: 'copy',
+      },
+    })
+  })
+
+  it('handleRotate failure sets error status and toasts', async () => {
+    const result = await setupWithPaths()
+    mockInvoke.mockRejectedValueOnce(new Error('boom'))
+
+    await act(async () => {
+      await result.current.handleRotate()
+    })
+
+    expect(result.current.status).toBe('error')
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+  })
+
+  it('handleReveal invokes reveal_in_folder with the output path', async () => {
+    const result = await setupWithPaths()
+    await act(async () => {
+      await result.current.handleReveal()
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_in_folder', {
+      path: '/out/movie_rotated.mp4',
+    })
+  })
+
+  it('reset returns the form to pristine state', async () => {
+    const result = await setupWithPaths()
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.inputPath).toBeNull()
+    expect(result.current.outputPath).toBeNull()
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/src/features/settings/hooks/useThemeEffect.test.tsx
+++ b/src/features/settings/hooks/useThemeEffect.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * useThemeEffect suite.
+ *
+ * The hook maps the settings.theme slice onto the document root (class,
+ * colorScheme, localStorage) and the native window theme via the shared
+ * setup.ts window mock.
+ */
+
+import { store } from '@/app/store'
+import { useThemeEffect } from '@/features/settings/hooks/useThemeEffect'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// setup.ts returns a single shared window instance, so this is the same
+// vi.fn the hook invokes.
+const mockSetTheme = getCurrentWindow().setTheme as unknown as ReturnType<
+  typeof vi.fn
+>
+
+const baseline: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+const root = () => window.document.documentElement
+
+describe('useThemeEffect', () => {
+  beforeEach(() => {
+    root().classList.remove('light', 'dark')
+    root().style.colorScheme = ''
+    window.localStorage.removeItem('ui-theme')
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    root().classList.remove('light', 'dark')
+  })
+
+  it('applies the light theme class, colorScheme, storage, and native theme', () => {
+    store.dispatch(setSettings(baseline))
+    renderHook(() => useThemeEffect(), { wrapper })
+
+    expect(root().classList.contains('light')).toBe(true)
+    expect(root().classList.contains('dark')).toBe(false)
+    expect(root().style.colorScheme).toBe('light')
+    expect(window.localStorage.getItem('ui-theme')).toBe('light')
+    expect(mockSetTheme).toHaveBeenCalledWith('light')
+  })
+
+  it('applies dark when settings.theme is dark', () => {
+    store.dispatch(setSettings({ ...baseline, theme: 'dark' }))
+    renderHook(() => useThemeEffect(), { wrapper })
+
+    expect(root().classList.contains('dark')).toBe(true)
+    expect(root().classList.contains('light')).toBe(false)
+    expect(root().style.colorScheme).toBe('dark')
+    expect(window.localStorage.getItem('ui-theme')).toBe('dark')
+    expect(mockSetTheme).toHaveBeenCalledWith('dark')
+  })
+
+  it('swaps the class when the theme changes while mounted', () => {
+    store.dispatch(setSettings(baseline))
+    const { rerender } = renderHook(() => useThemeEffect(), { wrapper })
+    expect(root().classList.contains('light')).toBe(true)
+
+    store.dispatch(setSettings({ ...baseline, theme: 'dark' }))
+    rerender()
+
+    expect(root().classList.contains('dark')).toBe(true)
+    expect(root().classList.contains('light')).toBe(false)
+    expect(mockSetTheme).toHaveBeenCalledWith('dark')
+  })
+
+  it('falls back to light when theme is undefined', () => {
+    store.dispatch(setSettings({ ...baseline, theme: undefined }))
+    renderHook(() => useThemeEffect(), { wrapper })
+
+    expect(root().classList.contains('light')).toBe(true)
+    expect(mockSetTheme).toHaveBeenCalledWith('light')
+  })
+})

--- a/src/features/settings/useSettings.test.tsx
+++ b/src/features/settings/useSettings.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * useSettings suite.
+ *
+ * Asserts the invoke commands ('get_settings' / 'set_settings' /
+ * 'update_lib_path') and their arguments via the global mockInvoke, plus
+ * Redux effects on the real singleton store. Toast content is asserted via
+ * a local toast spy (identity t from the centralized i18n mock).
+ */
+
+import { store } from '@/app/store'
+import { languages } from '@/features/settings/language/languages'
+import { setOpenDialog, setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { useSettings } from '@/features/settings/useSettings'
+import { toast } from '@/shared/ui/toast'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import i18next from 'i18next'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const toastSuccess = toast.success as unknown as Mock
+const toastError = toast.error as unknown as Mock
+const mockChangeLanguage = i18next.changeLanguage as unknown as Mock
+
+const baseline: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const backendSettings: Settings = {
+  ...baseline,
+  dlOutputPath: '/downloads',
+  language: 'ja',
+}
+
+function mockCommands(handlers: Record<string, unknown>) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    const handler = handlers[cmd]
+    if (handler instanceof Error) return Promise.reject(handler)
+    if (handler !== undefined) return Promise.resolve(handler)
+    return Promise.resolve(undefined)
+  })
+}
+
+describe('useSettings', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baseline))
+    store.dispatch(setOpenDialog(false))
+    vi.clearAllMocks()
+  })
+
+  describe('getSettings', () => {
+    it('fetches via get_settings and dispatches setSettings', async () => {
+      mockCommands({ get_settings: backendSettings })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      const fetched = await result.current.getSettings()
+
+      expect(mockInvoke).toHaveBeenCalledWith('get_settings')
+      expect(fetched).toEqual(backendSettings)
+      expect(store.getState().settings.dlOutputPath).toBe('/downloads')
+      expect(store.getState().settings.language).toBe('ja')
+    })
+  })
+
+  describe('updateSettings', () => {
+    it('dispatches first, then persists via set_settings', async () => {
+      mockCommands({ set_settings: undefined })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.updateSettings(backendSettings)
+
+      expect(mockInvoke).toHaveBeenCalledWith('set_settings', {
+        settings: backendSettings,
+      })
+      expect(store.getState().settings.dlOutputPath).toBe('/downloads')
+    })
+
+    it('keeps the dispatched state but throws when the backend rejects', async () => {
+      mockCommands({ set_settings: new Error('ERR::SAVE_FAILED') })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await expect(
+        result.current.updateSettings(backendSettings),
+      ).rejects.toThrow('ERR::SAVE_FAILED')
+      // The Redux update happened before the failed persistence call.
+      expect(store.getState().settings.dlOutputPath).toBe('/downloads')
+    })
+  })
+
+  describe('saveByForm', () => {
+    it('toasts settings.save_success on success', async () => {
+      mockCommands({ set_settings: undefined })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.saveByForm(backendSettings)
+
+      expect(toastSuccess).toHaveBeenCalledWith('settings.save_success')
+      expect(toastError).not.toHaveBeenCalled()
+    })
+
+    it('maps ERR:SETTINGS_PATH_NOT_DIRECTORY to a localized description', async () => {
+      mockCommands({
+        set_settings: new Error('ERR:SETTINGS_PATH_NOT_DIRECTORY'),
+      })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.saveByForm(backendSettings)
+
+      expect(toastError).toHaveBeenCalledWith('settings.save_failed_generic', {
+        duration: 10000,
+        description: 'settings.path_not_directory',
+      })
+    })
+
+    it('maps ERR:SETTINGS_PATH_NOT_EXIST to a localized description', async () => {
+      mockCommands({ set_settings: new Error('ERR:SETTINGS_PATH_NOT_EXIST') })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.saveByForm(backendSettings)
+
+      expect(toastError).toHaveBeenCalledWith('settings.save_failed_generic', {
+        duration: 10000,
+        description: 'settings.path_not_exist',
+      })
+    })
+
+    it('falls back to the raw error string for unknown codes', async () => {
+      mockCommands({ set_settings: new Error('weird failure') })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.saveByForm(backendSettings)
+
+      expect(toastError).toHaveBeenCalledWith('settings.save_failed_generic', {
+        duration: 10000,
+        // updateSettings re-wraps the backend error, so the raw fallback is
+        // double-prefixed: Error(String(Error('weird failure'))).
+        description: 'Error: Error: weird failure',
+      })
+    })
+
+    it('silent mode suppresses both success and error toasts', async () => {
+      mockCommands({ set_settings: new Error('ERR::SAVE_FAILED') })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.saveByForm(backendSettings, true)
+
+      expect(toastSuccess).not.toHaveBeenCalled()
+      expect(toastError).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateOpenDialog', () => {
+    it('dispatches setOpenDialog', () => {
+      const { result } = renderHookWithStore(() => useSettings())
+
+      result.current.updateOpenDialog(true)
+      expect(store.getState().settings.dialogOpen).toBe(true)
+
+      result.current.updateOpenDialog(false)
+      expect(store.getState().settings.dialogOpen).toBe(false)
+    })
+  })
+
+  describe('updateLanguage', () => {
+    it('changes i18n language and persists the settings', async () => {
+      mockCommands({ set_settings: undefined })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.updateLanguage('ja')
+
+      expect(mockChangeLanguage).toHaveBeenCalledWith('ja')
+      expect(mockInvoke).toHaveBeenCalledWith('set_settings', {
+        settings: expect.objectContaining({ language: 'ja' }),
+      })
+      expect(store.getState().settings.language).toBe('ja')
+    })
+  })
+
+  describe('updateLibPath', () => {
+    it('moves the lib, refetches settings, and toasts success', async () => {
+      mockCommands({
+        update_lib_path: undefined,
+        get_settings: backendSettings,
+      })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.updateLibPath('/Volumes/External')
+
+      expect(mockInvoke).toHaveBeenCalledWith('update_lib_path', {
+        newPath: '/Volumes/External',
+      })
+      expect(mockInvoke).toHaveBeenCalledWith('get_settings')
+      expect(toastSuccess).toHaveBeenCalledWith(
+        'settings.lib_path_change_success',
+      )
+    })
+
+    it('toasts the raw error and keeps the old settings on failure', async () => {
+      mockCommands({ update_lib_path: new Error('ERR::PERMISSION') })
+      const { result } = renderHookWithStore(() => useSettings())
+
+      await result.current.updateLibPath('/Volumes/External')
+
+      expect(toastError).toHaveBeenCalledWith(
+        'settings.lib_path_change_error',
+        {
+          duration: 10000,
+          description: 'Error: ERR::PERMISSION',
+        },
+      )
+      expect(mockInvoke).not.toHaveBeenCalledWith('get_settings')
+    })
+  })
+
+  describe('id2Label', () => {
+    it('returns the language label for a known id', () => {
+      const { result } = renderHookWithStore(() => useSettings())
+      const jaLabel = languages.find((l) => l.id === 'ja')!.label
+
+      expect(result.current.id2Label('ja')).toBe(jaLabel)
+    })
+
+    it('returns the id itself when unknown', () => {
+      const { result } = renderHookWithStore(() => useSettings())
+
+      expect(result.current.id2Label('xx' as 'ja')).toBe('xx')
+    })
+  })
+})

--- a/src/features/splash/hooks/useSplashLifecycle.test.tsx
+++ b/src/features/splash/hooks/useSplashLifecycle.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * useSplashLifecycle suite (fake timers): normal fade path, skip mode,
+ * finish_splash on done, disposed-before-fade guard.
+ *
+ * document.fonts.load is stubbed because happy-dom provides no FontFaceSet.
+ */
+
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSplashLifecycle } from './useSplashLifecycle'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+  vi.stubGlobal(
+    'document',
+    Object.assign(document, {
+      fonts: { load: vi.fn().mockResolvedValue(undefined) },
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+function settingsPayload(skip: boolean) {
+  mockInvoke.mockImplementation((cmd: string) =>
+    Promise.resolve(
+      cmd === 'get_settings' ? { skipSplashAnimation: skip } : undefined,
+    ),
+  )
+}
+
+async function flush(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('useSplashLifecycle', () => {
+  it('normal mode: active → fading after initialize + font + MIN_DISPLAY', async () => {
+    settingsPayload(false)
+    const { result } = renderHookWithStore(() => useSplashLifecycle())
+    expect(result.current.phase).toBe('active')
+
+    await flush(2_100)
+    expect(mockInvoke).toHaveBeenCalledWith('get_settings')
+    expect(mockInvoke).toHaveBeenCalledWith('initialize')
+    expect(result.current.phase).toBe('fading')
+    expect(result.current.skipMode).toBe(false)
+  })
+
+  it('skip mode: done immediately without the MIN_DISPLAY wait', async () => {
+    settingsPayload(true)
+    const { result } = renderHookWithStore(() => useSplashLifecycle())
+
+    await flush(10)
+    expect(result.current.phase).toBe('done')
+    expect(result.current.skipMode).toBe(true)
+  })
+
+  it('done phase invokes finish_splash exactly once', async () => {
+    settingsPayload(true)
+    const { result } = renderHookWithStore(() => useSplashLifecycle())
+    await flush(10)
+
+    expect(mockInvoke).toHaveBeenCalledWith('finish_splash')
+    const calls = mockInvoke.mock.calls.filter((c) => c[0] === 'finish_splash')
+    expect(calls).toHaveLength(1)
+
+    // Staying done must not re-fire
+    await flush(50)
+    expect(
+      mockInvoke.mock.calls.filter((c) => c[0] === 'finish_splash'),
+    ).toHaveLength(1)
+    expect(result.current.phase).toBe('done')
+  })
+
+  it('onFadeComplete transitions fading → done', async () => {
+    settingsPayload(false)
+    const { result } = renderHookWithStore(() => useSplashLifecycle())
+    await flush(2_100)
+    expect(result.current.phase).toBe('fading')
+
+    act(() => {
+      result.current.onFadeComplete()
+    })
+    expect(result.current.phase).toBe('done')
+  })
+
+  it('get_settings rejection defaults to the normal splash', async () => {
+    mockInvoke.mockRejectedValue(new Error('no store'))
+    const { result } = renderHookWithStore(() => useSplashLifecycle())
+    await flush(2_100)
+    expect(result.current.skipMode).toBe(false)
+    expect(result.current.phase).toBe('fading')
+  })
+})

--- a/src/features/trim/hooks/useTrim.test.tsx
+++ b/src/features/trim/hooks/useTrim.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * useTrim suite.
+ *
+ * Local-state tool hook: dialog picks via the setup plugin-dialog mocks,
+ * the trim_video / set_settings / reveal_in_folder commands via mockInvoke,
+ * progress via emitTauriEvent, and toasts via a local spy (identity t).
+ */
+
+import { store } from '@/app/store'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import { useTrim } from '@/features/trim/hooks/useTrim'
+import { toast } from '@/shared/ui/toast'
+import { clearTauriEvents, emitTauriEvent, mockInvoke } from '@/test/test-utils'
+import { open, save } from '@tauri-apps/plugin-dialog'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+const toastSuccess = toast.success as unknown as Mock
+const toastError = toast.error as unknown as Mock
+const mockOpen = open as unknown as Mock
+const mockSave = save as unknown as Mock
+
+const baseline: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+function mockCommands(handlers: Record<string, unknown>) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    const handler = handlers[cmd]
+    if (handler instanceof Error) return Promise.reject(handler)
+    if (handler !== undefined) return Promise.resolve(handler)
+    return Promise.resolve(undefined)
+  })
+}
+
+/** Picks an input and output so handleTrim can run. */
+async function pickPaths(
+  hook: { current: ReturnType<typeof useTrim> },
+  input = '/x/movie.mp4',
+  output = '/o/out.mp4',
+) {
+  mockOpen.mockResolvedValueOnce(input)
+  await act(async () => {
+    await hook.current.handleBrowse()
+  })
+  mockSave.mockResolvedValueOnce(output)
+  await act(async () => {
+    await hook.current.handleChooseOutput()
+  })
+}
+
+describe('useTrim', () => {
+  beforeEach(() => {
+    store.dispatch(setSettings(baseline))
+    clearTauriEvents()
+    vi.clearAllMocks()
+    mockCommands({})
+  })
+
+  it('starts idle with no paths and no range error', () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+
+    expect(result.current.inputPath).toBeNull()
+    expect(result.current.outputPath).toBeNull()
+    expect(result.current.status).toBe('idle')
+    expect(result.current.rangeError).toBeNull()
+    expect(result.current.progress).toBeNull()
+  })
+
+  it('rejects a trim with no range (both_empty) without invoking', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    await act(async () => {
+      await result.current.handleTrim()
+    })
+
+    expect(result.current.rangeError).toBe('both_empty')
+    expect(result.current.status).toBe('idle')
+    expect(mockInvoke).not.toHaveBeenCalledWith('trim_video')
+  })
+
+  it('rejects an inverted range (end_before_start)', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    act(() => {
+      result.current.setStart('00:00:10')
+      result.current.setEnd('00:00:05')
+    })
+    await act(async () => {
+      await result.current.handleTrim()
+    })
+
+    expect(result.current.rangeError).toBe('end_before_start')
+    expect(mockInvoke).not.toHaveBeenCalledWith('trim_video')
+  })
+
+  it('browse sets the input and resets a previously chosen output', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+    expect(result.current.outputPath).toBe('/o/out.mp4')
+
+    mockOpen.mockResolvedValueOnce('/x/other.mp4')
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+
+    expect(result.current.inputPath).toBe('/x/other.mp4')
+    expect(result.current.outputPath).toBeNull()
+  })
+
+  it('offers a *_trimmed.mp4 default name in the save dialog', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    mockOpen.mockResolvedValueOnce('/x/movie.mp4')
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+
+    mockSave.mockResolvedValueOnce('/o/out.mp4')
+    await act(async () => {
+      await result.current.handleChooseOutput()
+    })
+
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: 'movie_trimmed.mp4' }),
+    )
+    expect(result.current.outputPath).toBe('/o/out.mp4')
+  })
+
+  it('trims successfully with parsed timecodes and toasts', async () => {
+    mockCommands({ trim_video: { outputPath: '/o/out.mp4' } })
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    act(() => {
+      result.current.setStart('00:00:01')
+      result.current.setEnd('00:00:10')
+    })
+    await act(async () => {
+      await result.current.handleTrim()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('trim_video', {
+      options: {
+        inputPath: '/x/movie.mp4',
+        outputPath: '/o/out.mp4',
+        startTime: 1,
+        endTime: 10,
+        mode: 'copy',
+      },
+    })
+    expect(result.current.status).toBe('success')
+    expect(result.current.rangeError).toBeNull()
+    expect(result.current.progress?.progress).toBe(100)
+    expect(result.current.remainingSec).toBe(0)
+    expect(toastSuccess).toHaveBeenCalledWith(
+      'trim.success',
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'trim.openFolder' }),
+      }),
+    )
+  })
+
+  it('maps ERR::TRIM_SAME_PATH to a localized description', async () => {
+    mockCommands({ trim_video: new Error('ERR::TRIM_SAME_PATH') })
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    act(() => {
+      result.current.setStart('00:00:01')
+    })
+    await act(async () => {
+      await result.current.handleTrim()
+    })
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.progress).toBeNull()
+    expect(toastError).toHaveBeenCalledWith('trim.failed', {
+      description: 'trim.error.same_path',
+    })
+  })
+
+  it('setMode persists to the settings slice and backend', async () => {
+    mockCommands({ set_settings: undefined })
+    const { result } = renderHook(() => useTrim(), { wrapper })
+
+    act(() => {
+      result.current.setMode('reencode')
+    })
+
+    expect(result.current.mode).toBe('reencode')
+    expect(store.getState().settings.trimMode).toBe('reencode')
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('set_settings', {
+        settings: expect.objectContaining({ trimMode: 'reencode' }),
+      })
+    })
+  })
+
+  it('syncs the local mode when settings change externally', () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    expect(result.current.mode).toBe('copy')
+
+    act(() => {
+      store.dispatch(setSettings({ ...baseline, trimMode: 'reencode' }))
+    })
+
+    expect(result.current.mode).toBe('reencode')
+  })
+
+  it('updates progress from the trim://progress event while mounted', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    // Let the async listen() registration settle first.
+    await act(async () => {})
+
+    act(() => {
+      emitTauriEvent('trim://progress', {
+        progress: 40,
+        currentTimeSec: 4,
+        totalDurationSec: 10,
+      })
+    })
+
+    expect(result.current.progress?.progress).toBe(40)
+  })
+
+  it('reveal invokes reveal_in_folder with the output path', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    await act(async () => {
+      await result.current.handleReveal()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_in_folder', {
+      path: '/o/out.mp4',
+    })
+  })
+
+  it('reset clears paths, range, and progress', async () => {
+    const { result } = renderHook(() => useTrim(), { wrapper })
+    await pickPaths(result)
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.inputPath).toBeNull()
+    expect(result.current.outputPath).toBeNull()
+    expect(result.current.start).toBe('')
+    expect(result.current.end).toBe('')
+    expect(result.current.mode).toBe('copy')
+    expect(result.current.status).toBe('idle')
+    expect(result.current.progress).toBeNull()
+  })
+})

--- a/src/features/updater/hooks/useUpdateDownload.test.tsx
+++ b/src/features/updater/hooks/useUpdateDownload.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * useUpdateDownload suite: the Started/Progress/Finished reducer ladder,
+ * no-update and failure paths, retry, restart.
+ */
+
+import { store } from '@/app/store'
+import { resetUpdater } from '@/features/updater/model/updaterSlice'
+import { renderHookWithStore } from '@/test/test-utils'
+import { relaunch } from '@tauri-apps/plugin-process'
+import { check } from '@tauri-apps/plugin-updater'
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUpdateDownload } from './useUpdateDownload'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.dispatch(resetUpdater())
+})
+
+function mockUpdate(
+  events: { event: string; data: Record<string, number | null> }[],
+) {
+  vi.mocked(check).mockResolvedValue({
+    version: '1.2.0',
+    downloadAndInstall: vi.fn(async (onEvent) => {
+      for (const e of events) onEvent(e)
+    }),
+  } as never)
+}
+
+function updater() {
+  return store.getState().updater
+}
+
+describe('useUpdateDownload', () => {
+  it('ladders Started → Progress → Finished into Redux', async () => {
+    mockUpdate([
+      { event: 'Started', data: { contentLength: 200 } },
+      { event: 'Progress', data: { chunkLength: 100 } },
+      { event: 'Progress', data: { chunkLength: 50 } },
+      { event: 'Finished', data: {} },
+    ])
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+
+    expect(updater().downloadProgress).toBe(100)
+    expect(updater().isUpdateReady).toBe(true)
+    expect(updater().isDownloading).toBe(false)
+    expect(updater().error).toBeNull()
+  })
+
+  it('caps progress at 100 when chunks overshoot contentLength', async () => {
+    mockUpdate([
+      { event: 'Started', data: { contentLength: 100 } },
+      { event: 'Progress', data: { chunkLength: 250 } },
+      { event: 'Finished', data: {} },
+    ])
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+    expect(updater().downloadProgress).toBe(100)
+  })
+
+  it('zero contentLength keeps progress at 0 until Finished', async () => {
+    // Snapshot progress after each event: the intermediate Progress step
+    // must stay 0 (contentLength 0 guards the ratio), only Finished lifts
+    // it to 100 — otherwise this test is indistinguishable from the
+    // overshoot case above.
+    const snapshots: number[] = []
+    vi.mocked(check).mockResolvedValue({
+      version: '1.2.0',
+      downloadAndInstall: vi.fn(async (onEvent) => {
+        for (const e of [
+          { event: 'Started', data: { contentLength: 0 } },
+          { event: 'Progress', data: { chunkLength: 10 } },
+          { event: 'Finished', data: {} },
+        ]) {
+          onEvent(e)
+          snapshots.push(updater().downloadProgress)
+        }
+      }),
+    } as never)
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+    expect(snapshots[0]).toBe(0) // Started
+    expect(snapshots[1]).toBe(0) // Progress with contentLength 0
+    expect(snapshots[2]).toBe(100) // Finished
+  })
+
+  it('no update available sets the mapped error', async () => {
+    vi.mocked(check).mockResolvedValue(null)
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+    expect(updater().error).toBe('updater.error.no_update_available')
+    expect(updater().isDownloading).toBe(false)
+    expect(updater().downloadProgress).toBe(0)
+  })
+
+  it('download failure resets progress and sets the error', async () => {
+    vi.mocked(check).mockRejectedValue(new Error('network'))
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+    expect(updater().error).toBe('updater.error.download_failed')
+    expect(updater().downloadProgress).toBe(0)
+    expect(updater().isDownloading).toBe(false)
+  })
+
+  it('handleRetry clears the error and re-runs the download', async () => {
+    vi.mocked(check).mockRejectedValueOnce(new Error('flaky'))
+    mockUpdate([{ event: 'Finished', data: {} }])
+    const { result } = renderHookWithStore(() => useUpdateDownload())
+
+    await act(async () => {
+      await result.current.handleUpdate()
+    })
+    expect(updater().error).not.toBeNull()
+
+    act(() => {
+      result.current.handleRetry()
+    })
+    await waitFor(() => expect(updater().isUpdateReady).toBe(true))
+    await waitFor(() => expect(updater().error).toBeNull())
+    expect(updater().isUpdateReady).toBe(true)
+  })
+
+  it('handleRestart relaunches; failure sets restart_failed', async () => {
+    vi.mocked(relaunch).mockResolvedValue(undefined)
+    const ok = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await ok.result.current.handleRestart()
+    })
+    expect(relaunch).toHaveBeenCalledTimes(1)
+
+    vi.mocked(relaunch).mockRejectedValue(new Error('nope'))
+    const fail = renderHookWithStore(() => useUpdateDownload())
+    await act(async () => {
+      await fail.result.current.handleRestart()
+    })
+    expect(updater().error).toBe('updater.error.restart_failed')
+  })
+})

--- a/src/features/user/useUser.test.tsx
+++ b/src/features/user/useUser.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * useUser suite.
+ *
+ * getUserInfo drives the fetch_user command via mockInvoke and dispatches
+ * setUser; failures pass through interceptInvokeError and re-throw.
+ */
+
+import { store } from '@/app/store'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { useUser } from '@/features/user/useUser'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggedOutUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: { uname: '', isLogin: false, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: false,
+}
+
+const loggedInUser: User = {
+  code: 0,
+  message: 'ok',
+  ttl: 1,
+  data: {
+    mid: 42,
+    uname: 'bilibili fan',
+    isLogin: true,
+    wbiImg: { imgUrl: 'img', subUrl: 'sub' },
+  },
+  hasCookie: true,
+}
+
+describe('useUser', () => {
+  beforeEach(() => {
+    store.dispatch(setUser(loggedOutUser))
+    vi.clearAllMocks()
+  })
+
+  it('fetches via fetch_user, dispatches setUser, and returns the user', async () => {
+    mockInvoke.mockResolvedValue(loggedInUser)
+    const { result } = renderHookWithStore(() => useUser())
+
+    let fetched: User | undefined
+    await act(async () => {
+      fetched = await result.current.getUserInfo()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_user')
+    expect(fetched).toEqual(loggedInUser)
+    expect(store.getState().user.data.uname).toBe('bilibili fan')
+    expect(store.getState().user.data.isLogin).toBe(true)
+    expect(result.current.user.data.uname).toBe('bilibili fan')
+  })
+
+  it('re-throws fetch failures and keeps the previous user state', async () => {
+    mockInvoke.mockRejectedValue('ERR::UNAUTHORIZED')
+    const { result } = renderHookWithStore(() => useUser())
+
+    await act(async () => {
+      await expect(result.current.getUserInfo()).rejects.toBe(
+        'ERR::UNAUTHORIZED',
+      )
+    })
+
+    expect(store.getState().user.data.isLogin).toBe(false)
+  })
+
+  it('onChangeUser replaces the user state', () => {
+    const { result } = renderHookWithStore(() => useUser())
+
+    act(() => {
+      result.current.onChangeUser(loggedInUser)
+    })
+
+    expect(store.getState().user).toEqual(loggedInUser)
+    expect(result.current.user).toEqual(loggedInUser)
+  })
+})

--- a/src/features/video/hooks/usePartDownloadStatus.test.tsx
+++ b/src/features/video/hooks/usePartDownloadStatus.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * usePartDownloadStatus suite.
+ *
+ * Seeds the real store (queue + progress slices) and asserts the derived
+ * per-part status flags, including the "most recently enqueued part wins"
+ * downloadId resolution.
+ */
+
+import { store } from '@/app/store'
+import { usePartDownloadStatus } from '@/features/video/hooks/usePartDownloadStatus'
+import { clearProgress, setProgress } from '@/shared/progress/progressSlice'
+import {
+  clearQueue,
+  enqueue,
+  updateQueueStatus,
+} from '@/shared/queue/queueSlice'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+)
+
+const progressBase = {
+  downloadId: 'dl-p1',
+  filesize: 10,
+  downloaded: 1,
+  transferRate: 1024,
+  percentage: 10,
+  deltaTime: 0.5,
+  elapsedTime: 1,
+  isComplete: false,
+}
+
+describe('usePartDownloadStatus', () => {
+  beforeEach(() => {
+    store.dispatch(clearQueue())
+    store.dispatch(clearProgress())
+  })
+
+  it('returns empty status when the queue has no part', () => {
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.downloadId).toBeUndefined()
+    expect(result.current.status).toBeUndefined()
+    expect(result.current.isDownloading).toBe(false)
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.isComplete).toBe(false)
+    expect(result.current.progressEntries).toEqual([])
+  })
+
+  it('resolves the downloadId for part index 0 (-p1 suffix)', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-p1', status: 'running' }))
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.downloadId).toBe('dl-p1')
+    expect(result.current.status).toBe('running')
+    expect(result.current.isDownloading).toBe(true)
+    expect(result.current.isComplete).toBe(false)
+  })
+
+  it('isDownloading is false once the complete stage arrived', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-p1', status: 'running' }))
+    store.dispatch(
+      setProgress({ ...progressBase, stage: 'complete', isComplete: true }),
+    )
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.isComplete).toBe(true)
+    expect(result.current.isDownloading).toBe(false)
+  })
+
+  it('exposes error fields for an errored part', () => {
+    store.dispatch(
+      enqueue({
+        downloadId: 'dl-p1',
+        status: 'error',
+        errorMessage: 'boom',
+        outputPath: '/out/file.mp4',
+        filename: 'file.mp4',
+      }),
+    )
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.hasError).toBe(true)
+    expect(result.current.errorMessage).toBe('boom')
+    expect(result.current.outputPath).toBe('/out/file.mp4')
+    expect(result.current.filename).toBe('file.mp4')
+  })
+
+  it('flags cancelling and cancelled parts', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-p1', status: 'cancelling' }))
+    const first = renderHook(() => usePartDownloadStatus(0), { wrapper })
+    expect(first.result.current.isCancelling).toBe(true)
+    first.unmount()
+
+    store.dispatch(
+      updateQueueStatus({ downloadId: 'dl-p1', status: 'cancelled' }),
+    )
+    const second = renderHook(() => usePartDownloadStatus(0), { wrapper })
+    expect(second.result.current.isCancelled).toBe(true)
+    second.unmount()
+  })
+
+  it('prefers the most recently enqueued item for the same part index', () => {
+    // Simulates a re-download: a stale cancelled item from a prior session
+    // coexists with the fresh running one.
+    store.dispatch(enqueue({ downloadId: 'old-p1', status: 'cancelled' }))
+    store.dispatch(enqueue({ downloadId: 'new-p1', status: 'running' }))
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.downloadId).toBe('new-p1')
+    expect(result.current.isCancelled).toBe(false)
+    expect(result.current.isDownloading).toBe(true)
+  })
+
+  it('returns only the progress entries of the resolved download', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-p1', status: 'running' }))
+    store.dispatch(enqueue({ downloadId: 'dl-p2', status: 'running' }))
+    store.dispatch(setProgress({ ...progressBase, stage: 'video' }))
+    store.dispatch(
+      setProgress({ ...progressBase, downloadId: 'dl-p2', stage: 'video' }),
+    )
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+
+    expect(result.current.progressEntries).toHaveLength(1)
+    expect(result.current.progressEntries[0]!.downloadId).toBe('dl-p1')
+  })
+
+  it('re-renders when the queue status updates while mounted', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-p1', status: 'pending' }))
+    const { result } = renderHook(() => usePartDownloadStatus(0), { wrapper })
+    expect(result.current.isPending).toBe(true)
+
+    act(() => {
+      store.dispatch(updateQueueStatus({ downloadId: 'dl-p1', status: 'done' }))
+    })
+
+    expect(result.current.status).toBe('done')
+  })
+})

--- a/src/features/watch-history/hooks/useWatchHistory.test.tsx
+++ b/src/features/watch-history/hooks/useWatchHistory.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * useWatchHistory suite.
+ *
+ * Drives the fetch_watch_history command via mockInvoke, covering the
+ * first-page fetch, cursor-based pagination (including the empty-page
+ * isEnd guard), guards, error handling, and the filtered selectors.
+ */
+
+import { store } from '@/app/store'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { useWatchHistory } from '@/features/watch-history/hooks/useWatchHistory'
+import {
+  reset as resetWatchHistory,
+  setCursor,
+  setEntries,
+  setLoadingMore,
+  setSearchQuery,
+} from '@/features/watch-history/model/watchHistorySlice'
+import type {
+  WatchHistoryCursor,
+  WatchHistoryEntry,
+} from '@/features/watch-history/types'
+import { mockInvoke, renderHookWithStore } from '@/test/test-utils'
+import { act, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const nowSec = Math.floor(Date.now() / 1000)
+
+const entryOf = (
+  bvid: string,
+  title: string,
+  viewAt = nowSec,
+): WatchHistoryEntry => ({
+  title,
+  cover: 'cover',
+  bvid,
+  cid: 1,
+  page: 1,
+  viewAt,
+  duration: 60,
+  progress: 10,
+  url: 'url',
+})
+
+const loggedOutUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: { uname: '', isLogin: false, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: false,
+}
+
+const openCursor: WatchHistoryCursor = {
+  max: 7,
+  viewAt: 99,
+  isEnd: false,
+}
+
+function mockCommands(handlers: Record<string, unknown>) {
+  mockInvoke.mockImplementation((cmd: string) => {
+    const handler = handlers[cmd]
+    if (handler instanceof Error) return Promise.reject(handler)
+    if (handler !== undefined) return Promise.resolve(handler)
+    return Promise.resolve(undefined)
+  })
+}
+
+describe('useWatchHistory', () => {
+  beforeEach(() => {
+    store.dispatch(resetWatchHistory())
+    store.dispatch(setUser(loggedOutUser))
+    vi.clearAllMocks()
+    mockCommands({})
+  })
+
+  it('fetchInitial loads the first page with max=0, viewAt=0 and hides live entries', async () => {
+    mockCommands({
+      fetch_watch_history: {
+        entries: [entryOf('BV1', 'One'), entryOf('', 'Live stream')],
+        cursor: openCursor,
+      },
+    })
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.fetchInitial()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_watch_history', {
+      max: 0,
+      viewAt: 0,
+    })
+    // The live entry (empty bvid) is excluded by the selector.
+    expect(result.current.entries.map((e) => e.bvid)).toEqual(['BV1'])
+    expect(result.current.cursor).toEqual(openCursor)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('fetchMore appends the next page using the cursor boundary', async () => {
+    store.dispatch(setEntries([entryOf('BV1', 'One')]))
+    store.dispatch(setCursor(openCursor))
+    mockCommands({
+      fetch_watch_history: { entries: [entryOf('BV2', 'Two')], cursor: null },
+    })
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.fetchMore()
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_watch_history', {
+      max: 7,
+      viewAt: 99,
+    })
+    expect(result.current.entries.map((e) => e.bvid)).toEqual(['BV1', 'BV2'])
+    expect(result.current.loadingMore).toBe(false)
+  })
+
+  it('fetchMore marks the cursor ended on an empty page instead of looping', async () => {
+    store.dispatch(setEntries([entryOf('BV1', 'One')]))
+    store.dispatch(setCursor(openCursor))
+    const endCursor: WatchHistoryCursor = { max: 0, viewAt: 0, isEnd: false }
+    mockCommands({
+      fetch_watch_history: { entries: [], cursor: endCursor },
+    })
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.fetchMore()
+    })
+
+    expect(result.current.entries).toHaveLength(1)
+    expect(result.current.cursor?.isEnd).toBe(true)
+  })
+
+  it('fetchMore is a no-op without a cursor, at the end, or while loading more', async () => {
+    // No cursor at all.
+    const first = renderHookWithStore(() => useWatchHistory())
+    await act(async () => {
+      await first.result.current.fetchMore()
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+    first.unmount()
+
+    // Cursor already at the end.
+    store.dispatch(setCursor({ max: 1, viewAt: 1, isEnd: true }))
+    const second = renderHookWithStore(() => useWatchHistory())
+    await act(async () => {
+      await second.result.current.fetchMore()
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+    second.unmount()
+
+    // A load-more request is already in flight.
+    store.dispatch(setCursor(openCursor))
+    store.dispatch(setLoadingMore(true))
+    const third = renderHookWithStore(() => useWatchHistory())
+    await act(async () => {
+      await third.result.current.fetchMore()
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+    third.unmount()
+  })
+
+  it('sets the error message when the fetch fails', async () => {
+    mockCommands({ fetch_watch_history: new Error('ERR::RATE_LIMIT') })
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.fetchInitial()
+    })
+
+    expect(result.current.error).toBe('ERR::RATE_LIMIT')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('leaves the error unset for an unauthorized (handled) session expiry', async () => {
+    // Logged-out user: handleSessionExpiry returns early and the error is
+    // swallowed, so the slice must stay null.
+    // Plain-string rejection, the shape Tauri invoke actually rejects with.
+    mockInvoke.mockRejectedValue('ERR::UNAUTHORIZED')
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.fetchInitial()
+    })
+
+    expect(result.current.error).toBeNull()
+  })
+
+  it('filters entries by search query and date', async () => {
+    store.dispatch(
+      setEntries([entryOf('BV1', 'Alpha'), entryOf('BV2', 'Beta')]),
+    )
+    const { result } = renderHookWithStore(() => useWatchHistory())
+    await waitFor(() => expect(result.current.entries).toHaveLength(2))
+
+    act(() => result.current.setSearch('alpha'))
+    expect(result.current.entries.map((e) => e.title)).toEqual(['Alpha'])
+
+    act(() => result.current.setSearch(''))
+    act(() => result.current.setDate('today'))
+    // Both fixtures are stamped "now", so today keeps them; a month-old
+    // entry would drop out.
+    const stale = entryOf('BV3', 'Old', nowSec - 40 * 24 * 3600)
+    act(() => {
+      store.dispatch(setEntries([entryOf('BV1', 'Alpha'), stale]))
+    })
+    expect(result.current.entries.map((e) => e.title)).toEqual(['Alpha'])
+
+    expect(result.current.dateFilter).toBe('today')
+  })
+
+  it('refresh resets and refetches the first page', async () => {
+    store.dispatch(setEntries([entryOf('BV1', 'Stale')]))
+    store.dispatch(setSearchQuery('stale'))
+    mockCommands({
+      fetch_watch_history: {
+        entries: [entryOf('BV9', 'Fresh')],
+        cursor: openCursor,
+      },
+    })
+    const { result } = renderHookWithStore(() => useWatchHistory())
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.entries.map((e) => e.bvid)).toEqual(['BV9'])
+    expect(result.current.searchQuery).toBe('')
+    expect(result.current.cursor).toEqual(openCursor)
+  })
+})

--- a/src/shared/hooks/usePendingDownload.test.tsx
+++ b/src/shared/hooks/usePendingDownload.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * usePendingDownload suite.
+ *
+ * Asserts the setPendingDownload dispatch on the real store and the
+ * navigation to /home through MemoryRouter.
+ */
+
+import { store } from '@/app/store'
+import { resetInput } from '@/features/video/model/inputSlice'
+import { usePendingDownload } from '@/shared/hooks/usePendingDownload'
+import { act, renderHook, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>
+    <MemoryRouter initialEntries={['/watch-history']}>
+      <Routes>
+        <Route path="/home" element={<div>home-page</div>} />
+        <Route path="*" element={children} />
+      </Routes>
+    </MemoryRouter>
+  </Provider>
+)
+
+describe('usePendingDownload', () => {
+  beforeEach(() => {
+    store.dispatch(resetInput())
+  })
+
+  it('stores the pending download and navigates to /home', () => {
+    const { result } = renderHook(() => usePendingDownload(), { wrapper })
+
+    act(() => {
+      result.current('BV1xx411c7XD', 12345, 2)
+    })
+
+    expect(store.getState().input.pendingDownload).toEqual({
+      bvid: 'BV1xx411c7XD',
+      cid: 12345,
+      page: 2,
+    })
+    expect(screen.getByText('home-page')).toBeTruthy()
+  })
+
+  it('accepts a null cid (favorites entry point)', () => {
+    const { result } = renderHook(() => usePendingDownload(), { wrapper })
+
+    act(() => {
+      result.current('BV1favoritE', null, 1)
+    })
+
+    expect(store.getState().input.pendingDownload).toEqual({
+      bvid: 'BV1favoritE',
+      cid: null,
+      page: 1,
+    })
+    expect(screen.getByText('home-page')).toBeTruthy()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,7 +37,11 @@ export default defineConfig({
       ],
       // Ratchet baseline; bump per PR, 100 at the end of the F-series.
       // Lines only: v8 branch/function metrics on TSX are noisy.
-      thresholds: { lines: 28 },
+      // Why: 48 sits just under the measured lines coverage of this batch
+      // (48.87% via `npx vitest run --coverage`), so the gate passes today
+      // and only a real regression fails. v8 counts drift slightly across
+      // platforms, so on a CI/local mismatch re-measure rather than lowering.
+      thresholds: { lines: 48 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

F3 of the frontend test-coverage plan. **501 → 636 tests (+135)**, coverage threshold 28 → 48 (measured 48.87). No production code touched.

- **ListenerContext** (15 tests): all 7 backend events driven through the in-memory event bus — progress stage → queue status transitions, #492 merge-fallback and quality-fallback toasts, the late-cancel done/error race guard, quality/subtitle resolved payloads, retrying flag, and full listener detachment on unmount
- **UpdaterProvider** (5): production path unlocked via `vi.stubEnv('DEV', false)` — version dispatch, `get_release_notes` fetch, fallback message on notes failure, silent offline handling
- **useUpdateDownload** (7): Started/Progress/Finished ladder with per-event progress snapshots, 100% cap on chunk overshoot, zero-contentLength guard, retry, relaunch failure mapping
- **Feature hooks** (14 suites): settings/theme/init/pendingDownload/partStatus/history/favorite/watchHistory/user/trim + rotation (settings persistence, lifecycle), audio (probe-driven bitrate auto-select incl. probe-rejection fallback), concat (validation gates, fallback toast, progress), splash lifecycle (fake-timer phases, `finish_splash` fired exactly once)

## Testing

`npm run test:coverage`: 636 passed / 4 skipped, threshold met (48.87% ≥ 48). typecheck / lint / prettier / build green. Review pass verified event maps and lifecycle assertions against hook sources; one undiscriminating test (zero-contentLength) was tightened to per-event snapshots during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)