### PR TITLE
fix(login): make QR code login session actually take effect

### DIFF
--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -101,9 +101,21 @@ pub async fn initialize(app: AppHandle) -> Result<(), String> {
                         Ok(_) => {
                             emit_step(&app, "init.cookie_refreshed");
                         }
-                        Err(_) => {
-                            // Refresh failed: clear the stale session, stay logged out.
-                            let _ = qr_login::logout(&app).await;
+                        Err(e) => {
+                            // Refresh failed: keep the stale session file for now so
+                            // the user can retry without re-scanning on transient
+                            // network failures, but do not claim the session was
+                            // restored. The subsequent `fetch_user_info` will
+                            // return `isLogin=false` for a truly invalid session,
+                            // and `SettingsForm` now checks the live user state
+                            // (not just file existence) so the UI stays
+                            // consistent (both AppBar and Settings show not
+                            // logged-in / expired).
+                            log::warn!(
+                                "[BE] init: cookie refresh failed, keeping stale session for retry: {}",
+                                e
+                            );
+                            emit_step(&app, "init.cookie_failed");
                         }
                     }
                 }

--- a/src-tauri/src/handlers/qr_login.rs
+++ b/src-tauri/src/handlers/qr_login.rs
@@ -21,14 +21,13 @@ use std::sync::RwLock;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use image::Luma;
 use qrcode::QrCode;
-use reqwest::Client;
 use reqwest::Url;
 use tauri::AppHandle;
 use tauri::Manager;
 use tauri_plugin_store::StoreExt;
 
 use crate::constants;
-use crate::handlers::bilibili::fetch_user_info;
+use crate::handlers::bilibili::build_client;
 use crate::models::cookie::CookieCache;
 use crate::models::cookie::CookieEntry;
 use crate::models::qr_login::{
@@ -88,6 +87,70 @@ fn bilibili_cookie(name: &str, value: String) -> CookieEntry {
         name: name.to_string(),
         value,
     }
+}
+
+/// Builds a `Cookie` header value from a `Session` without touching the
+/// global `CookieCache`. Used for temporary verification of a freshly
+/// extracted QR session (review P2: avoid polluting the global cache on
+/// failure and avoid deleting Firefox cookies on `clear_cookie_cache`).
+fn build_cookie_header_from_session(session: &Session) -> String {
+    let mut parts = vec![
+        format!("SESSDATA={}", session.sessdata),
+        format!("bili_jct={}", session.bili_jct),
+        format!("DedeUserID={}", session.dede_user_id),
+        format!("DedeUserID__ckMd5={}", session.dede_user_id_ck_md5),
+    ];
+    if !session.buvid3.is_empty() {
+        parts.push(format!("buvid3={}", session.buvid3));
+    }
+    if !session.buvid4.is_empty() {
+        parts.push(format!("buvid4={}", session.buvid4));
+    }
+    parts.join("; ")
+}
+
+/// Verifies a session by calling the nav API with a temporary cookie header.
+///
+/// Does not read or write the global `CookieCache`, so a failed
+/// verification never clobbers existing Firefox cookies.
+async fn verify_session_with_header(
+    cookie_header: &str,
+) -> Result<crate::models::frontend_dto::User, String> {
+    use crate::handlers::bilibili::BiliApi;
+    use crate::models::bilibili_api::UserApiResponse;
+    use crate::models::frontend_dto::{User, UserData};
+
+    if cookie_header.is_empty() {
+        return Ok(User {
+            code: 0,
+            message: String::new(),
+            data: UserData {
+                mid: None,
+                uname: None,
+                is_login: false,
+            },
+            has_cookie: false,
+        });
+    }
+
+    let api = BiliApi::from_cookie_header(cookie_header.to_string())?;
+    let body = api
+        .get("/x/web-interface/nav")
+        .await?
+        .json::<UserApiResponse>()
+        .await
+        .map_err(|e| format!("UserApi Failed to parse response JSON:: {e}"))?;
+
+    Ok(User {
+        code: body.code,
+        message: body.message,
+        data: UserData {
+            mid: body.data.mid,
+            uname: body.data.uname,
+            is_login: body.data.is_login,
+        },
+        has_cookie: true,
+    })
 }
 
 /// Saves session to encrypted file storage.
@@ -208,11 +271,43 @@ fn delete_session_from_store(app: &AppHandle) -> Result<(), String> {
 /// - QR code generation fails
 pub async fn generate_qr_code(_app: &AppHandle) -> Result<QrCodeResult, String> {
     log::info!("[BE] generate_qr_code: generating QR code");
-    let client = Client::new();
 
-    // Call Bilibili QR generate API
-    let response = client
+    // Pre-fetch buvid3/buvid4 to activate device fingerprint before QR
+    // generation. Bilibili passport risk control may require a valid device
+    // fingerprint. The returned buvid values are forwarded as `Cookie`
+    // headers on the generate request so the server sees a consistent
+    // fingerprint (previous code fetched but discarded them, so the next
+    // request used a fresh client without cookies).
+    // Best-effort: failure is logged but does not block QR generation.
+    let buvid_cookie = match fetch_buvid().await {
+        Ok((b3, b4)) => {
+            log::info!(
+                "[BE] generate_qr_code: pre-fetched buvid3 ({} bytes), buvid4 ({} bytes) to activate fingerprint",
+                b3.len(),
+                b4.len()
+            );
+            if b3.is_empty() && b4.is_empty() {
+                String::new()
+            } else {
+                format!("buvid3={}; buvid4={}", b3, b4)
+            }
+        }
+        Err(e) => {
+            log::warn!("[BE] generate_qr_code: failed to pre-fetch buvid: {}", e);
+            String::new()
+        }
+    };
+
+    let client = build_client()?;
+
+    // Call Bilibili QR generate API (with UA/Referer to match other Bilibili requests)
+    let mut request = client
         .get(QR_GENERATE_URL)
+        .header(reqwest::header::REFERER, constants::REFERER);
+    if !buvid_cookie.is_empty() {
+        request = request.header(reqwest::header::COOKIE, buvid_cookie);
+    }
+    let response = request
         .send()
         .await
         .map_err(|e| format!("Failed to request QR code: {}", e))?;
@@ -279,15 +374,28 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
         "[BE] poll_qr_status: polling with qrcode_key={}",
         qrcode_key
     );
-    let client = Client::new();
+    let client = build_client()?;
 
-    // Call Bilibili QR poll API
-    let url = format!("{}?qrcode_key={}", QR_POLL_URL, qrcode_key);
+    // Call Bilibili QR poll API (with UA/Referer to match other Bilibili requests).
+    // `source=main-fe-header` matches the web header login widget; without it
+    // some responses omit Set-Cookie headers.
     let response = client
-        .get(&url)
+        .get(QR_POLL_URL)
+        .header(reqwest::header::REFERER, constants::REFERER)
+        .query(&[("qrcode_key", qrcode_key), ("source", "main-fe-header")])
         .send()
         .await
         .map_err(|e| format!("Failed to poll QR status: {}", e))?;
+
+    // Current Bilibili poll responses may leave credentials out of `data.url`
+    // and deliver them only as Set-Cookie. Capture headers before consuming
+    // the body.
+    let set_cookie_values: Vec<String> = response
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_string))
+        .collect();
 
     let poll_response: QrCodePollResponse = response
         .json()
@@ -306,7 +414,31 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
 
     // On success, extract cookies and store session
     if status == QrCodeStatus::Success {
-        let mut session = extract_session_from_url(&data.url, &data.refresh_token, data.timestamp)?;
+        let mut session = match extract_session(
+            &data.url,
+            &set_cookie_values,
+            &data.refresh_token,
+            data.timestamp,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("[BE] poll_qr_status: failed to extract session: {}", e);
+                return Ok(QrPollResult {
+                    status: QrCodeStatus::Error,
+                    message: e,
+                    session: None,
+                });
+            }
+        };
+
+        // Diagnostic: log extracted cookie lengths for troubleshooting
+        // (do not log values themselves to avoid leaking tokens)
+        log::info!(
+            "[BE] poll_qr_status: extracted sessdata {} bytes, bili_jct {} bytes, dede_user_id={}",
+            session.sessdata.len(),
+            session.bili_jct.len(),
+            session.dede_user_id
+        );
 
         // Fetch buvid3/buvid4 for WBI authentication
         match fetch_buvid().await {
@@ -321,24 +453,59 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
             }
         }
 
-        // Also update the in-memory cookie cache for immediate use
-        update_cookie_cache(app, &session);
-
-        // Fetch username from user info API
-        match fetch_user_info(app).await {
+        // Verify session validity using a temporary cookie header so the
+        // global `CookieCache` (which may hold Firefox cookies) is not
+        // polluted on failure. Only on successful verification do we commit
+        // the new cookies to the global cache and persistent storage (review
+        // P2).
+        let temp_cookie_header = build_cookie_header_from_session(&session);
+        match verify_session_with_header(&temp_cookie_header).await {
             Ok(user) => {
+                log::info!(
+                    "[BE] poll_qr_status: verification is_login={}, has_cookie={}, uname={:?}, sessdata_len={}, bili_jct_len={}",
+                    user.data.is_login,
+                    user.has_cookie,
+                    user.data.uname,
+                    session.sessdata.len(),
+                    session.bili_jct.len()
+                );
+                if !user.data.is_login {
+                    log::error!(
+                        "[BE] poll_qr_status: login verification failed - is_login=false (code={}), sessdata_len={}, bili_jct_len={}, refresh_token_len={}",
+                        user.code,
+                        session.sessdata.len(),
+                        session.bili_jct.len(),
+                        session.refresh_token.len()
+                    );
+                    return Ok(QrPollResult {
+                        status: QrCodeStatus::Error,
+                        message: "ERR::QR_COOKIE_REJECTED".to_string(),
+                        session: None,
+                    });
+                }
                 if let Some(uname) = user.data.uname {
                     session.uname = uname;
                 }
+                // Verification succeeded: commit to global cache and storage.
+                update_cookie_cache(app, &session);
+                save_session(app, &session).await?;
             }
             Err(e) => {
-                log::debug!("[BE] Failed to fetch user info: {}", e);
-                // Continue without uname - not critical
+                // Nav API failure is likely transient (network). Keep the
+                // session and commit it so a fresh SESSDATA that may actually
+                // be valid is not discarded. The frontend's `getUserInfo`
+                // verification (QRCodeDisplay) will surface the state and
+                // avoid closing the dialog on a false success.
+                log::warn!(
+                    "[BE] poll_qr_status: nav API failed after QR login, keeping session: {}, sessdata_len={}, bili_jct_len={}",
+                    e,
+                    session.sessdata.len(),
+                    session.bili_jct.len()
+                );
+                update_cookie_cache(app, &session);
+                save_session(app, &session).await?;
             }
         }
-
-        // Store session to persistent storage
-        save_session(app, &session).await?;
     }
 
     Ok(QrPollResult {
@@ -362,11 +529,10 @@ pub async fn poll_qr_status(app: &AppHandle, qrcode_key: &str) -> Result<QrPollR
 /// Returns an error if the API request fails or returns invalid data.
 async fn fetch_buvid() -> Result<(String, String), String> {
     log::info!("[BE] fetch_buvid: fetching buvid3/buvid4 from API");
-    let client = Client::new();
+    let client = build_client()?;
 
     let response = client
         .get("https://api.bilibili.com/x/frontend/finger/spi")
-        .header(reqwest::header::USER_AGENT, constants::USER_AGENT)
         .header(reqwest::header::REFERER, constants::REFERER)
         .send()
         .await
@@ -394,36 +560,92 @@ async fn fetch_buvid() -> Result<(String, String), String> {
     Ok((data.b_3, data.b_4))
 }
 
-/// Extracts session data from the login URL.
+/// Builds a session from the QR poll payload.
 ///
-/// The URL contains query parameters with cookie values.
-fn extract_session_from_url(
+/// Credentials may arrive as query params on `data.url` (legacy) and/or as
+/// `Set-Cookie` headers on the poll response (current Bilibili clients).
+/// Header values overlay URL params. `SESSDATA` and `bili_jct` must be
+/// present or login is treated as failed rather than stored as an incomplete
+/// session (SESSDATA alone cannot perform authenticated writes).
+///
+/// This dual-source extraction is critical because recent Bilibili poll
+/// responses may return an empty `data.url` and deliver credentials only
+/// via `Set-Cookie` (see PR #546). Header extraction uses
+/// `parse_set_cookie_values` which handles `; Path=/` attributes and
+/// last-write-wins for duplicate names.
+fn extract_session(
     url: &str,
+    set_cookie_values: &[String],
     refresh_token: &str,
     timestamp: i64,
 ) -> Result<Session, String> {
-    // Parse URL and extract query parameters
-    let parsed_url = Url::parse(url).map_err(|e| format!("Failed to parse login URL: {}", e))?;
+    let mut fields: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
-    let query_pairs: std::collections::HashMap<String, String> = parsed_url
-        .query_pairs()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect();
+    if !url.is_empty() {
+        if let Ok(parsed_url) = Url::parse(url) {
+            for (k, v) in parsed_url.query_pairs() {
+                fields.insert(k.to_string(), v.to_string());
+            }
+        } else {
+            log::warn!("[BE] extract_session: failed to parse url, trying Set-Cookie only");
+        }
+    }
+
+    for (k, v) in parse_set_cookie_values(set_cookie_values) {
+        fields.insert(k, v);
+    }
+
+    let sessdata = fields.get("SESSDATA").cloned().unwrap_or_default();
+    if sessdata.is_empty() {
+        log::error!(
+            "[BE] extract_session: SESSDATA is empty or missing, url_len={}, cookie_headers={}, refresh_token_len={}, timestamp={}",
+            url.len(),
+            set_cookie_values.len(),
+            refresh_token.len(),
+            timestamp
+        );
+        return Err("ERR::QR_SESSDATA_MISSING".to_string());
+    }
+
+    // A session without the CSRF token can read public data but every
+    // authenticated write (favorites, cookie refresh confirm) would fail,
+    // so treat it as an incomplete login rather than storing it.
+    let bili_jct = fields.get("bili_jct").cloned().unwrap_or_default();
+    if bili_jct.is_empty() {
+        log::error!(
+            "[BE] extract_session: bili_jct is empty or missing (SESSDATA {} bytes), url_len={}, cookie_headers={}, refresh_token_len={}, timestamp={}",
+            sessdata.len(),
+            url.len(),
+            set_cookie_values.len(),
+            refresh_token.len(),
+            timestamp
+        );
+        return Err("ERR::QR_SESSDATA_MISSING".to_string());
+    }
 
     Ok(Session {
-        sessdata: query_pairs.get("SESSDATA").cloned().unwrap_or_default(),
-        bili_jct: query_pairs.get("bili_jct").cloned().unwrap_or_default(),
-        dede_user_id: query_pairs.get("DedeUserID").cloned().unwrap_or_default(),
-        dede_user_id_ck_md5: query_pairs
-            .get("DedeUserID__ckMd5")
-            .cloned()
-            .unwrap_or_default(),
+        sessdata,
+        bili_jct,
+        dede_user_id: fields.get("DedeUserID").cloned().unwrap_or_default(),
+        dede_user_id_ck_md5: fields.get("DedeUserID__ckMd5").cloned().unwrap_or_default(),
         refresh_token: refresh_token.to_string(),
         timestamp,
         uname: String::new(),
         buvid3: String::new(),
         buvid4: String::new(),
     })
+}
+
+/// Extracts session data from the login URL only (legacy helper for tests).
+///
+/// Thin wrapper around `extract_session` with no Set-Cookie headers.
+#[allow(dead_code)]
+fn extract_session_from_url(
+    url: &str,
+    refresh_token: &str,
+    timestamp: i64,
+) -> Result<Session, String> {
+    extract_session(url, &[], refresh_token, timestamp)
 }
 
 /// Saves the session to encrypted file storage and login method to store.
@@ -720,10 +942,13 @@ pub async fn check_cookie_refresh(app: &AppHandle) -> Result<CookieRefreshInfo, 
     let cookies = get_cookie_header(app);
     log::debug!("[BE] Checking with cookies: {} bytes", cookies.len());
 
-    let client = Client::new();
+    // UA/Referer to match other Bilibili requests: bare clients trip passport
+    // risk control, which misreads valid sessions as expired (-101).
+    let client = build_client()?;
     let response = client
         .get(COOKIE_INFO_URL)
         .header("Cookie", &cookies)
+        .header(reqwest::header::REFERER, constants::REFERER)
         .send()
         .await
         .map_err(|e| format!("Failed to check cookie refresh: {}", e))?;
@@ -828,14 +1053,18 @@ async fn fetch_refresh_csrf(app: &AppHandle, correspond_path: &str) -> Result<St
     let url = format!("{}{}", CORRESPOND_URL_PREFIX, correspond_path);
     log::debug!("[BE] fetch_refresh_csrf: URL: {}", url);
 
-    let client = Client::new();
+    // build_client() supplies the canonical USER_AGENT; the previous inline
+    // Chrome/120 string went stale as fingerprinting material.
+    let client = build_client()?;
     let response = client
         .get(&url)
         .header("Cookie", &cookies)
-        .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        .header(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
         .header("Accept-Language", "en-US,en;q=0.5")
         .header("Accept-Encoding", "identity")
-        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
         .send()
         .await
         .map_err(|e| format!("Failed to fetch refresh_csrf: {}", e))?;
@@ -932,7 +1161,8 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
 
     // Step 3: Call cookie refresh API
     let cookies = get_cookie_header(app);
-    let client = Client::new();
+    // UA/Referer to match other Bilibili requests (passport risk control).
+    let client = build_client()?;
 
     let params = [
         ("csrf", session.bili_jct.clone()),
@@ -945,6 +1175,7 @@ pub async fn refresh_cookie(app: &AppHandle) -> Result<Session, String> {
     let response = client
         .post(COOKIE_REFRESH_URL)
         .header("Cookie", &cookies)
+        .header(reqwest::header::REFERER, constants::REFERER)
         .form(&params)
         .send()
         .await
@@ -1130,16 +1361,82 @@ mod tests {
 
     #[test]
     fn extract_session_from_url_missing_params_default_empty() {
-        let session =
-            extract_session_from_url("https://example.com/crossDomain?x=1", "rt", 1).unwrap();
-        assert!(session.sessdata.is_empty());
-        assert!(session.bili_jct.is_empty());
-        assert_eq!(session.refresh_token, "rt");
+        // SESSDATA is now required; missing SESSDATA must error instead of
+        // silently returning an empty session (prevents persisting invalid logins).
+        let err =
+            extract_session_from_url("https://example.com/crossDomain?x=1", "rt", 1).unwrap_err();
+        assert!(
+            err.contains("SESSDATA"),
+            "missing SESSDATA must error: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_session_from_url_empty_sessdata_errors() {
+        let err = extract_session_from_url(
+            "https://example.com/crossDomain?SESSDATA=&bili_jct=jct",
+            "rt",
+            1,
+        )
+        .unwrap_err();
+        assert!(err.contains("SESSDATA"), "empty SESSDATA must error: {err}");
+    }
+
+    #[test]
+    fn extract_session_missing_bili_jct_errors() {
+        // SESSDATA without the CSRF token is an incomplete login: it can read
+        // public data but every authenticated write would fail.
+        let err =
+            extract_session_from_url("https://example.com/crossDomain?SESSDATA=s%2Cd", "rt", 1)
+                .unwrap_err();
+        assert!(
+            err.contains("SESSDATA"),
+            "missing bili_jct must error with the credentials code: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_session_bili_jct_from_set_cookie_overlays_missing_url_param() {
+        // SESSDATA arrives on data.url, bili_jct only via Set-Cookie.
+        let cookies = vec!["bili_jct=csrf; Path=/".to_string()];
+        let session = extract_session(
+            "https://passport.biligame.com/crossDomain?SESSDATA=s%2Cd",
+            &cookies,
+            "rt",
+            1,
+        )
+        .unwrap();
+        assert_eq!(session.sessdata, "s,d");
+        assert_eq!(session.bili_jct, "csrf");
     }
 
     #[test]
     fn extract_session_from_url_rejects_garbage() {
         assert!(extract_session_from_url("not a url", "rt", 1).is_err());
+    }
+
+    #[test]
+    fn extract_session_from_set_cookie_when_url_has_no_credentials() {
+        let cookies = vec![
+            "SESSDATA=from-header; Path=/; HttpOnly".to_string(),
+            "bili_jct=csrf; Path=/".to_string(),
+            "DedeUserID=99; Path=/".to_string(),
+            "DedeUserID__ckMd5=md5; Path=/".to_string(),
+        ];
+        let session = extract_session("https://www.bilibili.com/", &cookies, "rt", 1).unwrap();
+        assert_eq!(session.sessdata, "from-header");
+        assert_eq!(session.bili_jct, "csrf");
+        assert_eq!(session.dede_user_id, "99");
+        assert_eq!(session.dede_user_id_ck_md5, "md5");
+    }
+
+    #[test]
+    fn extract_session_set_cookie_overlays_url() {
+        let url = "https://passport.biligame.com/crossDomain?SESSDATA=from-url&bili_jct=old";
+        let cookies = vec!["SESSDATA=from-header; Path=/".to_string()];
+        let session = extract_session(url, &cookies, "rt", 1).unwrap();
+        assert_eq!(session.sessdata, "from-header");
+        assert_eq!(session.bili_jct, "old");
     }
 
     #[test]

--- a/src/features/login/ui/QRCodeDisplay.tsx
+++ b/src/features/login/ui/QRCodeDisplay.tsx
@@ -27,6 +27,7 @@
 
 import { useUser } from '@/features/user'
 import { logger } from '@/shared/lib/logger'
+import { mapBackendError } from '@/shared/lib/mapBackendError'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/button'
 import {
@@ -38,16 +39,18 @@ import {
 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
+import { setError, setQrStatus } from '../model/loginSlice'
 import { useLogin } from '../model/useLogin'
 
 /**
  * QRCodeDisplay component props.
- *
- * Currently this component has no props as it manages all its state
- * internally via the useLogin hook.
  */
-export type QRCodeDisplayProps = Record<string, never>
+export type QRCodeDisplayProps = {
+  /** Optional callback invoked after successful login (after success animation). */
+  onSuccess?: () => void
+}
 
 /**
  * Status configuration for display.
@@ -81,9 +84,10 @@ interface StatusConfig {
  * <QRCodeDisplay />
  * ```
  */
-export function QRCodeDisplay() {
+export function QRCodeDisplay({ onSuccess }: QRCodeDisplayProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const dispatch = useDispatch()
   const { getUserInfo } = useUser()
   const {
     qrCodeImage,
@@ -93,7 +97,6 @@ export function QRCodeDisplay() {
     error,
     generateNewQrCode,
     stopPolling,
-    resetLogin,
   } = useLogin()
 
   // Track if we've handled the success state to prevent duplicate navigation
@@ -103,17 +106,13 @@ export function QRCodeDisplay() {
   const navigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   /**
-   * Reset login state and generate QR code on mount.
+   * Generate a QR code on mount.
    *
-   * This effect runs when the component first mounts:
-   * 1. Resets the login state to clear any previous success/error status
-   * 2. Generates a new QR code
-   * 3. Enables success handling after QR code is generated
+   * `generateNewQrCode` already clears prior QR UI state (via `clearQrCode`);
+   * do not call `resetLogin()` here — it would wipe the just-saved session
+   * and reset the login method to Firefox (see PR #546).
    */
   useEffect(() => {
-    // Reset login state to clear previous success status
-    resetLogin()
-    // Generate QR code and enable success handling after it's ready
     generateNewQrCode().then(() => {
       // Enable success handling only after new QR code is generated
       setHasHandledSuccess(false)
@@ -136,7 +135,7 @@ export function QRCodeDisplay() {
   }, [])
 
   /**
-   * Handle login success - navigate to home after short delay.
+   * Handle login success - navigate to home or invoke onSuccess after short delay.
    *
    * This effect:
    * 1. Detects when login status changes to 'success'
@@ -144,10 +143,11 @@ export function QRCodeDisplay() {
    * 3. Requires qrCodeImage to exist (guards against stale success state)
    * 4. Stops polling immediately
    * 5. Refreshes user info to update app bar
-   * 6. Navigates to home after 1.5 second delay to show success message
+   * 6. After 1.5s delay to show success animation, either calls onSuccess
+   *    (when rendered inside a dialog) or navigates to home (standalone page)
    *
-   * The delay allows the user to see the success animation before
-   * being redirected to the home page.
+   * The onSuccess callback allows QRCodeLoginDialog to auto-close after a
+   * successful login without relying on navigation side-effects.
    */
   useEffect(() => {
     // Only run once when qrStatus becomes 'success' AND qrCodeImage exists
@@ -158,17 +158,56 @@ export function QRCodeDisplay() {
       // Stop polling immediately to prevent unnecessary API calls
       stopPolling()
 
-      // Refresh user info to update AppBar with logged-in state
-      getUserInfo().catch((e) =>
-        logger.error('QRCodeDisplay: Failed to get user info after login', e),
-      )
-
-      // Navigate after a short delay to show success message
-      navigationTimerRef.current = setTimeout(() => {
-        navigate('/home')
-      }, 1500)
+      // Verify that the QR login actually established a valid session before
+      // closing the dialog or navigating. If verification fails, keep the
+      // dialog open and surface an error so the user can retry instead of
+      // showing a false "success" that leaves the AppBar in a logged-out
+      // state (see review P1).
+      getUserInfo()
+        .then((user) => {
+          if (!user.data.isLogin) {
+            logger.error(
+              'QRCodeDisplay: getUserInfo after QR success returned isLogin=false',
+              user,
+            )
+            dispatch(
+              setQrStatus({
+                status: 'error',
+                message: 'ERR::QR_VERIFY_FAILED',
+              }),
+            )
+            dispatch(setError('ERR::QR_VERIFY_FAILED'))
+            return
+          }
+          // After delay to show success message, either close dialog or navigate
+          navigationTimerRef.current = setTimeout(() => {
+            if (onSuccess) {
+              onSuccess()
+            } else {
+              navigate('/home')
+            }
+          }, 1500)
+        })
+        .catch((e) => {
+          logger.error('QRCodeDisplay: Failed to get user info after login', e)
+          dispatch(
+            setQrStatus({
+              status: 'error',
+              message: 'ERR::QR_VERIFY_FAILED',
+            }),
+          )
+          dispatch(setError('ERR::QR_VERIFY_FAILED'))
+        })
     }
-  }, [qrStatus, qrCodeImage, hasHandledSuccess]) // Minimal deps - navigate and getUserInfo are stable
+  }, [
+    qrStatus,
+    qrCodeImage,
+    hasHandledSuccess,
+    onSuccess,
+    navigate,
+    getUserInfo,
+    dispatch,
+  ])
 
   /**
    * Gets the status configuration based on current QR code status.
@@ -192,12 +231,16 @@ export function QRCodeDisplay() {
           text: t('login.qrExpired', 'QR code expired'),
           colorClass: 'text-red-500',
         }
-      case 'error':
+      case 'error': {
+        const mappedKey = statusMessage ? mapBackendError(statusMessage) : null
         return {
           icon: <XCircle className="h-5 w-5 text-red-500" />,
-          text: statusMessage || t('login.loginFailed', 'Login failed'),
+          text: mappedKey
+            ? t(mappedKey)
+            : statusMessage || t('login.loginFailed', 'Login failed'),
           colorClass: 'text-red-500',
         }
+      }
       case 'scannedWaitingConfirm':
         return {
           icon: <Smartphone className="h-5 w-5 text-blue-500" />,
@@ -287,7 +330,14 @@ export function QRCodeDisplay() {
       </div>
 
       {/* Error message - shown when polling fails */}
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {error && (
+        <p className="text-sm text-red-500">
+          {(() => {
+            const k = mapBackendError(error)
+            return k ? t(k) : error
+          })()}
+        </p>
+      )}
 
       {/* Instructions - shown when waiting for user to scan */}
       {qrStatus === 'waitingForScan' && (

--- a/src/features/login/ui/QRCodeLoginDialog.tsx
+++ b/src/features/login/ui/QRCodeLoginDialog.tsx
@@ -54,7 +54,10 @@ export function QRCodeLoginDialog({
         <DialogHeader>
           <DialogTitle>{t('login.title', 'Login to Bilibili')}</DialogTitle>
         </DialogHeader>
-        <QRCodeDisplay />
+        {/* Mount QRCodeDisplay only when open so polling stops on close
+            and a fresh QR is generated on each open (remount triggers
+            QRCodeDisplay's mount effect). */}
+        {open && <QRCodeDisplay onSuccess={() => onOpenChange(false)} />}
       </DialogContent>
     </Dialog>
   )

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -7,7 +7,7 @@ import {
   type LoginMethod,
   type Session,
 } from '@/features/login'
-import { useUser } from '@/features/user'
+import { fetchUser, useUser } from '@/features/user'
 import type { User } from '@/features/user/types'
 import { setUser } from '@/features/user/userSlice'
 import { videoApi } from '@/features/video'
@@ -104,6 +104,13 @@ function getLoginStatusText(
       : 'login.notLoggedIn'
   }
   if (session === null) return 'login.notLoggedIn'
+  // QR method with a stored session: the file existing does not guarantee
+  // the cookies are still valid (e.g. refresh failed, wind-control issued an
+  // empty SESSDATA). Check the live user state as well so the Settings UI
+  // stays consistent with the AppBar, which is driven by the nav API.
+  if (!user.hasCookie || !user.data.isLogin) {
+    return 'login.session_expired'
+  }
   return 'login.qrCodeLoggedIn'
 }
 
@@ -269,13 +276,24 @@ function SettingsForm() {
    * Refreshes local login state from the backend and syncs userSlice.
    *
    * Used after operations that change server-side session state (logout,
-   * login-method switch) so the form and AppBar stay consistent.
+   * login-method switch) so the form and AppBar stay consistent. The user
+   * is fetched from the live nav API rather than derived from the session
+   * file so a stale QR session that failed verification does not incorrectly
+   * appear as logged-in (see review P1).
    */
   const refreshLoginState = async () => {
     const state = await getLoginState()
     setLoginMethod(state.method)
     setSession(state.session)
-    store.dispatch(setUser(sessionToUser(state.session)))
+    try {
+      const user = await fetchUser()
+      store.dispatch(setUser(user))
+    } catch {
+      // Fallback to file-derived user when the API is unreachable (e.g.
+      // network offline). This keeps the UI responsive while still
+      // preferring the live state when available.
+      store.dispatch(setUser(sessionToUser(state.session)))
+    }
     return state
   }
 

--- a/src/features/user/index.ts
+++ b/src/features/user/index.ts
@@ -28,6 +28,9 @@
  * ```
  */
 
+// API
+export { fetchUser } from './api/fetchUser'
+
 // Custom hooks
 export * from './useUser'
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -675,7 +675,9 @@
     "session_expired": "Session expired. Please log in again.",
     "loginMethodDescription": "Choose how the app authenticates with Bilibili. Restart required after switching.",
     "loginMethodChanged": "Login method updated",
-    "restartRequired": "Please restart the app for the change to take effect."
+    "restartRequired": "Please restart the app for the change to take effect.",
+    "qrVerifyFailed": "Login verification failed. Please try again or use Firefox cookie login.",
+    "qrSessdataMissing": "Failed to get login credentials. Please try again."
   },
   "downloadStatus": {
     "title": "Download Status",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -675,7 +675,9 @@
     "session_expired": "La sesión ha expirado. Por favor, inicia sesión de nuevo.",
     "loginMethodDescription": "Elige cómo se autentica la app con Bilibili. Es necesario reiniciar la app después de cambiar.",
     "loginMethodChanged": "Método de inicio de sesión actualizado",
-    "restartRequired": "Reinicia la app para que el cambio surta efecto."
+    "restartRequired": "Reinicia la app para que el cambio surta efecto.",
+    "qrVerifyFailed": "Error al verificar el inicio de sesión. Inténtalo de nuevo o usa la cookie de Firefox.",
+    "qrSessdataMissing": "No se pudieron obtener las credenciales. Inténtalo de nuevo."
   },
   "downloadStatus": {
     "title": "Estado de descarga",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -675,7 +675,9 @@
     "session_expired": "La session a expiré. Veuillez vous reconnecter.",
     "loginMethodDescription": "Choisissez comment l'application s'authentifie auprès de Bilibili. Un redémarrage est nécessaire après le changement.",
     "loginMethodChanged": "Méthode de connexion mise à jour",
-    "restartRequired": "Veuillez redémarrer l'application pour appliquer le changement."
+    "restartRequired": "Veuillez redémarrer l'application pour appliquer le changement.",
+    "qrVerifyFailed": "Échec de la vérification de connexion. Veuillez réessayer ou utiliser le cookie Firefox.",
+    "qrSessdataMissing": "Impossible d'obtenir les identifiants. Veuillez réessayer."
   },
   "downloadStatus": {
     "title": "Statut du téléchargement",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -675,7 +675,9 @@
     "session_expired": "セッションの有効期限が切れました。再度ログインしてください。",
     "loginMethodDescription": "Bilibiliとの認証方法を選択します。切り替え後にアプリの再起動が必要です。",
     "loginMethodChanged": "ログイン方法を変更しました",
-    "restartRequired": "変更を反映するにはアプリを再起動してください。"
+    "restartRequired": "変更を反映するにはアプリを再起動してください。",
+    "qrVerifyFailed": "ログイン検証に失敗しました。再試行するか、Firefox Cookieでログインしてください。",
+    "qrSessdataMissing": "ログイン情報の取得に失敗しました。再試行してください。"
   },
   "downloadStatus": {
     "title": "ダウンロード状況",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -675,7 +675,9 @@
     "session_expired": "세션이 만료되었습니다. 다시 로그인해 주세요.",
     "loginMethodDescription": "Bilibili 인증 방식을 선택합니다. 전환 후 앱 재시작이 필요합니다.",
     "loginMethodChanged": "로그인 방식이 업데이트되었습니다.",
-    "restartRequired": "변경 사항을 적용하려면 앱을 재시작하세요."
+    "restartRequired": "변경 사항을 적용하려면 앱을 재시작하세요.",
+    "qrVerifyFailed": "로그인 검증에 실패했습니다. 다시 시도하거나 Firefox 쿠키로 로그인하세요.",
+    "qrSessdataMissing": "로그인 정보를 가져오지 못했습니다. 다시 시도하세요."
   },
   "downloadStatus": {
     "title": "다운로드 상태",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -675,7 +675,9 @@
     "session_expired": "会话已过期，请重新登录。",
     "loginMethodDescription": "选择应用与哔哩哔哩的认证方式。切换后需要重启应用。",
     "loginMethodChanged": "登录方式已更新",
-    "restartRequired": "请重启应用以使更改生效。"
+    "restartRequired": "请重启应用以使更改生效。",
+    "qrVerifyFailed": "登录验证失败，请重试或使用 Firefox Cookie 登录。",
+    "qrSessdataMissing": "获取登录凭证失败，请重试。"
   },
   "downloadStatus": {
     "title": "下载状态",

--- a/src/shared/lib/mapBackendError.ts
+++ b/src/shared/lib/mapBackendError.ts
@@ -31,6 +31,10 @@ const VIDEO_ERROR_MAP: Record<string, string> = {
   // Audio / media download error codes
   'ERR::INVALID_MEDIA_RESPONSE': 'video.invalid_media_response',
   'ERR::AUDIO_DOWNLOAD_FAILED': 'video.audio_download_failed',
+  // QR login error codes
+  'ERR::QR_COOKIE_REJECTED': 'login.qrVerifyFailed',
+  'ERR::QR_SESSDATA_MISSING': 'login.qrSessdataMissing',
+  'ERR::QR_VERIFY_FAILED': 'login.qrVerifyFailed',
   // Why: trailing "::" matches the "ERR::NETWORK::<detail>" shape produced
   // by retry_download (it appends segment-failure details after the code),
   // so the dynamic suffix is discarded and the fixed key is returned.


### PR DESCRIPTION
## Summary

Fixes #543.

QR code login reported "Login successful" but the session never took effect: the AppBar stayed "not logged in", downloads ran without account privileges, and restarting the app wiped the stored session entirely. This PR makes the QR login flow produce a session that Bilibili actually accepts, keeps the UI honest about failure, and preserves the session across restarts.

Verified working end-to-end on macOS (Apple Silicon, v1.51.0 build from this branch): QR scan → auto-close of the dialog → AppBar shows the masked username → session survives restart → 4K video download succeeds with the logged-in account.

## Root cause

1. **Headerless HTTP clients on the passport endpoints.** `generate_qr_code` and `poll_qr_status` used a bare `reqwest::Client::new()` with no `User-Agent`/`Referer`, while every other Bilibili request in the codebase goes through `build_client()`. Bilibili's passport risk control flags the inconsistent fingerprint and effectively invalidates the issued `SESSDATA`.
2. **Silent empty extraction.** `extract_session_from_url` defaulted missing cookie params to empty strings via `unwrap_or_default()` with no error and no log.
3. **Verification result ignored.** The `fetch_user_info` call right after a successful poll returned `is_login=false` (confirmed in the issue's app.log) but was only logged at `debug!` level and otherwise ignored.
4. **False success surfaced to the UI.** `QrPollResult.status` was unconditionally `"success"`, so the frontend showed the success state regardless of whether the session worked.
5. **Restart destroyed the evidence.** On startup, `check_cookie_refresh` saw `-101` (invalid SESSDATA) → refresh failed → `init.rs` called `logout()`, deleting the encrypted session file and resetting the login method.

A separate UI defect: `QRCodeDisplay` closed via `navigate('/home')`, which is a no-op when the dialog is opened from the home page or AppBar, so the dialog never closed even on genuine success.

## Changes

### Backend (`src-tauri`)

- **`generate_qr_code` / `poll_qr_status` / `fetch_buvid`** now use `build_client()` (canonical UA) and send `Referer`. `buvid3`/`buvid4` are fetched *before* QR generation and forwarded as `Cookie` on the generate request so the whole flow presents one consistent device fingerprint (previously the buvids were fetched but discarded).
- **Poll requests** add `source=main-fe-header` (matches the web header login widget; without it some responses omit `Set-Cookie`) and extract credentials from **both** `data.url` query params (legacy) and `Set-Cookie` headers (current Bilibili behavior), with header values overlaying URL params. Covers responses that now return an empty `data.url`.
- **`extract_session`** errors with `ERR::QR_SESSDATA_MISSING` when `SESSDATA` *or* `bili_jct` is missing/empty instead of silently storing an incomplete session (a session without the CSRF token could read public data but every authenticated write would fail).
- **Post-login verification.** On poll success the session is verified through the nav API using a *temporary* cookie header (`verify_session_with_header`), so the global `CookieCache` (which may hold Firefox cookies) is never polluted by a failed attempt:
  - `is_login=false` → returns `ERR::QR_COOKIE_REJECTED`, nothing is saved, no false "success" reaches the UI;
  - verification passes → the session is committed to the cache and encrypted storage, and the extracted `sessdata`/`bili_jct` byte lengths are logged (values are never logged);
  - nav API failure (likely transient network) → the session is kept and committed; the frontend re-verifies before closing the dialog.
- **Cookie refresh path hardened too.** `check_cookie_refresh`, `fetch_refresh_csrf`, and `refresh_cookie` also use `build_client()` + `Referer`; drops a stale inline `Chrome/120` UA string that had drifted from `constants::USER_AGENT`. These are the same passport endpoints implicated by risk control, and this is what makes the session actually *restorable* on restart.
- **`init.rs` no longer destroys the session on refresh failure.** A failed refresh logs a warning and emits `init.cookie_failed` (key already present in all locales); the encrypted session file and login-method setting are kept so the user can retry without re-scanning.

### Frontend

- **`QRCodeDisplay`** gains an `onSuccess` callback. After the poll reports success it re-verifies the live login state via `getUserInfo()` and only then closes the dialog (`onSuccess`) or navigates home (standalone `/login` page). Verification failure switches the tile to the error state with a translated message and keeps the dialog open for retry.
- **`QRCodeLoginDialog`** mounts `QRCodeDisplay` only while open (`{open && <QRCodeDisplay onSuccess={() => onOpenChange(false)} />}`): polling stops on close, a fresh QR is generated per open, and the dialog auto-closes on success in both embedders (home page banner and AppBar button).
- **Removed `resetLogin()` on mount** — it reset the slice's `loginMethod` to `firefox` and cleared the just-saved session from Redux. `generateNewQrCode` already resets the QR UI state via `clearQrCode`/`setQrCode`.
- **`SettingsForm`** now derives login status from the live user state (`fetchUser`, with a file-derived fallback when the API is unreachable) instead of trusting session-file existence, so Settings stays consistent with the AppBar when a stored session has failed verification. `fetchUser` is now exported from the `features/user` public API (import-rule fix).
- **Error mapping / i18n:** `ERR::QR_COOKIE_REJECTED`, `ERR::QR_VERIFY_FAILED`, `ERR::QR_SESSDATA_MISSING` mapped in `mapBackendError.ts`; new keys `login.qrVerifyFailed` / `login.qrSessdataMissing` added to **all 6 locales** (parity test passes).

## Tests

- Rust unit tests updated/added for the new extraction contract: missing/empty `SESSDATA` errors, missing `bili_jct` errors, credentials from `Set-Cookie` when `data.url` has none, and header-over-URL overlay semantics. `cargo test`: 262 passed.
- Frontend: `npm run lint`, `npm run typecheck`, `npm test` (636 passed, incl. the locale-parity gate) all green.
- Manual (production build of this branch, macOS arm64):
  - QR scan + confirm → dialog closes automatically, AppBar shows the masked username;
  - app restart → session restored, still logged in;
  - 4K video downloaded successfully with the logged-in account.

## Checklist

- [x] PR title follows the Conventional Commits format
- [x] One focused change (QR login session correctness)
- [x] References #543
- [x] lint / typecheck / tests pass locally
