### PR TITLE
fix(login): stop duplicating QR verify-failure error message

### DIFF
--- a/src/features/login/ui/QRCodeDisplay.tsx
+++ b/src/features/login/ui/QRCodeDisplay.tsx
@@ -41,7 +41,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
-import { setError, setQrStatus } from '../model/loginSlice'
+import { setQrStatus } from '../model/loginSlice'
 import { useLogin } from '../model/useLogin'
 
 /**
@@ -170,13 +170,14 @@ export function QRCodeDisplay({ onSuccess }: QRCodeDisplayProps) {
               'QRCodeDisplay: getUserInfo after QR success returned isLogin=false',
               user,
             )
+            // Why: setQrStatus only: the error tile already renders the mapped
+            // message; setError would duplicate it in the <p> below.
             dispatch(
               setQrStatus({
                 status: 'error',
                 message: 'ERR::QR_VERIFY_FAILED',
               }),
             )
-            dispatch(setError('ERR::QR_VERIFY_FAILED'))
             return
           }
           // After delay to show success message, either close dialog or navigate
@@ -190,13 +191,13 @@ export function QRCodeDisplay({ onSuccess }: QRCodeDisplayProps) {
         })
         .catch((e) => {
           logger.error('QRCodeDisplay: Failed to get user info after login', e)
+          // Why: setQrStatus only — same rationale as the isLogin=false branch.
           dispatch(
             setQrStatus({
               status: 'error',
               message: 'ERR::QR_VERIFY_FAILED',
             }),
           )
-          dispatch(setError('ERR::QR_VERIFY_FAILED'))
         })
     }
   }, [


### PR DESCRIPTION
## Summary

Follow-up nit to #552 (merged). The post-success verification failure paths in `QRCodeDisplay` dispatched both `setQrStatus({status:'error'})` and `setError()` with the same `ERR::QR_VERIFY_FAILED` code, so the mapped `login.qrVerifyFailed` message rendered twice: once in the error status tile and once in the error `<p>` below it.

This removes the `setError` dispatch from both verify-failure branches (isLogin=false and catch). `setError` remains reserved for polling/generation invoke failures, where the status tile is not in the error state — that division of labor is unchanged.

## Related Issue

None (follow-up cleanup to #552; #543 was already closed by it)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `npm run lint` / `npm run typecheck` clean
- [x] `npm test` — 636 passed (locale parity gate included)
- [ ] Manual: trigger a verify failure after QR success (e.g. by blocking the nav API) and confirm the error message appears exactly once

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — N/A, pure dispatch removal
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — no key changes