### PR TITLE
test: add hand-written component suites for shared ui, video, settings

### DIFF
--- a/src/features/about/ui/AboutDialog.test.tsx
+++ b/src/features/about/ui/AboutDialog.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * About dialog suite.
+ *
+ * Covers the settings-screen trigger (AboutDialog), the shared content
+ * (AboutDialogContent: get_app_info fetch, OS formatting, copy) and the
+ * macOS menu-bar entry (MenuAboutDialog, driven by the in-memory Tauri
+ * event bus from src/test/setup.ts).
+ */
+
+import type { AppInfo } from '@/features/about'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+import { emitTauriEvent } from '@/test/tauriEvents'
+
+import { AboutDialog } from './AboutDialog'
+import { AboutDialogContent } from './AboutDialogContent'
+import { MenuAboutDialog } from './MenuAboutDialog'
+
+const toastSuccess = toast.success as unknown as Mock
+
+const appInfo: AppInfo = {
+  app_name: 'Bilibili Downloader',
+  app_version: '1.2.3',
+  tauri_version: '2.7.0',
+  os_name: 'macos',
+  os_version: '15.0',
+  arch: 'aarch64',
+}
+
+/** happy-dom has no clipboard implementation. */
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+describe('AboutDialog (settings trigger)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_app_info') return Promise.resolve(appInfo)
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it('opens the dialog on click and shows the version row', async () => {
+    const { user } = renderWithProviders(<AboutDialog />)
+
+    await user.click(screen.getByRole('button', { name: 'about.button' }))
+
+    expect(await screen.findByText('v1.2.3')).toBeInTheDocument()
+    expect(mockInvoke).toHaveBeenCalledWith('get_app_info')
+  })
+})
+
+describe('AboutDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders placeholders before the info resolves', () => {
+    mockInvoke.mockResolvedValue(undefined)
+    renderWithProviders(<AboutDialogContent open onOpenChange={vi.fn()} />)
+
+    expect(screen.getByText('about.app_name')).toBeInTheDocument()
+    // All four info rows fall back to '-' while info is null
+    expect(screen.getAllByText('-')).toHaveLength(4)
+  })
+
+  it('formats the OS line per platform', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_app_info') {
+        return Promise.resolve({
+          ...appInfo,
+          os_name: 'windows',
+          os_version: '10.0.22631',
+        })
+      }
+      return Promise.resolve(undefined)
+    })
+    renderWithProviders(<AboutDialogContent open onOpenChange={vi.fn()} />)
+
+    // Build >= 22000 -> Windows 11
+    expect(
+      await screen.findByText('Windows 11 (build 22631)'),
+    ).toBeInTheDocument()
+  })
+
+  it('copies the environment info as a markdown list', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_app_info') return Promise.resolve(appInfo)
+      return Promise.resolve(undefined)
+    })
+    const { user } = renderWithProviders(
+      <AboutDialogContent open onOpenChange={vi.fn()} />,
+    )
+
+    // Copy stays disabled until get_app_info resolves; wait for the version.
+    // The clipboard stub must be installed AFTER render — happy-dom installs
+    // its own navigator.clipboard while the component tree loads.
+    await screen.findByText('v1.2.3')
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    await user.click(screen.getByRole('button', { name: 'about.copy' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    const text = writeText.mock.calls[0][0] as string
+    expect(text).toContain('- App: about.app_name v1.2.3')
+    expect(text).toContain('- OS: macOS 15.0')
+    expect(text).toContain('- Architecture: aarch64')
+    expect(text).toContain('- Tauri: 2.7.0')
+    expect(toastSuccess).toHaveBeenCalledWith('about.copied')
+  })
+
+  it('opens the repository link via openUrl', async () => {
+    const { openUrl } = await import('@tauri-apps/plugin-opener')
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_app_info') return Promise.resolve(appInfo)
+      return Promise.resolve(undefined)
+    })
+    const { user } = renderWithProviders(
+      <AboutDialogContent open onOpenChange={vi.fn()} />,
+    )
+
+    await screen.findByText('v1.2.3')
+    // The repo entry is a link-styled Button, not an anchor
+    await user.click(
+      screen.getByRole('button', {
+        name: 'github.com/j4rviscmd/bilibili-downloader-gui',
+      }),
+    )
+
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://github.com/j4rviscmd/bilibili-downloader-gui',
+    )
+  })
+})
+
+describe('MenuAboutDialog (macOS menu-bar entry)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_app_info') return Promise.resolve(appInfo)
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it('opens on the menu:about event and shows the version row', async () => {
+    renderWithProviders(<MenuAboutDialog />)
+
+    emitTauriEvent('menu:about', undefined)
+
+    expect(await screen.findByText('v1.2.3')).toBeInTheDocument()
+  })
+
+  it('does not open without the event', () => {
+    renderWithProviders(<MenuAboutDialog />)
+
+    expect(screen.queryByText('v1.2.3')).toBeNull()
+  })
+})

--- a/src/features/history/ui/HistoryExportDialog.test.tsx
+++ b/src/features/history/ui/HistoryExportDialog.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * HistoryExportDialog suite.
+ *
+ * Format radio selection flows into onExport; success closes the dialog,
+ * failure surfaces the error via the locally mocked toast.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+import HistoryExportDialog from './HistoryExportDialog'
+
+const toastError = toast.error as unknown as Mock
+
+describe('HistoryExportDialog', () => {
+  // Typed vi.fn so the mocks satisfy the component's callback props
+  const onExport = vi.fn<(format: 'json' | 'csv') => Promise<void>>()
+  const onOpenChange = vi.fn<(open: boolean) => void>()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    onExport.mockResolvedValue(undefined)
+  })
+
+  function renderDialog() {
+    return renderWithProviders(
+      <HistoryExportDialog
+        open
+        onOpenChange={onOpenChange}
+        onExport={onExport}
+      />,
+    )
+  }
+
+  it('exports with the json format by default', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    expect(onExport).toHaveBeenCalledWith('json')
+  })
+
+  it('exports csv after switching the radio', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByLabelText('history.exportCsv'))
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    expect(onExport).toHaveBeenCalledWith('csv')
+  })
+
+  it('closes the dialog on successful export', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await vi.waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it('toasts the error message and stays open on failure', async () => {
+    onExport.mockRejectedValue(new Error('disk full'))
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith('disk full'))
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('cancel closes without exporting', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'actions.cancel' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onExport).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/history/ui/HistoryFilters.test.tsx
+++ b/src/features/history/ui/HistoryFilters.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * HistoryFilters suite.
+ *
+ * Status dropdown: trigger shows the current filter's label and menu
+ * items report the chosen value through onChange.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import HistoryFilters from './HistoryFilters'
+
+describe('HistoryFilters', () => {
+  it('shows the current filter label on the trigger', () => {
+    renderWithProviders(<HistoryFilters value="completed" onChange={vi.fn()} />)
+
+    expect(
+      screen.getByRole('button', { name: 'history.filterSuccess' }),
+    ).toBeInTheDocument()
+  })
+
+  it('reports the picked status through onChange', async () => {
+    const onChange = vi.fn()
+    const { user } = renderWithProviders(
+      <HistoryFilters value="all" onChange={onChange} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'history.filterAll' }))
+    await user.click(
+      screen.getByRole('menuitem', { name: 'history.filterFailed' }),
+    )
+
+    expect(onChange).toHaveBeenCalledWith('failed')
+  })
+})

--- a/src/features/history/ui/HistoryItem.test.tsx
+++ b/src/features/history/ui/HistoryItem.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * HistoryItem suite.
+ *
+ * Pure presentational entry row: asserts rendered metadata, the copy /
+ * delete / download callbacks and the failed-state error line. Toast is
+ * mocked locally (identity t keys).
+ */
+
+import type { HistoryEntry } from '@/features/history/model/historySlice'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+import HistoryItem from './HistoryItem'
+
+const toastSuccess = toast.success as unknown as Mock
+
+const completed: HistoryEntry = {
+  id: '1',
+  title: 'Sample Video',
+  bvid: 'BV1xx',
+  url: 'https://www.bilibili.com/video/BV1xx',
+  filename: 'sample.mp4',
+  downloadedAt: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+  duration: 125,
+  status: 'completed',
+  fileSize: 1_500_000,
+  quality: '1080p',
+  thumbnailUrl: 'https://img.example/th.jpg',
+}
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+function renderEntry(overrides: Partial<HistoryEntry> = {}) {
+  const onDelete = vi.fn()
+  const onDownload = vi.fn()
+  const utils = renderWithProviders(
+    <HistoryItem
+      entry={{ ...completed, ...overrides }}
+      onDelete={onDelete}
+      onDownload={onDownload}
+    />,
+  )
+  return { ...utils, onDelete, onDownload }
+}
+
+describe('HistoryItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the entry metadata for a completed download', () => {
+    renderEntry()
+
+    expect(screen.getByText('Sample Video')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: completed.url }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('sample.mp4')).toBeInTheDocument()
+    expect(screen.getByText('1080p')).toBeInTheDocument()
+    expect(screen.getByText('1.5 MB')).toBeInTheDocument()
+    expect(screen.getByText('2:05')).toBeInTheDocument() // duration badge
+    expect(screen.getByText('history.filterSuccess')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Sample Video' })).toHaveAttribute(
+      'src',
+      completed.thumbnailUrl,
+    )
+  })
+
+  it('formats the relative download date', () => {
+    renderEntry()
+
+    expect(screen.getByText('watchHistory.time.daysAgo')).toBeInTheDocument()
+  })
+
+  it('shows the error line and failed badge for failed entries', () => {
+    renderEntry({ status: 'failed', errorMessage: 'network reset' })
+
+    expect(screen.getByText('history.filterFailed')).toBeInTheDocument()
+    expect(screen.getByText('network reset')).toBeInTheDocument()
+  })
+
+  it('renders the thumbnail placeholder when no thumbnail exists', () => {
+    renderEntry({ thumbnailUrl: undefined })
+
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('copies the URL to the clipboard and toasts success', async () => {
+    const { user } = renderEntry()
+    // Clipboard stub must be installed AFTER render (happy-dom quirk)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    await user.click(screen.getByTitle('history.copyUrl'))
+
+    await vi.waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(completed.url),
+    )
+    expect(toastSuccess).toHaveBeenCalledWith('history.copySuccess')
+  })
+
+  it('invokes onDelete from the delete button', async () => {
+    const { user, onDelete } = renderEntry()
+
+    await user.click(screen.getByTitle('history.deleteConfirm'))
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onDownload from the download button', async () => {
+    const { user, onDownload } = renderEntry()
+
+    await user.click(
+      screen.getByRole('button', { name: 'watchHistory.download' }),
+    )
+
+    expect(onDownload).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the download button and keeps it rendered when disabled', () => {
+    renderWithProviders(
+      <HistoryItem
+        entry={completed}
+        onDelete={vi.fn()}
+        onDownload={vi.fn()}
+        disabled
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'watchHistory.download' }),
+    ).toBeDisabled()
+  })
+
+  it('omits the download button when the entry has no bvid', () => {
+    renderEntry({ bvid: undefined })
+
+    expect(
+      screen.queryByRole('button', { name: 'watchHistory.download' }),
+    ).toBeNull()
+  })
+})

--- a/src/features/history/ui/HistoryList.test.tsx
+++ b/src/features/history/ui/HistoryList.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * HistoryList suite.
+ *
+ * Loading/empty states render synchronously. The populated path goes
+ * through react-virtuoso, which cannot compute a viewport under
+ * happy-dom (zero-sized rects, no layout engine), so items never
+ * materialize — the populated test only locks in that the Virtuoso
+ * scroller mounts. Per-entry rendering/actions are covered by
+ * HistoryItem.test.tsx.
+ */
+
+import type { HistoryEntry } from '@/features/history/model/historySlice'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import HistoryList from './HistoryList'
+
+const entry: HistoryEntry = {
+  id: '1',
+  title: 'A downloaded video',
+  url: 'https://www.bilibili.com/video/BV1xx',
+  downloadedAt: new Date().toISOString(),
+  status: 'completed',
+}
+
+beforeAll(() => {
+  // happy-dom ships no ResizeObserver; react-virtuoso requires one.
+  if (!('ResizeObserver' in globalThis)) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+  }
+})
+
+describe('HistoryList', () => {
+  it('shows the loading state while fetching', () => {
+    renderWithProviders(<HistoryList entries={[]} loading onDelete={vi.fn()} />)
+
+    expect(screen.getByText('init.initializing')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when there are no entries', () => {
+    renderWithProviders(
+      <HistoryList entries={[]} loading={false} onDelete={vi.fn()} />,
+    )
+
+    expect(screen.getByText('history.empty')).toBeInTheDocument()
+  })
+
+  it('mounts the virtualized scroller when entries exist', () => {
+    renderWithProviders(
+      <HistoryList entries={[entry]} loading={false} onDelete={vi.fn()} />,
+    )
+
+    expect(
+      document.querySelector('[data-virtuoso-scroller]'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/history/ui/HistorySearch.test.tsx
+++ b/src/features/history/ui/HistorySearch.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * HistorySearch suite.
+ *
+ * Controlled input: typing propagates through onChange; placeholder comes
+ * from the identity t mock.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import HistorySearch from './HistorySearch'
+
+describe('HistorySearch', () => {
+  it('renders the seeded value and localized placeholder', () => {
+    renderWithProviders(<HistorySearch value="initial" onChange={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('history.searchPlaceholder')
+    expect(input).toHaveValue('initial')
+  })
+
+  it('propagates every keystroke through onChange', async () => {
+    const onChange = vi.fn()
+    const { user } = renderWithProviders(
+      <HistorySearch value="" onChange={onChange} />,
+    )
+
+    await user.type(
+      screen.getByPlaceholderText('history.searchPlaceholder'),
+      'abc',
+    )
+
+    expect(onChange).toHaveBeenLastCalledWith('c')
+    expect(onChange).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/features/login/ui/QRCodeDisplay.test.tsx
+++ b/src/features/login/ui/QRCodeDisplay.test.tsx
@@ -28,7 +28,15 @@ const login = vi.hoisted(() => ({
 }))
 
 const userHook = vi.hoisted(() => ({
-  getUserInfo: vi.fn().mockResolvedValue(undefined),
+  // Why resolved shape: the post-success verification path reads
+  // user.data.isLogin — undefined would take the ERR::QR_VERIFY_FAILED
+  // branch and never navigate.
+  getUserInfo: vi.fn().mockResolvedValue({
+    code: 0,
+    message: '0',
+    data: { mid: 42, uname: 'u', isLogin: true },
+    hasCookie: true,
+  }),
 }))
 
 vi.mock('@/features/login/model/useLogin', () => ({
@@ -88,8 +96,9 @@ describe('QRCodeDisplay', () => {
 
     expect(screen.getByText('login.generatingQR')).toBeInTheDocument()
     expect(screen.queryByRole('img')).toBeNull()
-    // Mount effect resets stale state and requests a code
-    expect(login.resetLogin).toHaveBeenCalled()
+    // Mount effect requests a code; resetLogin was dropped upstream (it
+    // reset loginMethod back to firefox on every mount)
+    expect(login.resetLogin).not.toHaveBeenCalled()
     expect(login.generateNewQrCode).toHaveBeenCalled()
   })
 

--- a/src/features/login/ui/QRCodeDisplay.test.tsx
+++ b/src/features/login/ui/QRCodeDisplay.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * QRCodeDisplay suite.
+ *
+ * The useLogin hook and useUser are mocked at the hook level (covered by
+ * the F3 hook suites); the component is exercised per loginSlice state
+ * shape. MemoryRouter probe routes assert the post-login navigation.
+ */
+
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { act, screen } from '@testing-library/react'
+import { Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const login = vi.hoisted(() => ({
+  state: {
+    qrStatus: null as string | null,
+    qrCodeImage: null as string | null,
+    qrcodeKey: null as string | null,
+    statusMessage: '',
+    loginMethod: 'firefox' as const,
+    session: null,
+    isQrLoading: false,
+    error: null as string | null,
+  },
+  generateNewQrCode: vi.fn().mockResolvedValue(undefined),
+  stopPolling: vi.fn(),
+  resetLogin: vi.fn(),
+}))
+
+const userHook = vi.hoisted(() => ({
+  getUserInfo: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/features/login/model/useLogin', () => ({
+  useLogin: () => ({
+    ...login.state,
+    generateNewQrCode: login.generateNewQrCode,
+    stopPolling: login.stopPolling,
+    logout: vi.fn(),
+    changeLoginMethod: vi.fn(),
+    resetLogin: login.resetLogin,
+  }),
+}))
+vi.mock('@/features/user', () => ({
+  useUser: () => ({
+    user: null,
+    onChangeUser: vi.fn(),
+    getUserInfo: userHook.getUserInfo,
+  }),
+}))
+
+import { QRCodeDisplay } from './QRCodeDisplay'
+
+/** Wraps the component with a /home probe route for navigation asserts. */
+function renderLogin() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/" element={<QRCodeDisplay />} />
+      <Route path="/home" element={<div>HOME-MARKER</div>} />
+    </Routes>,
+    { route: '/' },
+  )
+}
+
+describe('QRCodeDisplay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    mockInvoke.mockResolvedValue(undefined)
+    Object.assign(login.state, {
+      qrStatus: null,
+      qrCodeImage: null,
+      qrcodeKey: null,
+      statusMessage: '',
+      session: null,
+      isQrLoading: false,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows the loading state while the first QR code generates', () => {
+    Object.assign(login.state, { isQrLoading: true })
+    renderLogin()
+
+    expect(screen.getByText('login.generatingQR')).toBeInTheDocument()
+    expect(screen.queryByRole('img')).toBeNull()
+    // Mount effect resets stale state and requests a code
+    expect(login.resetLogin).toHaveBeenCalled()
+    expect(login.generateNewQrCode).toHaveBeenCalled()
+  })
+
+  it('renders the QR image with the waiting-for-scan status', async () => {
+    Object.assign(login.state, {
+      qrStatus: 'waitingForScan',
+      qrCodeImage: 'data:image/png;base64,qr',
+    })
+    renderLogin()
+
+    const img = await screen.findByRole('img', {
+      name: 'Bilibili Login QR Code',
+    })
+    expect(img).toHaveAttribute('src', 'data:image/png;base64,qr')
+    expect(screen.getByText('login.scanWithApp')).toBeInTheDocument()
+    expect(screen.getByText('login.instructions')).toBeInTheDocument()
+  })
+
+  it('shows the confirm-on-phone status while waiting for confirmation', () => {
+    Object.assign(login.state, {
+      qrStatus: 'scannedWaitingConfirm',
+      qrCodeImage: 'data:image/png;base64,qr',
+    })
+    renderLogin()
+
+    expect(screen.getByText('login.confirmOnPhone')).toBeInTheDocument()
+  })
+
+  it('shows the expired overlay with refresh actions', () => {
+    Object.assign(login.state, {
+      qrStatus: 'expired',
+      qrCodeImage: 'data:image/png;base64,qr',
+    })
+    renderLogin()
+
+    expect(screen.getByText('login.qrExpired')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'login.refresh' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'login.tryAgain' }),
+    ).toBeInTheDocument()
+  })
+
+  it('refresh button regenerates the QR code', async () => {
+    Object.assign(login.state, {
+      qrStatus: 'expired',
+      qrCodeImage: 'data:image/png;base64,qr',
+    })
+    const { user } = renderLogin()
+
+    await user.click(screen.getByRole('button', { name: 'login.tryAgain' }))
+
+    expect(login.generateNewQrCode).toHaveBeenCalledTimes(2) // mount + click
+  })
+
+  it('on success refreshes user info and navigates home after the delay', async () => {
+    vi.useFakeTimers()
+    Object.assign(login.state, {
+      qrStatus: 'success',
+      qrCodeImage: 'data:image/png;base64,qr',
+    })
+    renderLogin()
+
+    // generateNewQrCode() resolved -> success handling enabled
+    await vi.waitFor(() =>
+      expect(userHook.getUserInfo).toHaveBeenCalledTimes(1),
+    )
+    expect(login.stopPolling).toHaveBeenCalled()
+
+    // Still on the login page before the 1.5s delay elapses
+    expect(screen.queryByText('HOME-MARKER')).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+
+    expect(screen.getByText('HOME-MARKER')).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/dialog/SettingsDialog.test.tsx
+++ b/src/features/settings/dialog/SettingsDialog.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Settings dialog wiring suite.
+ *
+ * Covers both halves of the open/close contract:
+ * - OpenSettingsDialogButton flips settings.dialogOpen (requires a
+ *   SidebarProvider ancestor for SidebarMenuButton)
+ * - SettingsDialog renders/mounts SettingsForm based on the same flag
+ *
+ * SettingsForm itself is stubbed here (it has a dedicated suite).
+ */
+
+import { store } from '@/app/store'
+import { setOpenDialog } from '@/features/settings/settingsSlice'
+import { Sidebar, SidebarProvider } from '@/shared/animate-ui/radix/sidebar'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/features/settings/dialog/SettingsForm', () => ({
+  default: () => <div data-testid="settings-form" />,
+}))
+
+import OpenSettingsDialogButton from '@/features/settings/dialog/OpenSettingsDialogButton'
+import SettingsDialog from '@/features/settings/dialog/SettingsDialog'
+
+describe('OpenSettingsDialogButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(setOpenDialog(false))
+  })
+
+  it('opens the settings dialog on click', async () => {
+    // SidebarMenuButton requires the full Sidebar tree (MotionHighlight +
+    // useSidebar contexts), matching how PageLayoutShell mounts it.
+    const { user } = renderWithProviders(
+      <SidebarProvider>
+        <Sidebar>
+          <OpenSettingsDialogButton />
+        </Sidebar>
+      </SidebarProvider>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'settings.title' }))
+
+    expect(store.getState().settings.dialogOpen).toBe(true)
+  })
+})
+
+describe('SettingsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(setOpenDialog(false))
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('renders nothing until dialogOpen is true', () => {
+    renderWithProviders(<SettingsDialog />)
+
+    expect(screen.queryByText('settings.dialog_title')).toBeNull()
+    expect(screen.queryByTestId('settings-form')).toBeNull()
+  })
+
+  it('shows the title and mounts the form when open', () => {
+    store.dispatch(setOpenDialog(true))
+    renderWithProviders(<SettingsDialog />)
+
+    expect(screen.getByText('settings.dialog_title')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-form')).toBeInTheDocument()
+  })
+
+  it('closing via Escape dispatches dialogOpen false', () => {
+    store.dispatch(setOpenDialog(true))
+    renderWithProviders(<SettingsDialog />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(store.getState().settings.dialogOpen).toBe(false)
+  })
+})

--- a/src/features/settings/dialog/SettingsForm.test.tsx
+++ b/src/features/settings/dialog/SettingsForm.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * SettingsForm suite (three-layer strategy — key wiring only).
+ *
+ * - formSchema validation rules are unit-tested in formSchema.test.ts and
+ *   are NOT re-tested here (only the required-path FormMessage wiring).
+ * - Sibling API/hook layers are mocked: '@/features/login' (getLoginState
+ *   / qrLogout / setLoginMethod), '@/features/user' (useUser) and
+ *   '@/features/video' (videoApi reset).
+ * - useSettings stays real: assertions go through the seeded singleton
+ *   store and the 'set_settings' mockInvoke payload.
+ * - Decorative siblings (updater/about/logs/dev sections) are stubbed;
+ *   TitleReplacementSettings stays real so its wiring is exercised via
+ *   the form too.
+ */
+
+import { store } from '@/app/store'
+import type { Session } from '@/features/login'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// --- Mocked sibling layers (hoisted refs so factories stay pure) ---------
+
+const loginApi = vi.hoisted(() => ({
+  getLoginState: vi
+    .fn()
+    .mockResolvedValue({ method: 'firefox', session: null }),
+  qrLogout: vi.fn().mockResolvedValue(undefined),
+  setLoginMethod: vi.fn().mockResolvedValue(undefined),
+}))
+
+const userHook = vi.hoisted(() => ({
+  user: null as User | null,
+  onChangeUser: vi.fn(),
+  getUserInfo: vi.fn().mockResolvedValue(undefined),
+}))
+
+const videoApiMock = vi.hoisted(() => ({
+  // resetApiState() must return a dispatchable plain action
+  util: { resetApiState: vi.fn().mockReturnValue({ type: 'videoApi/reset' }) },
+}))
+
+vi.mock('@/features/login', () => loginApi)
+vi.mock('@/features/user', () => ({
+  useUser: () => ({
+    user: userHook.user,
+    onChangeUser: userHook.onChangeUser,
+    getUserInfo: userHook.getUserInfo,
+  }),
+}))
+vi.mock('@/features/video', () => ({ videoApi: videoApiMock }))
+
+// --- Stubbed decorative siblings (each has its own suite) -----------------
+
+vi.mock('@/features/about', () => ({
+  AboutDialog: () => <div data-testid="about-dialog" />,
+}))
+vi.mock('@/features/settings/ui/UpdateCheckButton', () => ({
+  UpdateCheckButton: () => <div data-testid="update-check" />,
+}))
+vi.mock('@/features/settings/ui/ReleaseNotesSection', () => ({
+  ReleaseNotesSection: () => <div data-testid="release-notes" />,
+}))
+vi.mock('@/features/settings/ui/OpenLogsButton', () => ({
+  OpenLogsButton: () => <div data-testid="open-logs" />,
+}))
+vi.mock('@/features/settings/ui/DevOptions', () => ({
+  DevOptions: () => <div data-testid="dev-options" />,
+}))
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+import SettingsForm from './SettingsForm'
+
+const toastSuccess = toast.success as unknown as Mock
+const toastInfo = toast.info as unknown as Mock
+
+// --- Fixtures --------------------------------------------------------------
+
+const baseline: Settings = {
+  dlOutputPath: '/downloads/out',
+  language: 'ja',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+const session: Session = {
+  sessdata: 'sess',
+  biliJct: 'jct',
+  dedeUserId: '42',
+  dedeUserIdCkMd5: 'md5',
+  refreshToken: 'rt',
+  timestamp: 1,
+  uname: 'qr-user',
+}
+
+const loggedInFirefoxUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: {
+    mid: 7,
+    uname: 'ff-user',
+    isLogin: true,
+    wbiImg: { imgUrl: '', subUrl: '' },
+  },
+  hasCookie: true,
+}
+
+const loggedOutUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: { uname: '', isLogin: false, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: false,
+}
+
+/** Returns the latest set_settings payload, or undefined. */
+function lastSetSettings(): Settings | undefined {
+  const calls = mockInvoke.mock.calls.filter(
+    (c: unknown[]) => c[0] === 'set_settings',
+  )
+  const call = calls[calls.length - 1]
+  return call?.[1]?.settings as Settings | undefined
+}
+
+function seedSettings(partial: Partial<Settings> = {}) {
+  store.dispatch(setSettings({ ...baseline, ...partial }))
+  userHook.user = loggedOutUser
+  store.dispatch(setUser(loggedOutUser))
+}
+
+describe('SettingsForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_current_lib_path') return Promise.resolve('/lib')
+      return Promise.resolve(undefined)
+    })
+    loginApi.getLoginState.mockResolvedValue({
+      method: 'firefox',
+      session: null,
+    })
+    loginApi.qrLogout.mockResolvedValue(undefined)
+    loginApi.setLoginMethod.mockResolvedValue(undefined)
+    seedSettings()
+  })
+
+  it('renders with the seeded settings (path input and language radio)', async () => {
+    seedSettings()
+    renderWithProviders(<SettingsForm />)
+
+    expect(screen.getByDisplayValue('/downloads/out')).toBeInTheDocument()
+    // Radix radios render aria-checked on the button element
+    expect(
+      document.getElementById('lang-ja')?.getAttribute('aria-checked'),
+    ).toBe('true')
+    // Firefox + logged-out user
+    expect(screen.getByText('login.notLoggedIn')).toBeInTheDocument()
+    // Login state is fetched on mount
+    await waitFor(() => expect(loginApi.getLoginState).toHaveBeenCalled())
+    expect(mockInvoke).toHaveBeenCalledWith('get_current_lib_path')
+  })
+
+  it('changing the language persists via set_settings', async () => {
+    seedSettings()
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    await user.click(screen.getByLabelText('English'))
+
+    await waitFor(() =>
+      expect(lastSetSettings()).toMatchObject({ language: 'en' }),
+    )
+  })
+
+  it('submitting with an empty path shows the required FormMessage and skips saving', async () => {
+    seedSettings({ dlOutputPath: '' })
+    renderWithProviders(<SettingsForm />)
+
+    fireEvent.submit(document.querySelector('form')!)
+
+    expect(
+      await screen.findByText('validation.path.required'),
+    ).toBeInTheDocument()
+    expect(mockInvoke.mock.calls.some((c) => c[0] === 'set_settings')).toBe(
+      false,
+    )
+  })
+
+  it('changing the theme persists the new theme', async () => {
+    seedSettings()
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    await user.click(screen.getByLabelText('settings.theme_dark'))
+
+    await waitFor(() =>
+      expect(lastSetSettings()).toMatchObject({ theme: 'dark' }),
+    )
+  })
+
+  it('shows the QR-logged-in status and logout button for an active QR session', async () => {
+    loginApi.getLoginState.mockResolvedValue({
+      method: 'qrCode',
+      session,
+    })
+    renderWithProviders(<SettingsForm />)
+
+    expect(await screen.findByText('login.qrCodeLoggedIn')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'login.logout' })).toBeEnabled()
+  })
+
+  it('shows the Firefox-cookie status when the cookie authenticates', async () => {
+    userHook.user = loggedInFirefoxUser
+    renderWithProviders(<SettingsForm />)
+
+    expect(
+      await screen.findByText('login.firefoxCookieLoggedIn'),
+    ).toBeInTheDocument()
+    // Firefox sessions never offer the QR logout button
+    expect(screen.queryByRole('button', { name: 'login.logout' })).toBeNull()
+  })
+
+  it('logout confirms, calls qrLogout and resets the user slice', async () => {
+    loginApi.getLoginState.mockResolvedValueOnce({
+      method: 'qrCode',
+      session,
+    })
+    loginApi.getLoginState.mockResolvedValue({
+      method: 'qrCode',
+      session: null,
+    })
+    store.dispatch(setUser(loggedInFirefoxUser))
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    await user.click(
+      await screen.findByRole('button', { name: 'login.logout' }),
+    )
+    // Confirmation dialog: the AlertDialogAction is the last matching button
+    const dialog = await screen.findByRole('alertdialog')
+    await user.click(
+      within(dialog).getByRole('button', { name: 'login.logout' }),
+    )
+
+    await waitFor(() => expect(loginApi.qrLogout).toHaveBeenCalledTimes(1))
+    expect(toastSuccess).toHaveBeenCalledWith('login.qrSessionDeleted')
+    // refreshLoginState dispatched the logged-out user derived from session=null
+    expect(store.getState().user.data.isLogin).toBe(false)
+    expect(store.getState().user.hasCookie).toBe(false)
+  })
+
+  it('switching login method persists it, refreshes state and toasts', async () => {
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    await user.click(screen.getByLabelText('login.qrCode'))
+
+    await waitFor(() =>
+      expect(loginApi.setLoginMethod).toHaveBeenCalledWith('qrCode'),
+    )
+    // mount fetch + refresh after the switch
+    await waitFor(() => expect(loginApi.getLoginState).toHaveBeenCalledTimes(2))
+    expect(toastSuccess).toHaveBeenCalledWith('login.loginMethodChanged')
+    expect(toastInfo).toHaveBeenCalledWith('login.restartRequired')
+  })
+
+  it('adding a title replacement rule persists the expanded list', async () => {
+    seedSettings()
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.title_replacement.add_rule',
+      }),
+    )
+
+    await waitFor(() =>
+      expect(lastSetSettings()?.titleReplacements).toEqual([
+        ...defaultRules(),
+        { from: '', to: '', enabled: true },
+      ]),
+    )
+    // Video cache is reset so the new rules apply to future fetches
+    expect(videoApiMock.util.resetApiState).toHaveBeenCalled()
+  })
+
+  it('toggling auto-rename persists it and resets the video cache', async () => {
+    seedSettings()
+    const { user } = renderWithProviders(<SettingsForm />)
+
+    // The Switch has no htmlFor-linked label; find it as the sibling of the
+    // section label container (first switch in the form's settings sections).
+    const section = screen
+      .getByText('settings.auto_rename_duplicates_label')
+      .closest('div.flex.items-center.justify-between')!
+    const toggle = section.querySelector('button[role="switch"]')!
+    await user.click(toggle as HTMLElement)
+
+    await waitFor(() =>
+      expect(lastSetSettings()).toMatchObject({ autoRenameDuplicates: false }),
+    )
+    expect(videoApiMock.util.resetApiState).toHaveBeenCalled()
+  })
+})
+
+/** Mirrors DEFAULT_RULES in TitleReplacementSettings (backend defaults). */
+function defaultRules() {
+  return [
+    { from: '/', to: '-', enabled: true },
+    { from: ':', to: '_', enabled: true },
+    { from: '*', to: 'x', enabled: true },
+    { from: '?', to: '', enabled: true },
+    { from: '"', to: "'", enabled: true },
+    { from: '<', to: '(', enabled: true },
+    { from: '>', to: ')', enabled: true },
+    { from: '|', to: '-', enabled: true },
+  ]
+}

--- a/src/features/settings/dialog/SettingsForm.test.tsx
+++ b/src/features/settings/dialog/SettingsForm.test.tsx
@@ -38,6 +38,9 @@ const userHook = vi.hoisted(() => ({
   user: null as User | null,
   onChangeUser: vi.fn(),
   getUserInfo: vi.fn().mockResolvedValue(undefined),
+  // Why fetchUser mock: upstream now derives the login status from the live
+  // nav API via fetchUser() instead of the session file.
+  fetchUser: vi.fn(),
 }))
 
 const videoApiMock = vi.hoisted(() => ({
@@ -52,6 +55,7 @@ vi.mock('@/features/user', () => ({
     onChangeUser: userHook.onChangeUser,
     getUserInfo: userHook.getUserInfo,
   }),
+  fetchUser: userHook.fetchUser,
 }))
 vi.mock('@/features/video', () => ({ videoApi: videoApiMock }))
 
@@ -152,6 +156,10 @@ describe('SettingsForm', () => {
     })
     loginApi.qrLogout.mockResolvedValue(undefined)
     loginApi.setLoginMethod.mockResolvedValue(undefined)
+    // Default fetchUser -> network-unreachable fallback (sessionToUser), so
+    // tests read like the pre-verification file-derived flow unless they
+    // explicitly opt into the live nav-API path.
+    userHook.fetchUser.mockRejectedValue(new Error('offline'))
     seedSettings()
   })
 
@@ -212,6 +220,10 @@ describe('SettingsForm', () => {
       method: 'qrCode',
       session,
     })
+    // Live nav API confirms the stored session is still valid; the
+    // dispatched setUser result is what useUser surfaces on re-render
+    userHook.fetchUser.mockResolvedValue(loggedInFirefoxUser)
+    userHook.user = loggedInFirefoxUser
     renderWithProviders(<SettingsForm />)
 
     expect(await screen.findByText('login.qrCodeLoggedIn')).toBeInTheDocument()

--- a/src/features/settings/ui/DevOptions.test.tsx
+++ b/src/features/settings/ui/DevOptions.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * DevOptions suite.
+ *
+ * useUser is mocked at the hook level (its behavior is covered by the F3
+ * hook suite); the settings flow runs against the real store + mockInvoke.
+ * The component renders only when import.meta.env.DEV is true, which is
+ * the Vitest default.
+ */
+
+import { store } from '@/app/store'
+import { setSimulateLogout } from '@/features/settings/devSlice'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// vi.mock factories may only reference hoisted bindings: keep the spies and
+// the live user snapshot here, refreshed in beforeEach.
+const userHook = vi.hoisted(() => ({
+  onChangeUser: vi.fn(),
+  getUserInfo: vi.fn().mockResolvedValue(undefined),
+  user: null as User | null,
+}))
+
+vi.mock('@/features/user', () => ({
+  useUser: () => ({
+    user: userHook.user,
+    onChangeUser: userHook.onChangeUser,
+    getUserInfo: userHook.getUserInfo,
+  }),
+}))
+
+import { DevOptions } from './DevOptions'
+
+const baseline: Settings = {
+  dlOutputPath: '/downloads',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+  openDevtoolsOnStartup: true,
+}
+
+const loggedInUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: {
+    mid: 42,
+    uname: 'bilibili-user',
+    isLogin: true,
+    wbiImg: { imgUrl: '', subUrl: '' },
+  },
+  hasCookie: true,
+}
+
+/** Switches carry stable ids; Radix renders them as role="switch" buttons. */
+function switchById(id: string): HTMLElement {
+  const el = document.getElementById(id)
+  expect(el, `expected switch #${id}`).toBeTruthy()
+  return el as HTMLElement
+}
+
+describe('DevOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+    store.dispatch(setUser(loggedInUser))
+    userHook.user = loggedInUser
+    store.dispatch(setSimulateLogout(false))
+    store.dispatch(setSettings(baseline))
+  })
+
+  it('hides options until the collapsible trigger is opened', async () => {
+    const { user } = renderWithProviders(<DevOptions />)
+
+    expect(
+      screen.queryByText('settings.dev_options.simulate_logout'),
+    ).toBeNull()
+
+    await user.click(screen.getByText('settings.dev_options.title'))
+
+    expect(
+      screen.getByText('settings.dev_options.simulate_logout'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('settings.dev_options.open_devtools_on_startup'),
+    ).toBeInTheDocument()
+  })
+
+  it('toggling simulate-logout on invokes the backend, flags dev state and replaces the user', async () => {
+    const { user } = renderWithProviders(<DevOptions />)
+    await user.click(screen.getByText('settings.dev_options.title'))
+
+    await user.click(switchById('simulate-logout'))
+
+    expect(mockInvoke).toHaveBeenCalledWith('set_simulate_logout', {
+      enabled: true,
+    })
+    expect(store.getState().dev.simulateLogout).toBe(true)
+    // The logged-in user is replaced with a logged-out stub.
+    const dispatched = userHook.onChangeUser.mock.calls[0][0] as User
+    expect(dispatched.data.isLogin).toBe(false)
+    expect(dispatched.hasCookie).toBe(false)
+    expect(userHook.getUserInfo).not.toHaveBeenCalled()
+  })
+
+  it('toggling simulate-logout off restores the real user via getUserInfo', async () => {
+    store.dispatch(setSimulateLogout(true))
+    const { user } = renderWithProviders(<DevOptions />)
+    await user.click(screen.getByText('settings.dev_options.title'))
+
+    await user.click(switchById('simulate-logout'))
+
+    expect(mockInvoke).toHaveBeenCalledWith('set_simulate_logout', {
+      enabled: false,
+    })
+    expect(store.getState().dev.simulateLogout).toBe(false)
+    expect(userHook.getUserInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggling devtools persists openDevtoolsOnStartup via set_settings', async () => {
+    const { user } = renderWithProviders(<DevOptions />)
+    await user.click(screen.getByText('settings.dev_options.title'))
+
+    await user.click(switchById('open-devtools-on-startup'))
+
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'set_settings')
+    expect(call?.[1]).toMatchObject({
+      settings: { openDevtoolsOnStartup: false },
+    })
+  })
+})

--- a/src/features/settings/ui/OpenLogsButton.test.tsx
+++ b/src/features/settings/ui/OpenLogsButton.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * OpenLogsButton suite.
+ *
+ * The button is a thin shell around the 'reveal_log_file' invoke; assert
+ * the command name on success and the localized toast on failure.
+ */
+
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { OpenLogsButton } from './OpenLogsButton'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+
+const toastError = toast.error as unknown as Mock
+
+describe('OpenLogsButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('reveals the log file via invoke on click', async () => {
+    const { user } = renderWithProviders(<OpenLogsButton />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.open_logs_button' }),
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_log_file')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('toasts the localized failure when invoke rejects', async () => {
+    mockInvoke.mockRejectedValue(new Error('boom'))
+    const { user } = renderWithProviders(<OpenLogsButton />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.open_logs_button' }),
+    )
+
+    // The toast fires in the async catch; wait for it.
+    await vi.waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith('settings.open_logs_failed'),
+    )
+  })
+})

--- a/src/features/settings/ui/ReleaseNotesSection.test.tsx
+++ b/src/features/settings/ui/ReleaseNotesSection.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ReleaseNotesSection suite.
+ *
+ * Notes are fetched through the 'get_all_release_notes' invoke (the
+ * updater api layer is real; only invoke is mocked). The dialog markup
+ * renders via ReactMarkdown — assert on rendered heading/list nodes.
+ *
+ * CAUTION: motion's exit animations never complete under the happy-dom
+ * WAAPI polyfill, so the dialog DOM stays mounted after close. Close
+ * state is therefore asserted via the overlay's data-state instead of
+ * DOM removal.
+ */
+
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReleaseNotesSection } from './ReleaseNotesSection'
+
+const NOTES = '# Release Notes\n\n- Fixed download stall\n- Added CSV export'
+
+/** The Radix overlay reflects open state even while exit content lingers. */
+function overlayState(): string | null | undefined {
+  return document
+    .querySelector('[data-slot="dialog-overlay"]')
+    ?.getAttribute('data-state')
+}
+
+describe('ReleaseNotesSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_all_release_notes') return Promise.resolve(NOTES)
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it('fetches notes on first open and renders the markdown', async () => {
+    const { user } = renderWithProviders(<ReleaseNotesSection />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.release_notes.button_aria',
+      }),
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_all_release_notes', {
+      owner: 'j4rviscmd',
+      repo: 'bilibili-downloader-gui',
+    })
+    expect(
+      await screen.findByRole('heading', { name: 'Release Notes' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Fixed download stall')).toBeInTheDocument()
+    expect(screen.getByText('Added CSV export')).toBeInTheDocument()
+  })
+
+  it('closes via the dialog close button', async () => {
+    const { user } = renderWithProviders(<ReleaseNotesSection />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.release_notes.button_aria',
+      }),
+    )
+    await screen.findByRole('heading', { name: 'Release Notes' })
+    expect(overlayState()).toBe('open')
+
+    await user.click(screen.getByRole('button', { name: /close/i }))
+
+    await vi.waitFor(() => expect(overlayState()).toBe('closed'))
+  })
+
+  it('reuses the cached notes without refetching on the second open', async () => {
+    const { user } = renderWithProviders(<ReleaseNotesSection />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.release_notes.button_aria',
+      }),
+    )
+    await screen.findByRole('heading', { name: 'Release Notes' })
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    await vi.waitFor(() => expect(overlayState()).toBe('closed'))
+
+    await user.click(
+      // The closed dialog's exit content lingers (see file comment) and keeps
+      // aria-hidden on the rest of the page, so query with hidden: true.
+      screen.getByRole('button', {
+        name: 'settings.release_notes.button_aria',
+        hidden: true,
+      }),
+    )
+
+    // Cached path: setOpen(true) without a second fetch.
+    await vi.waitFor(() => expect(overlayState()).toBe('open'))
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the error message when the fetch fails', async () => {
+    mockInvoke.mockRejectedValueOnce(new Error('github down'))
+    const { user } = renderWithProviders(<ReleaseNotesSection />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.release_notes.button_aria',
+      }),
+    )
+
+    expect(
+      await screen.findByText('settings.release_notes.error'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/ui/TitleReplacementSettings.test.tsx
+++ b/src/features/settings/ui/TitleReplacementSettings.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * TitleReplacementSettings suite.
+ *
+ * Renders the real component against the singleton store seeded via
+ * setSettings BEFORE render (the store is shared across tests), and
+ * asserts every mutation persists through the 'set_settings' invoke
+ * payload (useSettings is real). Rule rows are located via their
+ * read-only Input display values.
+ */
+
+import { store } from '@/app/store'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings, TitleReplacement } from '@/features/settings/type'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TitleReplacementSettings } from './TitleReplacementSettings'
+
+const baseline: Settings = {
+  dlOutputPath: '/downloads',
+  language: 'en',
+  fontSize: 14,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+}
+
+/** Two concrete rules so row locators stay unambiguous. */
+const rules: TitleReplacement[] = [
+  { from: '/', to: '-', enabled: true },
+  { from: ':', to: '_', enabled: false },
+]
+
+/** Returns the rule row (grid div) containing the given Input value. */
+function rowOf(value: string): HTMLElement {
+  const input = document.querySelector<HTMLInputElement>(
+    `input[value="${value}"]`,
+  )
+  expect(input, `expected a rule input with value "${value}"`).toBeTruthy()
+  return input!.closest('div.grid') as HTMLElement
+}
+
+function seed(partial: Partial<Settings> = {}) {
+  store.dispatch(setSettings({ ...baseline, ...partial }))
+}
+
+describe('TitleReplacementSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+    seed()
+  })
+
+  it('shows the default-rules note and backend default rules when unset', () => {
+    renderWithProviders(<TitleReplacementSettings />)
+
+    // settings.titleReplacements is undefined -> the 8 DEFAULT_RULES render
+    const froms = ['/', ':', '*', '?', '"', '<', '>', '|']
+    for (const from of froms) {
+      expect(screen.getByDisplayValue(from)).toBeInTheDocument()
+    }
+    expect(
+      screen.getByText('settings.title_replacement.default_rules_note'),
+    ).toBeInTheDocument()
+  })
+
+  it('adds a rule and persists the appended list', async () => {
+    seed({ titleReplacements: rules })
+    const { user } = renderWithProviders(<TitleReplacementSettings />)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.title_replacement.add_rule',
+      }),
+    )
+
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'set_settings')
+    expect(call?.[1]).toMatchObject({
+      settings: {
+        titleReplacements: [...rules, { from: '', to: '', enabled: true }],
+      },
+    })
+  })
+
+  it('toggles a rule enabled state', async () => {
+    seed({ titleReplacements: rules })
+    const { user } = renderWithProviders(<TitleReplacementSettings />)
+
+    await user.click(within(rowOf('/')).getByRole('switch'))
+
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'set_settings')
+    expect(call?.[1]).toMatchObject({
+      settings: {
+        titleReplacements: [
+          { from: '/', to: '-', enabled: false },
+          { from: ':', to: '_', enabled: false },
+        ],
+      },
+    })
+  })
+
+  it('edits a rule from/to values and saves on OK', async () => {
+    seed({ titleReplacements: rules })
+    const { user } = renderWithProviders(<TitleReplacementSettings />)
+
+    const row = rowOf('/')
+    // Row action buttons in DOM order: [edit (Pencil), delete (Trash2)]
+    await user.click(within(row).getAllByRole('button')[0])
+
+    const [fromInput, toInput] = within(row).getAllByRole('textbox')
+    await user.clear(fromInput)
+    await user.type(fromInput, '?')
+    await user.clear(toInput)
+    await user.type(toInput, 'x')
+    await user.click(within(row).getByRole('button', { name: 'OK' }))
+
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'set_settings')
+    expect(call?.[1]).toMatchObject({
+      settings: {
+        titleReplacements: [
+          { from: '?', to: 'x', enabled: true },
+          { from: ':', to: '_', enabled: false },
+        ],
+      },
+    })
+  })
+
+  it('deletes a rule', async () => {
+    seed({ titleReplacements: rules })
+    const { user } = renderWithProviders(<TitleReplacementSettings />)
+
+    await user.click(within(rowOf(':')).getAllByRole('button')[1])
+
+    const call = mockInvoke.mock.calls.find((c) => c[0] === 'set_settings')
+    expect(call?.[1]).toMatchObject({
+      settings: { titleReplacements: [{ from: '/', to: '-', enabled: true }] },
+    })
+  })
+
+  it('disables add and warns at MAX_RULES (20)', () => {
+    seed({
+      titleReplacements: Array.from({ length: 20 }, (_, i) => ({
+        from: String(i),
+        to: String(i),
+        enabled: true,
+      })),
+    })
+    renderWithProviders(<TitleReplacementSettings />)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'settings.title_replacement.add_rule',
+      }),
+    ).toBeDisabled()
+    expect(
+      screen.getByText('settings.title_replacement.max_rules_reached'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the empty-rules note when the user cleared all rules', () => {
+    seed({ titleReplacements: [] })
+    renderWithProviders(<TitleReplacementSettings />)
+
+    expect(
+      screen.getByText('settings.title_replacement.empty_rules_note'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/ui/UpdateCheckButton.test.tsx
+++ b/src/features/settings/ui/UpdateCheckButton.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * UpdateCheckButton suite.
+ *
+ * The button captures import.meta.env.DEV at module scope (disabled in
+ * dev), so DEV is flipped false via vi.hoisted BEFORE the module import.
+ * The updater plugin 'check' mock comes from src/test/setup.ts; the app
+ * version from '@tauri-apps/api/app' is mocked locally.
+ */
+
+import { store } from '@/app/store'
+import { resetUpdater } from '@/features/updater/model/updaterSlice'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { getVersion } from '@tauri-apps/api/app'
+import { check } from '@tauri-apps/plugin-updater'
+import { screen, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  // Module-scope read: must happen before the component module is imported.
+  import.meta.env.DEV = false
+})
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('1.2.3'),
+}))
+
+import { UpdateCheckButton } from './UpdateCheckButton'
+
+const mockGetVersion = getVersion as unknown as Mock
+const mockCheck = check as unknown as Mock
+
+describe('UpdateCheckButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetVersion.mockResolvedValue('1.2.3')
+    mockCheck.mockResolvedValue(null)
+    mockInvoke.mockImplementation(() => Promise.resolve(undefined))
+    store.dispatch(resetUpdater())
+  })
+
+  it('renders the current version fetched on mount', async () => {
+    renderWithProviders(<UpdateCheckButton />)
+
+    await waitFor(() => expect(mockGetVersion).toHaveBeenCalled())
+    // Identity t renders the raw key ('{{version}}' is interpolated inside
+    // the translation, not the key).
+    expect(screen.getByText('settings.current_version')).toBeInTheDocument()
+  })
+
+  it('clicking check with no update shows the up-to-date badge', async () => {
+    const { user } = renderWithProviders(<UpdateCheckButton />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.update_check.button_idle' }),
+    )
+
+    await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1))
+    expect(
+      await screen.findByText('settings.update_check.latest'),
+    ).toBeInTheDocument()
+    expect(store.getState().updater.updateAvailable).toBe(false)
+  })
+
+  it('dispatches setUpdateAvailable and shows the badge when an update exists', async () => {
+    mockCheck.mockResolvedValue({ version: '2.0.0', currentVersion: '1.2.3' })
+    const { user } = renderWithProviders(<UpdateCheckButton />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.update_check.button_idle' }),
+    )
+
+    expect(
+      await screen.findByText('settings.update_check.available'),
+    ).toBeInTheDocument()
+    const updater = store.getState().updater
+    expect(updater.updateAvailable).toBe(true)
+    expect(updater.latestVersion).toBe('2.0.0')
+    expect(updater.currentVersion).toBe('1.2.3')
+  })
+
+  it('falls back to the unknown-version label when getVersion rejects', async () => {
+    mockGetVersion.mockRejectedValue(new Error('no app'))
+    renderWithProviders(<UpdateCheckButton />)
+
+    // The fallback is only applied into state, not new DOM text; assert the
+    // component still renders the version line without crashing.
+    expect(
+      await screen.findByText('settings.current_version'),
+    ).toBeInTheDocument()
+  })
+
+  it('resets to idle and stores the error when the check fails', async () => {
+    mockCheck.mockRejectedValue(new Error('network down'))
+    const { user } = renderWithProviders(<UpdateCheckButton />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.update_check.button_idle' }),
+    )
+
+    await waitFor(() =>
+      expect(store.getState().updater.error).toBe(
+        'settings.update_check.error',
+      ),
+    )
+    // Status returned to idle -> button label back to idle, no badge.
+    expect(
+      screen.getByRole('button', { name: 'settings.update_check.button_idle' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('settings.update_check.latest')).toBeNull()
+  })
+})

--- a/src/features/video/ui/DownloadButton.test.tsx
+++ b/src/features/video/ui/DownloadButton.test.tsx
@@ -1,0 +1,127 @@
+import { store } from '@/app/store'
+import { useVideoInfo } from '@/features/video'
+import type { Input } from '@/features/video/types'
+import { clearQueue, enqueue } from '@/shared/queue'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import DownloadButton from './DownloadButton'
+
+// useVideoInfo is fully covered by its own tests; mock the hook so this
+// suite controls only the inputs DownloadButton branches on.
+vi.mock('@/features/video', () => ({
+  useVideoInfo: vi.fn(),
+}))
+
+const emptyInput: Input = {
+  url: 'https://www.bilibili.com/video/BV1xx411c7XD',
+  partInputs: [],
+  pendingDownload: null,
+  homePage: 1,
+}
+
+/** Builds a useVideoInfo return value with the "ready to download" defaults. */
+function createMockUseVideoInfo(
+  overrides: Partial<ReturnType<typeof useVideoInfo>> = {},
+): ReturnType<typeof useVideoInfo> {
+  return {
+    download: vi.fn(),
+    isForm1Valid: true,
+    isForm2ValidAll: true,
+    duplicateIndices: [],
+    selectedCount: 1,
+    input: emptyInput,
+    ...overrides,
+  } as ReturnType<typeof useVideoInfo>
+}
+
+/** Enqueues a parent + child so selectHasActiveDownloads matches. */
+function seedRunningDownload() {
+  store.dispatch(
+    enqueue({ downloadId: 'p1', filename: 'parent', status: 'running' }),
+  )
+  store.dispatch(
+    enqueue({ downloadId: 'p1-p1', parentId: 'p1', status: 'running' }),
+  )
+}
+
+describe('DownloadButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(clearQueue())
+    vi.mocked(useVideoInfo).mockReturnValue(createMockUseVideoInfo())
+  })
+
+  it('is enabled when all validations pass and starts the download', async () => {
+    const download = vi.fn()
+    vi.mocked(useVideoInfo).mockReturnValue(
+      createMockUseVideoInfo({ download }),
+    )
+    const { user: actor } = renderWithProviders(<DownloadButton />)
+
+    const button = screen.getByRole('button', { name: 'actions.download' })
+    expect(button).toBeEnabled()
+
+    await actor.click(button)
+    expect(download).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the downloading label and disables while a download runs', () => {
+    seedRunningDownload()
+
+    renderWithProviders(<DownloadButton />)
+
+    expect(
+      screen.getByRole('button', { name: 'video.downloading' }),
+    ).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'actions.download' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the cancelling label while a download is being cancelled', () => {
+    store.dispatch(enqueue({ downloadId: 'p1', status: 'cancelling' }))
+
+    renderWithProviders(<DownloadButton />)
+
+    expect(
+      screen.getByRole('button', { name: 'video.download_cancelling' }),
+    ).toBeDisabled()
+  })
+
+  it('returns to the idle label once every download is done', () => {
+    store.dispatch(enqueue({ downloadId: 'p1-p1', status: 'done' }))
+
+    renderWithProviders(<DownloadButton />)
+
+    // 'done' items are not active downloads, so the button re-enables
+    expect(
+      screen.getByRole('button', { name: 'actions.download' }),
+    ).toBeEnabled()
+  })
+
+  it('is disabled when the URL form is invalid', () => {
+    vi.mocked(useVideoInfo).mockReturnValue(
+      createMockUseVideoInfo({ isForm1Valid: false }),
+    )
+
+    renderWithProviders(<DownloadButton />)
+
+    expect(
+      screen.getByRole('button', { name: 'actions.download' }),
+    ).toBeDisabled()
+  })
+
+  it('is disabled when the part-settings form is invalid', () => {
+    vi.mocked(useVideoInfo).mockReturnValue(
+      createMockUseVideoInfo({ isForm2ValidAll: false }),
+    )
+
+    renderWithProviders(<DownloadButton />)
+
+    expect(
+      screen.getByRole('button', { name: 'actions.download' }),
+    ).toBeDisabled()
+  })
+})

--- a/src/features/video/ui/PartDownloadProgress.test.tsx
+++ b/src/features/video/ui/PartDownloadProgress.test.tsx
@@ -1,0 +1,189 @@
+import { TooltipProvider } from '@/shared/animate-ui/radix/tooltip'
+import type { Progress } from '@/shared/progress/types'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PartDownloadStatus } from '../hooks/usePartDownloadStatus'
+import { PartDownloadProgress } from './PartDownloadProgress'
+
+/** Builds a Progress stage entry. */
+function stage(overrides: Partial<Progress> = {}): Progress {
+  return {
+    downloadId: 'dl-1-p1',
+    deltaTime: 1,
+    filesize: 45.6,
+    downloaded: 12.3,
+    transferRate: 512,
+    percentage: 50,
+    elapsedTime: 10,
+    isComplete: false,
+    stage: 'audio',
+    ...overrides,
+  }
+}
+
+/** Builds an idle PartDownloadStatus with per-test overrides. */
+function createMockStatus(
+  overrides: Partial<PartDownloadStatus> = {},
+): PartDownloadStatus {
+  return {
+    downloadId: 'dl-1-p1',
+    status: undefined,
+    errorMessage: undefined,
+    outputPath: undefined,
+    filename: undefined,
+    progressEntries: [],
+    isComplete: false,
+    isDownloading: false,
+    isPending: false,
+    hasError: false,
+    isCancelling: false,
+    isCancelled: false,
+    ...overrides,
+  }
+}
+
+/** Renders the component inside the TooltipProvider its stage icons need. */
+function setup(status: PartDownloadStatus, onCancel?: () => void) {
+  return renderWithProviders(
+    <TooltipProvider>
+      <PartDownloadProgress status={status} onCancel={onCancel} />
+    </TooltipProvider>,
+  )
+}
+
+describe('PartDownloadProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Component chains .catch() on invoke's return
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('renders nothing for a part with no activity', () => {
+    const { container } = setup(createMockStatus())
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows the pending state with a cancel action', async () => {
+    const onCancel = vi.fn()
+    const { user: actor } = setup(
+      createMockStatus({ isPending: true }),
+      onCancel,
+    )
+
+    expect(screen.getByText('video.download_pending')).toBeInTheDocument()
+
+    await actor.click(screen.getByRole('button', { name: 'actions.cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the cancel button when no handler is provided', () => {
+    setup(createMockStatus({ isPending: true }))
+
+    expect(
+      screen.queryByRole('button', { name: 'actions.cancel' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders per-stage progress while downloading', async () => {
+    const onCancel = vi.fn()
+    const { user: actor } = setup(
+      createMockStatus({
+        isDownloading: true,
+        progressEntries: [
+          stage({ stage: 'audio', percentage: 50 }),
+          stage({ stage: 'video', percentage: 75, transferRate: 1536 }),
+        ],
+      }),
+      onCancel,
+    )
+
+    // Both stage percentages and the MB/s formatting appear
+    expect(screen.getByText('50')).toBeInTheDocument()
+    expect(screen.getByText('1.5MB/s')).toBeInTheDocument()
+    // Both stages show their downloaded/total sizes
+    expect(screen.getAllByText('12.3')).toHaveLength(2)
+    expect(screen.getAllByText('45.6')).toHaveLength(2)
+    // Merge waits until audio and video both finish
+    expect(
+      screen.getByText('video.stage_merge: video.stage_waiting'),
+    ).toBeInTheDocument()
+
+    // The icon cancel button is the only button in the downloading row
+    await actor.click(screen.getByRole('button'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables cancellation during the merge stage', () => {
+    setup(
+      createMockStatus({
+        isDownloading: true,
+        progressEntries: [
+          stage({ stage: 'video', percentage: 100 }),
+          stage({ stage: 'merge', percentage: 40 }),
+        ],
+      }),
+      vi.fn(),
+    )
+
+    expect(screen.getByText('video.stage_merge')).toBeInTheDocument()
+    expect(screen.getByText('40%')).toBeInTheDocument()
+    // Killing ffmpeg mid-merge races the final write, so no cancel control
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('shows the complete state with open/reveal actions', async () => {
+    const { user: actor } = setup(
+      createMockStatus({
+        isComplete: true,
+        outputPath: '/downloads/video.mp4',
+      }),
+    )
+
+    expect(screen.getByText('video.download_complete')).toBeInTheDocument()
+
+    await actor.click(screen.getByRole('button', { name: 'video.open_file' }))
+    expect(mockInvoke).toHaveBeenCalledWith('open_file', {
+      path: '/downloads/video.mp4',
+    })
+  })
+
+  it('maps a known backend error code to its translation key', () => {
+    setup(createMockStatus({ hasError: true, errorMessage: 'ERR::DISK_FULL' }))
+
+    expect(screen.getByText('video.disk_full')).toBeInTheDocument()
+  })
+
+  it('shows the raw message for unknown errors and a generic label for none', () => {
+    const { rerender } = setup(
+      createMockStatus({ hasError: true, errorMessage: 'boom' }),
+    )
+    expect(screen.getByText('boom')).toBeInTheDocument()
+
+    // No store context is needed, so a bare rerender is safe here
+    rerender(
+      <TooltipProvider>
+        <PartDownloadProgress status={createMockStatus({ hasError: true })} />
+      </TooltipProvider>,
+    )
+    expect(screen.getByText('video.download_failed_part')).toBeInTheDocument()
+  })
+
+  it('shows the cancelling state in place of the pending row', () => {
+    setup(createMockStatus({ isPending: true, isCancelling: true }))
+
+    expect(screen.getByText('video.download_cancelling')).toBeInTheDocument()
+    expect(screen.queryByText('video.download_pending')).not.toBeInTheDocument()
+  })
+
+  it('prefers the complete view when cancel lands after a finished merge', () => {
+    setup(createMockStatus({ isComplete: true, isCancelled: true }))
+
+    expect(screen.getByText('video.download_complete')).toBeInTheDocument()
+    expect(
+      screen.queryByText('video.download_cancelled'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/features/video/ui/QualityRadioGroup.test.tsx
+++ b/src/features/video/ui/QualityRadioGroup.test.tsx
@@ -1,0 +1,58 @@
+import { RadioGroup } from '@/shared/animate-ui/radix/radio-group'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { QualityRadioGroup } from './QualityRadioGroup'
+
+const options = [
+  { id: '80', label: '1080p', isAvailable: true },
+  { id: '64', label: '720p', isAvailable: true },
+  { id: '120', label: '4K', isAvailable: false },
+]
+
+/** Renders the group inside the RadioGroup root it is used with in prod. */
+function setup(onValueChange = vi.fn()) {
+  const result = renderWithProviders(
+    <RadioGroup value="" onValueChange={onValueChange}>
+      <QualityRadioGroup options={options} idPrefix="vq-1" />
+    </RadioGroup>,
+  )
+  return { ...result, onValueChange }
+}
+
+describe('QualityRadioGroup', () => {
+  it('renders one radio per option with its label', () => {
+    setup()
+
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+    expect(screen.getByText('1080p')).toBeInTheDocument()
+    expect(screen.getByText('720p')).toBeInTheDocument()
+    expect(screen.getByText('4K')).toBeInTheDocument()
+  })
+
+  it('disables unavailable qualities and dims their label', () => {
+    setup()
+
+    expect(screen.getByRole('radio', { name: '4K' })).toBeDisabled()
+    // The dimmed wrapper marks unavailable options visually
+    expect(screen.getByText('4K').closest('div')).toHaveClass(
+      'text-muted-foreground/60',
+    )
+  })
+
+  it('keeps available qualities enabled', () => {
+    setup()
+
+    expect(screen.getByRole('radio', { name: '1080p' })).toBeEnabled()
+  })
+
+  it('selects a quality through the parent RadioGroup callback', async () => {
+    const { onValueChange, user: actor } = setup()
+
+    await actor.click(screen.getByRole('radio', { name: '1080p' }))
+
+    expect(onValueChange).toHaveBeenCalledWith('80')
+  })
+})

--- a/src/features/video/ui/SubtitleSection.test.tsx
+++ b/src/features/video/ui/SubtitleSection.test.tsx
@@ -1,0 +1,136 @@
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SubtitleConfig } from '../types'
+import { SubtitleSection } from './SubtitleSection'
+
+const subtitles = [
+  { lan: 'zh', lanDoc: 'Chinese', isAi: false },
+  { lan: 'ai-zh', lanDoc: 'AI Chinese', isAi: true },
+]
+
+const offConfig: SubtitleConfig = { mode: 'off', selectedLans: [] }
+
+/** Renders the section in the given config, returning the change spy. */
+function setup(config: SubtitleConfig, disabled = false) {
+  const onConfigChange = vi.fn()
+  const result = renderWithProviders(
+    <SubtitleSection
+      subtitles={subtitles}
+      config={config}
+      disabled={disabled}
+      page={1}
+      onConfigChange={onConfigChange}
+    />,
+  )
+  return { ...result, onConfigChange }
+}
+
+describe('SubtitleSection', () => {
+  it('renders nothing when the part has no subtitles', () => {
+    const { container } = renderWithProviders(
+      <SubtitleSection
+        subtitles={[]}
+        config={offConfig}
+        disabled={false}
+        page={1}
+        onConfigChange={vi.fn()}
+      />,
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the off/soft/hard mode options', () => {
+    setup(offConfig)
+
+    expect(screen.getByText('video.subtitle_off')).toBeInTheDocument()
+    expect(screen.getByText('video.subtitle_soft')).toBeInTheDocument()
+    expect(screen.getByText('video.subtitle_hard')).toBeInTheDocument()
+    // Mode 'off' renders no language list
+    expect(
+      screen.queryByText('video.subtitle_select_multiple'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('selecting soft mode reports every language as selected', async () => {
+    const { onConfigChange, user: actor } = setup(offConfig)
+
+    await actor.click(
+      screen.getByRole('radio', { name: 'video.subtitle_soft' }),
+    )
+
+    expect(onConfigChange).toHaveBeenCalledWith({
+      mode: 'soft',
+      selectedLans: ['zh', 'ai-zh'],
+    })
+  })
+
+  it('selecting hard mode reports only the first language', async () => {
+    const { onConfigChange, user: actor } = setup(offConfig)
+
+    await actor.click(
+      screen.getByRole('radio', { name: 'video.subtitle_hard' }),
+    )
+
+    expect(onConfigChange).toHaveBeenCalledWith({
+      mode: 'hard',
+      selectedLans: ['zh'],
+    })
+  })
+
+  it('soft mode lists every language with checkboxes and the AI badge', async () => {
+    const softConfig: SubtitleConfig = {
+      mode: 'soft',
+      selectedLans: ['zh', 'ai-zh'],
+    }
+    const { onConfigChange, user: actor } = setup(softConfig)
+
+    expect(
+      screen.getByText('video.subtitle_select_multiple'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Chinese')).toBeInTheDocument()
+    expect(screen.getByText('AI Chinese')).toBeInTheDocument()
+    // AI-generated subtitles are badged
+    expect(screen.getByText('AI')).toBeInTheDocument()
+
+    // The soft-mode checkboxes carry no accessible name (no htmlFor wiring),
+    // so locate positionally: they render in subtitle order.
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+    const aiCheckbox = checkboxes[1]!
+    expect(aiCheckbox).toBeChecked()
+
+    await actor.click(aiCheckbox)
+    expect(onConfigChange).toHaveBeenCalledWith({
+      mode: 'soft',
+      selectedLans: ['zh'],
+    })
+  })
+
+  it('hard mode shows a radio per language plus the burn-in warning', async () => {
+    const hardConfig: SubtitleConfig = { mode: 'hard', selectedLans: ['zh'] }
+    const { onConfigChange, user: actor } = setup(hardConfig)
+
+    expect(screen.getByText('video.subtitle_hard_warning')).toBeInTheDocument()
+
+    // Hard subtitles burn exactly one language track into the video
+    await actor.click(screen.getByRole('radio', { name: /AI Chinese/ }))
+    expect(onConfigChange).toHaveBeenCalledWith({
+      mode: 'hard',
+      selectedLans: ['ai-zh'],
+    })
+  })
+
+  it('disables the mode controls when disabled', () => {
+    setup(offConfig, true)
+
+    expect(
+      screen.getByRole('radio', { name: 'video.subtitle_soft' }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('radio', { name: 'video.subtitle_hard' }),
+    ).toBeDisabled()
+  })
+})

--- a/src/features/video/ui/VideoForm1.test.tsx
+++ b/src/features/video/ui/VideoForm1.test.tsx
@@ -1,0 +1,106 @@
+import { store } from '@/app/store'
+import { useVideoInfo } from '@/features/video'
+import { setInput } from '@/features/video/model/inputSlice'
+import { clearQueue } from '@/shared/queue'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import VideoForm1 from './VideoForm1'
+
+// The context hook is covered by its own tests; mock it so this suite
+// drives the URL form directly. Validation rules live in formSchema.test.
+vi.mock('@/features/video', () => ({
+  useVideoInfo: vi.fn(),
+}))
+vi.mock('@/features/video/api/expandShortUrl', () => ({
+  expandShortUrl: vi.fn(),
+}))
+
+const VALID_URL = 'https://www.bilibili.com/video/BV1xx411c7XD'
+
+/** Renders the form with a fresh store input and a spied onValid1. */
+function setup(isFetching = false) {
+  const onValid1 = vi.fn()
+  store.dispatch(
+    setInput({ url: '', partInputs: [], pendingDownload: null, homePage: 1 }),
+  )
+  vi.mocked(useVideoInfo).mockReturnValue({
+    input: store.getState().input,
+    onValid1,
+    isFetching,
+  } as unknown as ReturnType<typeof useVideoInfo>)
+  return { ...renderWithProviders(<VideoForm1 />), onValid1 }
+}
+
+describe('VideoForm1', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(clearQueue())
+  })
+
+  it('renders the URL input with its example placeholder', () => {
+    setup()
+
+    expect(
+      screen.getByPlaceholderText('video.url_placeholder_example'),
+    ).toBeInTheDocument()
+  })
+
+  it('submits a valid URL to onValid1', async () => {
+    const { user: actor, onValid1 } = setup()
+
+    const input = screen.getByPlaceholderText('video.url_placeholder_example')
+    await actor.type(input, `${VALID_URL}{Enter}`)
+
+    expect(onValid1).toHaveBeenCalledTimes(1)
+    expect(onValid1).toHaveBeenCalledWith(VALID_URL)
+  })
+
+  it('rejects a non-bilibili domain with an inline error and no fetch', async () => {
+    const { user: actor, onValid1 } = setup()
+
+    const input = screen.getByPlaceholderText('video.url_placeholder_example')
+    await actor.type(input, 'https://example.com/video/x{Enter}')
+
+    expect(onValid1).not.toHaveBeenCalled()
+    expect(screen.getByText('validation.video.url.domain')).toBeInTheDocument()
+  })
+
+  it('disables the input while video info is fetching', () => {
+    setup(true)
+
+    expect(
+      screen.getByPlaceholderText('video.url_placeholder_example'),
+    ).toBeDisabled()
+  })
+
+  it('clears the input via the clear button', async () => {
+    const { user: actor } = setup()
+
+    const input = screen.getByPlaceholderText(
+      'video.url_placeholder_example',
+    ) as HTMLInputElement
+    await actor.type(input, VALID_URL)
+    expect(input.value).toBe(VALID_URL)
+
+    // The clear control is the only icon-only button in the field
+    await actor.click(screen.getByRole('button'))
+    expect(input.value).toBe('')
+  })
+
+  it('resubmits the same URL after clearing', async () => {
+    const { user: actor, onValid1 } = setup()
+    const input = screen.getByPlaceholderText('video.url_placeholder_example')
+
+    await actor.type(input, `${VALID_URL}{Enter}`)
+    expect(onValid1).toHaveBeenCalledTimes(1)
+
+    await actor.click(screen.getByRole('button'))
+    await actor.type(input, VALID_URL)
+    await actor.click(document.body)
+
+    // lastFetchedUrl was reset by clear, so the resubmission is not skipped
+    expect(onValid1).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/features/video/ui/VideoPartCard.test.tsx
+++ b/src/features/video/ui/VideoPartCard.test.tsx
@@ -1,0 +1,256 @@
+import { store } from '@/app/store'
+import { useVideoInfo } from '@/features/video'
+import type { PartDownloadStatus } from '@/features/video/hooks/usePartDownloadStatus'
+import { usePartDownloadStatus } from '@/features/video/hooks/usePartDownloadStatus'
+import { setInput } from '@/features/video/model/inputSlice'
+import type { Input, PartInput, Video } from '@/features/video/types'
+import { TooltipProvider } from '@/shared/animate-ui/radix/tooltip'
+import { clearQueue } from '@/shared/queue'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import VideoPartCard from './VideoPartCard'
+
+// The orchestrating context hook and the status hook are covered by their
+// own tests; mock at the hook level so this suite drives the card directly.
+vi.mock('@/features/video', () => ({
+  useVideoInfo: vi.fn(),
+}))
+vi.mock('@/features/video/hooks/usePartDownloadStatus', () => ({
+  usePartDownloadStatus: vi.fn(),
+}))
+vi.mock('@/features/video/api/fetchVideoInfo', () => ({
+  fetchPartQualities: vi.fn(),
+  fetchBangumiPartQualities: vi.fn(),
+  fetchSubtitlesForPart: vi.fn(),
+}))
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}))
+
+/** Minimal single-part video the card is rendered against. */
+const video: Video = {
+  title: 'My Video',
+  bvid: 'BV1xx411c7XD',
+  contentType: 'video',
+  isLimitedQuality: false,
+  parts: [
+    {
+      part: 'Part 1',
+      page: 1,
+      cid: 111,
+      duration: 125,
+      videoQualities: [],
+      audioQualities: [],
+      thumbnail: { url: '' },
+      subtitles: [],
+    },
+  ],
+}
+
+/** Idle status the mocked hook returns by default. */
+function createMockStatus(
+  overrides: Partial<PartDownloadStatus> = {},
+): PartDownloadStatus {
+  return {
+    downloadId: undefined,
+    status: undefined,
+    errorMessage: undefined,
+    outputPath: undefined,
+    filename: undefined,
+    progressEntries: [],
+    isComplete: false,
+    isDownloading: false,
+    isPending: false,
+    hasError: false,
+    isCancelling: false,
+    isCancelled: false,
+    ...overrides,
+  }
+}
+
+/** Builds a selected PartInput for page 1. */
+function createPartInput(overrides: Partial<PartInput> = {}): PartInput {
+  return {
+    cid: 111,
+    page: 1,
+    title: 'My Video Part 1',
+    videoQuality: '',
+    audioQuality: '',
+    selected: true,
+    duration: 125,
+    subtitle: { mode: 'off', selectedLans: [] },
+    ...overrides,
+  }
+}
+
+/** Builds the useVideoInfo value the card consumes. */
+function createMockVideoInfo(): ReturnType<typeof useVideoInfo> {
+  return {
+    onValid2: vi.fn(),
+    onValid1: vi.fn(),
+    download: vi.fn(),
+    isForm1Valid: true,
+    isForm2ValidAll: true,
+    duplicateIndices: [],
+    selectedCount: 1,
+    isFetching: false,
+    input: {} as Input,
+    progress: [],
+    video,
+  } as ReturnType<typeof useVideoInfo>
+}
+
+type SetupOptions = {
+  partInput?: Partial<PartInput>
+  status?: Partial<PartDownloadStatus>
+  isDuplicate?: boolean
+}
+
+/** Seeds the input slice plus both mocked hooks, then renders the card. */
+function setup({
+  partInput = {},
+  status = {},
+  isDuplicate,
+}: SetupOptions = {}) {
+  store.dispatch(
+    setInput({
+      url: '',
+      partInputs: [createPartInput(partInput)],
+      pendingDownload: null,
+      homePage: 1,
+    } satisfies Input),
+  )
+  vi.mocked(useVideoInfo).mockReturnValue(createMockVideoInfo())
+  vi.mocked(usePartDownloadStatus).mockReturnValue(createMockStatus(status))
+  return renderWithProviders(
+    // The app wraps cards in a global TooltipProvider; the part-name
+    // Tooltip relies on it and would throw bare.
+    <TooltipProvider>
+      <VideoPartCard video={video} page={1} isDuplicate={isDuplicate} />
+    </TooltipProvider>,
+  )
+}
+
+describe('VideoPartCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(clearQueue())
+  })
+
+  it('renders the page badge, default title, part name and duration', () => {
+    setup()
+
+    expect(screen.getByText('P1')).toBeInTheDocument()
+    expect(screen.getByText('Part 1')).toBeInTheDocument()
+    // 125s renders as separate "2m" and "5s" spans
+    expect(screen.getByText('2m')).toBeInTheDocument()
+    expect(screen.getByText('5s')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('My Video Part 1')).toBeInTheDocument()
+  })
+
+  it('unchecks the part selection in the store', async () => {
+    const { user: actor } = setup()
+    expect(store.getState().input.partInputs[0]!.selected).toBe(true)
+
+    await actor.click(screen.getByRole('checkbox'))
+
+    expect(store.getState().input.partInputs[0]!.selected).toBe(false)
+  })
+
+  it('shows the duplicate-title warning only for selected parts', () => {
+    setup({ isDuplicate: true })
+    expect(
+      screen.getByText('validation.video.title.duplicate'),
+    ).toBeInTheDocument()
+
+    setup({ partInput: { selected: false }, isDuplicate: true })
+    expect(
+      screen.queryByText('validation.video.title.duplicate'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders quality options with availability from the store when open', () => {
+    setup({
+      partInput: {
+        accordionOpen: true,
+        videoQualities: [{ id: 80, quality: '1080p' }],
+        audioQualities: [],
+        subtitles: [],
+      },
+    })
+
+    // 1080p is available; 4K Dolby Vision (id 120) is not in the store list
+    expect(screen.getByRole('radio', { name: '1080p' })).toBeEnabled()
+    expect(
+      screen.getByRole('radio', { name: '4K Dolby Vision' }),
+    ).toBeDisabled()
+
+    // No audio qualities -> embedded-audio info box instead of a radio group
+    expect(screen.getByText('video.bangumi_audio_embedded')).toBeInTheDocument()
+  })
+
+  it('disables all inputs while the part is downloading', () => {
+    setup({ status: { downloadId: 'dl-1', isDownloading: true } })
+
+    expect(screen.getByRole('checkbox')).toBeDisabled()
+    expect(screen.getByDisplayValue('My Video Part 1')).toBeDisabled()
+  })
+
+  it('shows the download progress area once the part is enqueued', () => {
+    setup({ status: { downloadId: 'dl-1', isPending: true } })
+
+    expect(screen.getByText('video.download_pending')).toBeInTheDocument()
+  })
+
+  it('deselects the part exactly when the download completes', () => {
+    const { rerender } = setup()
+
+    // Simulate the false -> true isComplete transition on rerender.
+    // rerender drops the providers applied by renderWithProviders, so wrap.
+    vi.mocked(usePartDownloadStatus).mockReturnValue(
+      createMockStatus({ downloadId: 'dl-1', isComplete: true }),
+    )
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <TooltipProvider>
+            <VideoPartCard video={video} page={1} />
+          </TooltipProvider>
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    expect(store.getState().input.partInputs[0]!.selected).toBe(false)
+  })
+
+  it('dispatches subtitle config changes to the store', async () => {
+    const { user: actor } = setup({
+      partInput: {
+        accordionOpen: true,
+        videoQualities: [{ id: 80, quality: '1080p' }],
+        audioQualities: [],
+        subtitles: [
+          {
+            lan: 'zh',
+            lanDoc: 'Chinese',
+            subtitleUrl: 'https://s.bcc',
+            isAi: false,
+          },
+        ],
+      },
+    })
+
+    await actor.click(
+      screen.getByRole('radio', { name: 'video.subtitle_soft' }),
+    )
+
+    expect(store.getState().input.partInputs[0]!.subtitle).toEqual({
+      mode: 'soft',
+      selectedLans: ['zh'],
+    })
+  })
+})

--- a/src/features/watch-history/ui/WatchHistoryFilters.test.tsx
+++ b/src/features/watch-history/ui/WatchHistoryFilters.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * WatchHistoryFilters suite.
+ *
+ * Date-filter Select: the picked option reports through onChange.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { WatchHistoryFilters } from './WatchHistoryFilters'
+
+beforeAll(() => {
+  // Radix Select calls these pointer APIs on open; happy-dom lacks them.
+  const stub = (name: string, impl: () => unknown) => {
+    if (!(name in Element.prototype)) {
+      Object.defineProperty(Element.prototype, name, {
+        value: impl,
+        configurable: true,
+      })
+    }
+  }
+  stub('hasPointerCapture', () => false)
+  stub('setPointerCapture', () => {})
+  stub('releasePointerCapture', () => {})
+})
+
+describe('WatchHistoryFilters', () => {
+  it('reports the picked date filter through onChange', async () => {
+    const onChange = vi.fn()
+    const { user } = renderWithProviders(
+      <WatchHistoryFilters value="all" onChange={onChange} />,
+    )
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(
+      screen.getByRole('option', { name: 'watchHistory.filter.week' }),
+    )
+
+    expect(onChange).toHaveBeenCalledWith('week')
+  })
+
+  it('lists all four date filter options when opened', async () => {
+    const { user } = renderWithProviders(
+      <WatchHistoryFilters value="all" onChange={vi.fn()} />,
+    )
+
+    await user.click(screen.getByRole('combobox'))
+
+    expect(
+      screen.getByRole('option', { name: 'watchHistory.filter.all' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'watchHistory.filter.today' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'watchHistory.filter.week' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'watchHistory.filter.month' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/watch-history/ui/WatchHistoryItem.test.tsx
+++ b/src/features/watch-history/ui/WatchHistoryItem.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * WatchHistoryItem suite.
+ *
+ * Presentational entry row: metadata, progress bar width, copy toast and
+ * the download callback (incl. the disabled tooltip wiring).
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WatchHistoryEntry } from '../types'
+import { WatchHistoryItem } from './WatchHistoryItem'
+
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+
+const toastSuccess = toast.success as unknown as Mock
+
+const entry: WatchHistoryEntry = {
+  title: 'Watched Video',
+  cover: 'https://img.example/cover.jpg',
+  bvid: 'BV1yy',
+  cid: 1,
+  page: 1,
+  viewAt: Math.floor((Date.now() - 2 * 24 * 3600 * 1000) / 1000),
+  duration: 2000,
+  progress: 1000, // exactly 50%
+  url: 'https://www.bilibili.com/video/BV1yy',
+}
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+function renderEntry(overrides: Partial<WatchHistoryEntry> = {}) {
+  const onDownload = vi.fn()
+  const utils = renderWithProviders(
+    <WatchHistoryItem
+      entry={{ ...entry, ...overrides }}
+      onDownload={onDownload}
+    />,
+  )
+  return { ...utils, onDownload }
+}
+
+describe('WatchHistoryItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders title, url and thumbnail', () => {
+    renderEntry()
+
+    expect(screen.getByText('Watched Video')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: entry.url })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Watched Video' })).toHaveAttribute(
+      'src',
+      entry.cover,
+    )
+  })
+
+  it('shows the short duration and the relative view time', () => {
+    renderEntry()
+
+    expect(screen.getByText('33:20')).toBeInTheDocument()
+    expect(screen.getByText('watchHistory.time.daysAgo')).toBeInTheDocument()
+  })
+
+  it('sizes the progress bar from progress/duration', () => {
+    renderEntry()
+
+    const bar = document.querySelector<HTMLElement>('.bg-gradient-to-r')
+    expect(bar).not.toBeNull()
+    expect(bar!.style.width).toBe('50%')
+  })
+
+  it('copies the URL and toasts success', async () => {
+    const { user } = renderEntry()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    await user.click(screen.getByTitle('history.copyUrl'))
+
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(entry.url))
+    expect(toastSuccess).toHaveBeenCalledWith('history.copySuccess')
+  })
+
+  it('invokes onDownload with the entry', async () => {
+    const { user, onDownload } = renderEntry()
+
+    await user.click(
+      screen.getByRole('button', { name: 'watchHistory.download' }),
+    )
+
+    expect(onDownload).toHaveBeenCalledWith(entry)
+  })
+
+  it('disables the download button when disabled', () => {
+    renderWithProviders(
+      <WatchHistoryItem entry={entry} onDownload={vi.fn()} disabled />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'watchHistory.download' }),
+    ).toBeDisabled()
+  })
+})

--- a/src/features/watch-history/ui/WatchHistoryList.test.tsx
+++ b/src/features/watch-history/ui/WatchHistoryList.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * WatchHistoryList suite.
+ *
+ * Loading/empty states render synchronously. Like HistoryList, entries
+ * go through react-virtuoso, which cannot compute a viewport under
+ * happy-dom (zero-sized rects, no layout engine) — infinite-scroll
+ * (endReached) and item rendering are therefore not exercised here;
+ * per-entry behavior is covered by WatchHistoryItem.test.tsx.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import type { WatchHistoryEntry } from '../types'
+import { WatchHistoryList } from './WatchHistoryList'
+
+const entry: WatchHistoryEntry = {
+  title: 'A watched video',
+  cover: 'https://img.example/c.jpg',
+  bvid: 'BV1zz',
+  cid: 1,
+  page: 1,
+  viewAt: Math.floor(Date.now() / 1000),
+  duration: 100,
+  progress: 10,
+  url: 'https://www.bilibili.com/video/BV1zz',
+}
+
+beforeAll(() => {
+  // happy-dom ships no ResizeObserver; react-virtuoso requires one.
+  if (!('ResizeObserver' in globalThis)) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+  }
+})
+
+describe('WatchHistoryList', () => {
+  it('shows the empty state when there are no entries', () => {
+    renderWithProviders(
+      <WatchHistoryList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('watchHistory.empty')).toBeInTheDocument()
+  })
+
+  it('mounts the virtualized scroller when entries exist', () => {
+    renderWithProviders(
+      <WatchHistoryList
+        entries={[entry]}
+        loading={false}
+        loadingMore={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    )
+
+    expect(
+      document.querySelector('[data-virtuoso-scroller]'),
+    ).toBeInTheDocument()
+  })
+})
+
+// Skipped: loading-state spinner assert — the loading branch renders only a
+// CircleIndicator (shared/ui, no text) and is covered by its own suite.

--- a/src/features/watch-history/ui/WatchHistorySearch.test.tsx
+++ b/src/features/watch-history/ui/WatchHistorySearch.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * WatchHistorySearch suite.
+ *
+ * Controlled input: typing propagates through onChange.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { WatchHistorySearch } from './WatchHistorySearch'
+
+describe('WatchHistorySearch', () => {
+  it('renders the seeded value and localized placeholder', () => {
+    renderWithProviders(
+      <WatchHistorySearch value="initial" onChange={vi.fn()} />,
+    )
+
+    expect(screen.getByPlaceholderText('watchHistory.search')).toHaveValue(
+      'initial',
+    )
+  })
+
+  it('propagates every keystroke through onChange', async () => {
+    const onChange = vi.fn()
+    const { user } = renderWithProviders(
+      <WatchHistorySearch value="" onChange={onChange} />,
+    )
+
+    await user.type(screen.getByPlaceholderText('watchHistory.search'), 'ab')
+
+    expect(onChange).toHaveBeenLastCalledWith('b')
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/pages/history/HistoryContent.test.tsx
+++ b/src/pages/history/HistoryContent.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * HistoryContent (history page) suite.
+ *
+ * Covers the page-level wiring that does not live in features/history/ui:
+ * search box -> setSearch, and the export flow -> save dialog +
+ * writeTextFile. useHistory and usePendingDownload are mocked at the hook
+ * level (F3 covers the hooks themselves); all UI children are real.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { save } from '@tauri-apps/plugin-dialog'
+import { writeTextFile } from '@tauri-apps/plugin-fs'
+import { screen, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const historyHook = vi.hoisted(() => ({
+  state: {
+    entries: [],
+    loading: false,
+    error: null,
+    filters: { status: 'all' as const },
+    searchQuery: '',
+  },
+  setSearch: vi.fn(),
+  updateFilters: vi.fn(),
+  exportData: vi.fn().mockResolvedValue('[{"id":"1"}]'),
+}))
+
+vi.mock('@/features/history/hooks/useHistory', () => ({
+  useHistory: () => ({ ...historyHook.state, ...historyHook }),
+}))
+vi.mock('@/shared/hooks/usePendingDownload', () => ({
+  usePendingDownload: () => vi.fn(),
+}))
+vi.mock('@/shared/ui/toast', () => ({
+  toast: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}))
+
+import { toast } from '@/shared/ui/toast'
+import { HistoryContent } from './index'
+
+const mockSave = save as unknown as Mock
+const mockWriteTextFile = writeTextFile as unknown as Mock
+const toastSuccess = toast.success as unknown as Mock
+
+describe('HistoryContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    historyHook.exportData.mockResolvedValue('[{"id":"1"}]')
+    mockSave.mockResolvedValue(null)
+    mockWriteTextFile.mockResolvedValue(undefined)
+  })
+
+  it('propagates search input to setSearch', async () => {
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    await user.type(
+      screen.getByPlaceholderText('history.searchPlaceholder'),
+      'abc',
+    )
+
+    expect(historyHook.setSearch).toHaveBeenLastCalledWith('c')
+  })
+
+  it('exports via save dialog and writeTextFile, then toasts success', async () => {
+    mockSave.mockResolvedValue('/out/history.json')
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    // Open the export dialog, then submit with the default json format
+    await user.click(
+      screen.getByRole('button', { name: 'history.exportTitle' }),
+    )
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await waitFor(() =>
+      expect(mockSave).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultPath: 'history.json' }),
+      ),
+    )
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      '/out/history.json',
+      '[{"id":"1"}]',
+    )
+    expect(toastSuccess).toHaveBeenCalledWith('history.exportSuccess')
+  })
+
+  it('skips writing when the save dialog is cancelled', async () => {
+    mockSave.mockResolvedValue(null)
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'history.exportTitle' }),
+    )
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await waitFor(() => expect(mockSave).toHaveBeenCalled())
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/layout/PageLayout.test.tsx
+++ b/src/shared/layout/PageLayout.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * PageLayoutShell suite.
+ *
+ * Heavy siblings are stubbed (SettingsDialog, DownloadStatusDialog — both
+ * have their own suites); the sidebar/app-bar chrome, route-aware nav
+ * button and children slot are asserted against the real store.
+ */
+
+import { store } from '@/app/store'
+import { setOpenDialog } from '@/features/settings/settingsSlice'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/features/download-status', () => ({
+  DownloadStatusDialog: () => <div data-testid="download-status-dialog" />,
+}))
+vi.mock('@/features/settings/dialog/SettingsDialog', () => ({
+  default: () => <div data-testid="settings-dialog" />,
+}))
+// AppBar chrome: GitHubStars fetches star counts (own suite in shared/ui)
+vi.mock('@/shared/ui/GitHubStars', () => ({
+  GitHubStars: () => <div data-testid="github-stars" />,
+}))
+
+import { PageLayoutShell } from './PageLayout'
+
+function renderShell(route = '/home') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/*" element={<PageLayoutShell>page-body</PageLayoutShell>} />
+    </Routes>,
+    { route },
+  )
+}
+
+/**
+ * The footer nav button, located via its visible span (tooltip also
+ * contributes to the accessible name, so role+name is brittle).
+ */
+function historyNavButton(): HTMLElement {
+  return screen
+    .getAllByText('nav.downloadHistory')
+    .map((el) => el.closest('button'))
+    .find((btn): btn is HTMLButtonElement => btn !== null)!
+}
+
+describe('PageLayoutShell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+    store.dispatch(setOpenDialog(false))
+  })
+
+  it('renders the chrome and children', () => {
+    renderShell()
+
+    expect(screen.getByText('page-body')).toBeInTheDocument()
+    // Chrome pieces: sidebar trigger, settings dialog slot, app bar
+    // (label depends on the sidebar's collapsed state)
+    expect(
+      screen.getByRole('button', { name: /nav\.aria\.(open|close)Sidebar/ }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('settings-dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('download-status-dialog')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'settings.title' }),
+    ).toBeInTheDocument()
+  })
+
+  it('marks the history nav active only on /history', () => {
+    renderShell('/history')
+
+    expect(historyNavButton().getAttribute('data-active')).toBe('true')
+  })
+
+  it('leaves the history nav inactive on other routes', () => {
+    renderShell('/home')
+
+    expect(historyNavButton().getAttribute('data-active')).toBe('false')
+  })
+
+  it('clicking the history nav navigates to /history', async () => {
+    const { user } = renderShell('/home')
+
+    await user.click(historyNavButton())
+
+    // Route changed: the shell re-rendered with /history active
+    await vi.waitFor(() =>
+      expect(historyNavButton().getAttribute('data-active')).toBe('true'),
+    )
+  })
+
+  it('the footer settings button opens the settings dialog state', async () => {
+    const { user } = renderShell('/home')
+
+    await user.click(screen.getByRole('button', { name: 'settings.title' }))
+
+    expect(store.getState().settings.dialogOpen).toBe(true)
+  })
+})

--- a/src/shared/layout/PageTemplate.test.tsx
+++ b/src/shared/layout/PageTemplate.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * PageTemplate suite.
+ *
+ * Pure presentational frame: assert both header layouts and that
+ * children land in the body wrapper.
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PageTemplate } from './PageTemplate'
+
+describe('PageTemplate', () => {
+  it('renders a simple header with title and description', () => {
+    renderWithProviders(
+      <PageTemplate title="Page Title" description="Page description">
+        <div>body-content</div>
+      </PageTemplate>,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Page Title' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Page description')).toBeInTheDocument()
+    expect(screen.getByText('body-content')).toBeInTheDocument()
+  })
+
+  it('omits the description node when not provided', () => {
+    renderWithProviders(
+      <PageTemplate title="Page Title">
+        <div>body-content</div>
+      </PageTemplate>,
+    )
+
+    expect(screen.queryByText('Page description')).toBeNull()
+  })
+
+  it('renders the toolbar layout when actions are provided', () => {
+    renderWithProviders(
+      <PageTemplate
+        title="Page Title"
+        actions={<button type="button">action-button</button>}
+      >
+        <div>body-content</div>
+      </PageTemplate>,
+    )
+
+    expect(screen.getByText('action-button')).toBeInTheDocument()
+    expect(screen.getByText('body-content')).toBeInTheDocument()
+  })
+})

--- a/src/shared/layout/PersistentPageLayout.test.tsx
+++ b/src/shared/layout/PersistentPageLayout.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * PersistentPageLayout suite.
+ *
+ * All nine page contents are stubbed with testid markers so the
+ * mount-persistence strategy itself is under test: lazy mount on first
+ * visit, display:none hiding, and the invalid-path redirect.
+ */
+
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/pages/home', () => ({
+  HomeContent: () => <div data-testid="page-home" />,
+}))
+vi.mock('@/pages/history', () => ({
+  HistoryContent: () => <div data-testid="page-history" />,
+}))
+vi.mock('@/pages/favorite', () => ({
+  FavoriteContent: () => <div data-testid="page-favorite" />,
+}))
+vi.mock('@/pages/watch-history', () => ({
+  WatchHistoryContent: () => <div data-testid="page-watch-history" />,
+}))
+vi.mock('@/pages/trim', () => ({
+  TrimContent: () => <div data-testid="page-trim" />,
+}))
+vi.mock('@/pages/concat', () => ({
+  ConcatContent: () => <div data-testid="page-concat" />,
+}))
+vi.mock('@/pages/audio', () => ({
+  AudioContent: () => <div data-testid="page-audio" />,
+}))
+vi.mock('@/pages/resolution', () => ({
+  ResolutionContent: () => <div data-testid="page-resolution" />,
+}))
+vi.mock('@/pages/rotation', () => ({
+  RotationContent: () => <div data-testid="page-rotation" />,
+}))
+vi.mock('@/shared/ui/GitHubStars', () => ({
+  GitHubStars: () => <div data-testid="github-stars" />,
+}))
+
+import { PersistentPageLayout } from './PersistentPageLayout'
+
+function renderLayout(route = '/home') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/*" element={<PersistentPageLayout />} />
+    </Routes>,
+    { route },
+  )
+}
+
+/** The visibility wrapper the layout puts around each page. */
+function wrapperOf(testid: string): HTMLElement {
+  return screen.getByTestId(testid).parentElement!.parentElement!
+}
+
+describe('PersistentPageLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('renders only /home initially', () => {
+    renderLayout('/home')
+
+    expect(screen.getByTestId('page-home')).toBeInTheDocument()
+    expect(screen.queryByTestId('page-history')).toBeNull()
+    expect(screen.queryByTestId('page-trim')).toBeNull()
+  })
+
+  it('redirects unknown paths to /home', () => {
+    renderLayout('/bogus')
+
+    expect(screen.getByTestId('page-home')).toBeInTheDocument()
+  })
+
+  it('mounts a page on first visit and keeps earlier pages mounted hidden', async () => {
+    const { user } = renderLayout('/home')
+
+    // Footer nav button, located via its visible span (tooltip also feeds
+    // the accessible name, so role+name is brittle)
+    const historyNav = screen
+      .getAllByText('nav.downloadHistory')
+      .map((el) => el.closest('button'))
+      .find((btn): btn is HTMLButtonElement => btn !== null)!
+    await user.click(historyNav)
+
+    expect(await screen.findByTestId('page-history')).toBeInTheDocument()
+    // /home stays mounted (state preserved) but is hidden via display:none
+    expect(screen.getByTestId('page-home')).toBeInTheDocument()
+    expect(wrapperOf('page-home').style.display).toBe('none')
+    expect(wrapperOf('page-history').style.display).toBe('')
+  })
+})

--- a/src/shared/ui/AppBar/AppBar.test.tsx
+++ b/src/shared/ui/AppBar/AppBar.test.tsx
@@ -1,0 +1,113 @@
+import { store } from '@/app/store'
+import { setSettings } from '@/features/settings/settingsSlice'
+import type { Settings } from '@/features/settings/type'
+import type { User } from '@/features/user/types'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AppBar from './AppBar'
+
+// Child feature widgets have their own concerns (settings hook, QR polling,
+// star fetching); stub them so this suite stays on AppBar's own logic.
+vi.mock('@/features/login', () => ({
+  QRCodeLoginDialog: ({ open }: { open: boolean }) =>
+    open ? <div>qr-login-dialog</div> : null,
+}))
+vi.mock('@/features/preference/ui/LanguageSwitcher', () => ({
+  default: () => <div>language-switcher</div>,
+}))
+vi.mock('@/features/preference/ui/ToggleThemeButton', () => ({
+  default: (props: { theme: string }) => <div>theme-{props.theme}</div>,
+}))
+vi.mock('@/shared/ui/GitHubStars', () => ({
+  GitHubStars: () => <div>github-stars</div>,
+}))
+
+/** Builds a User with the login fields the AppBar branches on. */
+function createUser(
+  overrides: { uname?: string; isLogin?: boolean; hasCookie?: boolean } = {},
+): User {
+  return {
+    code: 0,
+    message: '',
+    ttl: 0,
+    data: {
+      uname: overrides.uname ?? '',
+      isLogin: overrides.isLogin ?? false,
+      wbiImg: { imgUrl: '', subUrl: '' },
+    },
+    hasCookie: overrides.hasCookie ?? false,
+  }
+}
+
+const baseSettings: Settings = {
+  dlOutputPath: '',
+  language: 'en',
+  autoRenameDuplicates: true,
+  showGithubStars: true,
+  trimMode: 'copy',
+  audioFormat: 'mp3',
+  theme: 'light',
+  showTaskbarProgress: true,
+  flashTaskbarOnComplete: true,
+  videoCodecPriority: 'av1First',
+  downloadParallelism: 8,
+}
+
+/** Renders the AppBar, seeding settings.showGithubStars before render. */
+function setup(showGithubStars: boolean, user: User = createUser()) {
+  store.dispatch(setSettings({ ...baseSettings, showGithubStars }))
+  return renderWithProviders(
+    <AppBar user={user} theme="light" setTheme={vi.fn()} />,
+  )
+}
+
+describe('AppBar', () => {
+  it('shows the masked username when logged in', () => {
+    setup(
+      true,
+      createUser({ uname: 'someuser', isLogin: true, hasCookie: true }),
+    )
+
+    // Last 3 characters are masked for privacy ("someuser" -> "someu***")
+    expect(screen.getByText('someu***')).toBeInTheDocument()
+    expect(screen.queryByText('user.not_logged_in')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'login.qrCodeLogin' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('masks short usernames entirely', () => {
+    setup(true, createUser({ uname: 'abc', isLogin: true, hasCookie: true }))
+
+    expect(screen.getByText('***')).toBeInTheDocument()
+  })
+
+  it('shows the login prompt and QR button when logged out', async () => {
+    const { user: actor } = setup(true, createUser({ isLogin: false }))
+
+    expect(screen.getByText('user.not_logged_in')).toBeInTheDocument()
+
+    await actor.click(screen.getByRole('button', { name: 'login.qrCodeLogin' }))
+    expect(screen.getByText('qr-login-dialog')).toBeInTheDocument()
+  })
+
+  it('treats isLogin without a cookie as logged out', () => {
+    setup(true, createUser({ uname: 'ghost', isLogin: true, hasCookie: false }))
+
+    expect(screen.getByText('user.not_logged_in')).toBeInTheDocument()
+  })
+
+  it('hides GitHub stars when the setting is off', () => {
+    setup(false)
+
+    expect(screen.queryByText('github-stars')).not.toBeInTheDocument()
+  })
+
+  it('shows GitHub stars when the setting is on', () => {
+    setup(true)
+
+    expect(screen.getByText('github-stars')).toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/CircleIndicator/CircleIndicator.test.tsx
+++ b/src/shared/ui/CircleIndicator/CircleIndicator.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import CircleIndicator from './CircleIndicator'
+
+// Loader2 renders a plain svg with no role, so locate it structurally.
+function getLoader(container: HTMLElement): Element {
+  const svg = container.querySelector('svg')
+  expect(svg).not.toBeNull()
+  return svg!
+}
+
+describe('CircleIndicator', () => {
+  it('renders a spinning loader at the default lg size', () => {
+    const { container } = render(<CircleIndicator />)
+
+    expect(getLoader(container)).toHaveClass('animate-spin', 'h-8', 'w-8')
+  })
+
+  it('applies the class for each size variant', () => {
+    const { container, rerender } = render(<CircleIndicator size="sm" />)
+
+    const icon = getLoader(container)
+    expect(icon).toHaveClass('h-4', 'w-4')
+
+    rerender(<CircleIndicator size="md" />)
+    expect(icon).toHaveClass('h-6', 'w-6')
+  })
+
+  it('merges a custom className', () => {
+    const { container } = render(<CircleIndicator className="mt-2" />)
+
+    expect(getLoader(container)).toHaveClass('mt-2')
+  })
+})

--- a/src/shared/ui/ErrorBoundary.test.tsx
+++ b/src/shared/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,79 @@
+import { logger } from '@/shared/lib/logger'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from './ErrorBoundary'
+
+vi.mock('@/shared/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+/** Child that throws on render, to trip the boundary. */
+function Bomb(): React.ReactNode {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Silence React's own rstack report of the caught error.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <p>healthy content</p>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('healthy content')).toBeInTheDocument()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('renders the default fallback UI and logs via logger.error', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'An unexpected error occurred. Please restart the application.',
+      ),
+    ).toBeInTheDocument()
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalledWith(
+      'React Error Boundary caught an error',
+      expect.stringContaining('boom'),
+    )
+  })
+
+  it('shows the raw error message in DEV', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    )
+
+    // import.meta.env.DEV is true under Vitest
+    expect(screen.getByText('boom')).toBeInTheDocument()
+  })
+
+  it('renders a custom fallback instead of the default UI', () => {
+    render(
+      <ErrorBoundary fallback={<div>custom fallback</div>}>
+        <Bomb />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('custom fallback')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/GitHubStars/GitHubStars.test.tsx
+++ b/src/shared/ui/GitHubStars/GitHubStars.test.tsx
@@ -1,0 +1,96 @@
+import {
+  getCachedStars,
+  isCacheValid,
+  setCachedStars,
+} from '@/shared/lib/githubStarsCache'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GitHubStars } from './GitHubStars'
+
+// The cache is a pure localStorage wrapper; mock it so tests control
+// cache hits without touching storage state.
+vi.mock('@/shared/lib/githubStarsCache', () => ({
+  getCachedStars: vi.fn(),
+  isCacheValid: vi.fn(),
+  setCachedStars: vi.fn(),
+}))
+
+describe('GitHubStars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: cache miss
+    vi.mocked(getCachedStars).mockReturnValue(null)
+    vi.mocked(isCacheValid).mockReturnValue(false)
+  })
+
+  it('fetches and renders the formatted star count', async () => {
+    mockInvoke.mockResolvedValue(1234)
+
+    renderWithProviders(
+      <GitHubStars owner="j4rviscmd" repo="bilibili-downloader-gui" />,
+    )
+
+    // Loading placeholder until the invoke resolves
+    expect(screen.getByText('---')).toBeInTheDocument()
+    expect(await screen.findByText('1.2k')).toBeInTheDocument()
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_repo_stars', {
+      owner: 'j4rviscmd',
+      repo: 'bilibili-downloader-gui',
+    })
+    expect(setCachedStars).toHaveBeenCalledWith(
+      'j4rviscmd',
+      'bilibili-downloader-gui',
+      1234,
+    )
+  })
+
+  it('renders counts under 1000 without the k suffix', async () => {
+    mockInvoke.mockResolvedValue(999)
+
+    renderWithProviders(<GitHubStars owner="o" repo="r" />)
+
+    expect(await screen.findByText('999')).toBeInTheDocument()
+  })
+
+  it('links to the stargazers page with a count tooltip label', () => {
+    vi.mocked(getCachedStars).mockReturnValue(42)
+    vi.mocked(isCacheValid).mockReturnValue(true)
+
+    renderWithProviders(<GitHubStars owner="j4rviscmd" repo="app" />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/j4rviscmd/app/stargazers',
+    )
+    // Identity t: 'github.stars' with count interpolation leaves the key as-is
+    expect(link).toHaveAttribute('aria-label', 'github.stars')
+  })
+
+  it('skips the fetch entirely on a valid cache hit', () => {
+    vi.mocked(getCachedStars).mockReturnValue(42)
+    vi.mocked(isCacheValid).mockReturnValue(true)
+
+    renderWithProviders(<GitHubStars owner="o" repo="r" />)
+
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the repo label silently when the fetch fails', async () => {
+    mockInvoke.mockRejectedValue(new Error('rate limited'))
+
+    renderWithProviders(<GitHubStars owner="o" repo="r" />)
+
+    // Keeps the placeholder; no cached value exists to fall back to
+    await screen.findByText('---')
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'aria-label',
+      'github.repo',
+    )
+    expect(screen.queryByText('1.2k')).not.toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.test.tsx
+++ b/src/shared/ui/NavigationSidebar/NavigationSidebarHeader.test.tsx
@@ -1,0 +1,172 @@
+import { store } from '@/app/store'
+import type { User } from '@/features/user/types'
+import { setUser } from '@/features/user/userSlice'
+import { setHomePage } from '@/features/video/model/inputSlice'
+import { clearQueue } from '@/shared/queue'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { useLocation } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NavigationSidebarHeader } from './NavigationSidebarHeader'
+
+// The vendored sidebar shells need a SidebarProvider ancestor; passthrough
+// divs keep the suite on this component's own nav logic. SidebarMenuButton
+// drops its sidebar-only props (isActive/tooltip) and forwards the rest.
+vi.mock('@/shared/animate-ui/radix/sidebar', () => {
+  // The layout shells all collapse to the same passthrough div
+  const passthrough = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  return {
+    SidebarGroup: passthrough,
+    SidebarGroupContent: passthrough,
+    SidebarGroupLabel: passthrough,
+    SidebarMenu: passthrough,
+    SidebarMenuItem: passthrough,
+    SidebarSeparator: () => <hr />,
+    SidebarMenuButton: ({
+      children,
+      isActive,
+      tooltip,
+      ...props
+    }: React.ComponentProps<'button'> & {
+      isActive?: boolean
+      tooltip?: string
+    }) => {
+      // Strip sidebar-only props before they hit the DOM
+      void tooltip
+      return (
+        <button
+          type="button"
+          data-active={isActive ? 'true' : undefined}
+          {...props}
+        >
+          {children}
+        </button>
+      )
+    },
+  }
+})
+
+/** Exposes the current router location for assertions. */
+function LocationProbe() {
+  const location = useLocation()
+  return (
+    <div data-testid="location">
+      {location.pathname}
+      {location.search}
+    </div>
+  )
+}
+
+function renderSidebar(route = '/home') {
+  return renderWithProviders(
+    <>
+      <NavigationSidebarHeader />
+      <LocationProbe />
+    </>,
+    { route },
+  )
+}
+
+const loggedOutUser: User = {
+  code: 0,
+  message: '',
+  ttl: 0,
+  data: { uname: '', isLogin: false, wbiImg: { imgUrl: '', subUrl: '' } },
+  hasCookie: false,
+}
+
+describe('NavigationSidebarHeader', () => {
+  beforeEach(() => {
+    // Reset shared singleton-store slices between tests.
+    store.dispatch(setUser(loggedOutUser))
+    store.dispatch(clearQueue())
+    store.dispatch(setHomePage(1))
+  })
+
+  it('renders every navigation group and item with its label', () => {
+    renderSidebar()
+
+    const labels = [
+      'nav.home',
+      'nav.category.bilibili',
+      'nav.favorite',
+      'nav.watchHistory',
+      'nav.category.tool',
+      'nav.trim',
+      'nav.concat',
+      'nav.audio',
+      'nav.resolution',
+      'nav.rotation',
+    ]
+    for (const label of labels) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it('marks the current route as the active page', () => {
+    renderSidebar('/trim')
+
+    const trim = screen.getByRole('button', { name: 'nav.aria.trim' })
+    expect(trim).toHaveAttribute('aria-current', 'page')
+    expect(trim).toHaveAttribute('data-active', 'true')
+
+    const home = screen.getByRole('button', { name: 'nav.aria.home' })
+    expect(home).not.toHaveAttribute('aria-current')
+  })
+
+  it('navigates to the clicked item path', async () => {
+    const { user: actor } = renderSidebar('/home')
+
+    await actor.click(screen.getByRole('button', { name: 'nav.aria.concat' }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/concat')
+    expect(
+      screen.getByRole('button', { name: 'nav.aria.concat' }),
+    ).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('restores the last-viewed ?page= param on Home navigation', async () => {
+    store.dispatch(setHomePage(3))
+    const { user: actor } = renderSidebar('/trim')
+
+    await actor.click(screen.getByRole('button', { name: 'nav.aria.home' }))
+
+    // The Home button returns to the paginated page the user was on,
+    // taking URL priority over any stale ?p embedded in input.url.
+    expect(screen.getByTestId('location')).toHaveTextContent('/home?page=3')
+  })
+
+  it('disables auth-required items when logged out and blocks navigation', async () => {
+    const { user: actor } = renderSidebar('/home')
+
+    const favorite = screen.getByRole('button', { name: 'nav.aria.favorite' })
+    expect(favorite).toHaveAttribute('aria-disabled', 'true')
+
+    await actor.click(favorite)
+    expect(screen.getByTestId('location')).toHaveTextContent('/home')
+  })
+
+  it('enables auth-required items when logged in', async () => {
+    store.dispatch(
+      setUser({
+        ...loggedOutUser,
+        hasCookie: true,
+        data: {
+          uname: 'user',
+          isLogin: true,
+          wbiImg: { imgUrl: '', subUrl: '' },
+        },
+      }),
+    )
+    const { user: actor } = renderSidebar('/home')
+
+    const favorite = screen.getByRole('button', { name: 'nav.aria.favorite' })
+    expect(favorite).not.toHaveAttribute('aria-disabled')
+
+    await actor.click(favorite)
+    expect(screen.getByTestId('location')).toHaveTextContent('/favorite')
+  })
+})

--- a/src/shared/ui/Progress/ProgressStatusBar.test.tsx
+++ b/src/shared/ui/Progress/ProgressStatusBar.test.tsx
@@ -1,0 +1,82 @@
+import { store } from '@/app/store'
+import type { Progress } from '@/shared/progress/types'
+import { clearQueue, enqueue } from '@/shared/queue'
+import { renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import ProgressStatusBar from './ProgressStatusBar'
+
+/** Builds a full Progress object with test-friendly defaults. */
+function createProgress(overrides: Partial<Progress> = {}): Progress {
+  return {
+    downloadId: 'dl-1',
+    deltaTime: 1,
+    filesize: 45.6,
+    downloaded: 12.3,
+    transferRate: 512,
+    percentage: 27,
+    elapsedTime: 125,
+    isComplete: false,
+    ...overrides,
+  }
+}
+
+describe('ProgressStatusBar', () => {
+  beforeEach(() => {
+    // The real singleton store persists between tests; clear the queue.
+    store.dispatch(clearQueue())
+  })
+
+  it('renders elapsed, speed, sizes and percentage', () => {
+    renderWithProviders(
+      <ProgressStatusBar progress={createProgress({ elapsedTime: 3725 })} />,
+    )
+
+    // 3725s -> 1h2m5s
+    expect(
+      screen.getByText('progress.elapsed:', { exact: false }),
+    ).toHaveTextContent('1h2m5s')
+    expect(
+      screen.getByText('progress.speed:', { exact: false }),
+    ).toHaveTextContent('512KB/s')
+    expect(screen.getByText('12.3mb/45.6mb')).toBeInTheDocument()
+    expect(screen.getByText('27%')).toBeInTheDocument()
+  })
+
+  it('switches to MB/s at 1000 KB/s or above', () => {
+    renderWithProviders(
+      <ProgressStatusBar progress={createProgress({ transferRate: 1536 })} />,
+    )
+
+    expect(
+      screen.getByText('progress.speed:', { exact: false }),
+    ).toHaveTextContent('1.5MB/s')
+  })
+
+  it('omits speed and size when filesize is unknown', () => {
+    renderWithProviders(
+      <ProgressStatusBar progress={createProgress({ filesize: null! })} />,
+    )
+
+    expect(
+      screen.getByText('progress.elapsed:', { exact: false }),
+    ).toHaveTextContent('2m5s')
+    expect(screen.getByText('27%')).toBeInTheDocument()
+    expect(
+      screen.queryByText('progress.speed:', { exact: false }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('12.3mb/45.6mb')).not.toBeInTheDocument()
+  })
+
+  it('shows the queued label instead of elapsed for a pending queue item', () => {
+    store.dispatch(enqueue({ downloadId: 'dl-1', status: 'pending' }))
+
+    renderWithProviders(<ProgressStatusBar progress={createProgress()} />)
+
+    expect(screen.getByText('progress.queued')).toBeInTheDocument()
+    expect(
+      screen.queryByText('progress.elapsed:', { exact: false }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,11 +37,13 @@ export default defineConfig({
       ],
       // Ratchet baseline; bump per PR, 100 at the end of the F-series.
       // Lines only: v8 branch/function metrics on TSX are noisy.
-      // Why: 48 sits just under the measured lines coverage of this batch
-      // (48.87% via `npx vitest run --coverage`), so the gate passes today
-      // and only a real regression fails. v8 counts drift slightly across
-      // platforms, so on a CI/local mismatch re-measure rather than lowering.
-      thresholds: { lines: 48 },
+      // Why: 69 sits just under the measured lines coverage of this batch
+      // (70.09% via `npx vitest run --coverage`), so the gate passes today
+      // and only a real regression fails. One full point below rather than
+      // 70, since 70.09% leaves only ~3 covered lines of margin and v8
+      // counts drift slightly across platforms (macOS local vs Ubuntu CI);
+      // on a mismatch re-measure rather than lowering.
+      thresholds: { lines: 69 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

F4 of the frontend test-coverage plan. **636 → 801 tests (+165)**, threshold 48 → 69 (measured ~70%, one full point of headroom because the required CI gate runs Linux where v8 counts drift slightly vs local macOS). Vendored shadcn/animate-ui components remain out of scope (coverage excludes from F1); this PR contains no production changes.

- **shared/ui hand-written** (6 suites): ErrorBoundary (fallback + logger), GitHubStars (invoke + mocked cache), AppBar login states, NavigationSidebarHeader, ProgressStatusBar, CircleIndicator
- **video/ui** (6): VideoForm1, DownloadButton state matrix, QualityRadioGroup, SubtitleSection, PartDownloadProgress, VideoPartCard (hook mocks, duplicate-title and complete-transition effects)
- **settings** (7): **SettingsForm via the 3-layer strategy** — sibling API mocks + real `useSettings` + seeded store (language persist, empty-path FormMessage, logout, login-method switch); TitleReplacementSettings (MAX_RULES=20), UpdateCheckButton (hoisted DEV flip), DevOptions, ReleaseNotesSection, OpenLogsButton, SettingsDialog
- **login/about** (2): QRCodeDisplay status ladder + `/home` navigation probe, AboutDialog (`get_app_info`, OS row, `menu:about` event)
- **history/watch-history** (6): item/search/filters/list/export suites + HistoryContent export wiring (`save` dialog → `writeTextFile`)
- **layouts** (3): PageTemplate, PageLayout route-based active nav, PersistentPageLayout redirect + `display:none` persistence

### Merge adaptation

main gained the QR session verification fixes (#552/#553) while this branch was in review; a follow-up commit adapts three tests to the new flow (`resetLogin` dropped on mount, `getUserInfo` verification before navigation, SettingsForm deriving login status from live `fetchUser` instead of the session file).

## Testing

`npm run test:coverage`: 801 passed / 4 skipped, threshold met (69.96% ≥ 69 post-merge). typecheck / lint / prettier / build green. Review pass verified the 3-layer mock strategy, type shapes against `features/video/types.ts`, and the tight 70.09→69 threshold decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)