### PR TITLE
test: close coverage gaps in concat, updater, watch-history and video suites

### DIFF
--- a/src/features/concat/ui/FileList.test.tsx
+++ b/src/features/concat/ui/FileList.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * FileList suite.
+ *
+ * happy-dom cannot drive @dnd-kit pointer sensors, so DndContext is
+ * stubbed to capture `onDragEnd` and SortableContext/useSortable to
+ * pass-through stubs — the drag-end index resolution branches are then
+ * exercised by invoking the captured handler directly (same technique
+ * as the Virtuoso stub in FavoriteList.test.tsx).
+ */
+
+import { renderWithProviders } from '@/test/test-utils'
+import type { DragEndEvent } from '@dnd-kit/core'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dnd = vi.hoisted(() => ({
+  onDragEnd: null as null | ((e: DragEndEvent) => void),
+}))
+
+vi.mock('@dnd-kit/core', async (importActual) => {
+  const actual = await importActual<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode
+      onDragEnd: (e: DragEndEvent) => void
+    }) => {
+      dnd.onDragEnd = onDragEnd
+      return children
+    },
+  }
+})
+
+vi.mock('@dnd-kit/sortable', async (importActual) => {
+  const actual = await importActual<typeof import('@dnd-kit/sortable')>()
+  return {
+    ...actual,
+    SortableContext: ({ children }: { children: React.ReactNode }) => children,
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: null,
+      transition: null,
+      isDragging: false,
+    }),
+  }
+})
+
+import { FileList } from './FileList'
+
+const FILES = ['/media/a.mp4', '/media/b.mp4', '/media/c.mp4']
+
+function renderList(props: Partial<Parameters<typeof FileList>[0]> = {}) {
+  const onRemove = vi.fn()
+  const onReorder = vi.fn()
+  renderWithProviders(
+    <FileList
+      files={FILES}
+      isProcessing={false}
+      onRemove={onRemove}
+      onReorder={onReorder}
+      {...props}
+    />,
+  )
+  return { onRemove, onReorder }
+}
+
+/** Fires the captured drag-end handler with minimal active/over ids. */
+function drag(active: string, over: string | null) {
+  dnd.onDragEnd!({
+    active: { id: active },
+    over: over === null ? null : { id: over },
+  } as DragEndEvent)
+}
+
+describe('FileList', () => {
+  beforeEach(() => {
+    dnd.onDragEnd = null
+  })
+
+  it('renders every file with its position index and basename only', () => {
+    renderList()
+
+    expect(screen.getByText('1.')).toBeInTheDocument()
+    expect(screen.getByText('2.')).toBeInTheDocument()
+    expect(screen.getByText('3.')).toBeInTheDocument()
+    expect(screen.getByText('a.mp4')).toBeInTheDocument()
+    // Directory part is kept out of the visible name (title attr only)
+    expect(screen.queryByText('/media/a.mp4')).toBeNull()
+  })
+
+  it('reports the remove click with the item index', () => {
+    const { onRemove } = renderList()
+
+    // Second remove button (by aria label) belongs to b.mp4 at index 1
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((b) => b.getAttribute('aria-label') === 'concat.removeFileAria')
+    expect(buttons).toHaveLength(3)
+    buttons[1]!.click()
+
+    expect(onRemove).toHaveBeenCalledWith(1)
+  })
+
+  it('disables drag and remove controls while processing', () => {
+    renderList({ isProcessing: true })
+
+    const disabled = screen
+      .getAllByRole('button')
+      .filter((b) => b.hasAttribute('disabled'))
+    // 3 grip handles + 3 remove buttons
+    expect(disabled).toHaveLength(6)
+  })
+
+  it('reorders when the drag ends on a different file', () => {
+    const { onReorder } = renderList()
+
+    drag('/media/a.mp4', '/media/c.mp4')
+
+    expect(onReorder).toHaveBeenCalledWith(0, 2)
+  })
+
+  it('ignores a drop on the same item', () => {
+    const { onReorder } = renderList()
+
+    drag('/media/a.mp4', '/media/a.mp4')
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it('ignores a drop outside the list', () => {
+    const { onReorder } = renderList()
+
+    drag('/media/a.mp4', null)
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it('ignores ids that are not in the list', () => {
+    const { onReorder } = renderList()
+
+    drag('/media/x.mp4', '/media/c.mp4')
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/login/ui/QRCodeDisplay.test.tsx
+++ b/src/features/login/ui/QRCodeDisplay.test.tsx
@@ -178,4 +178,42 @@ describe('QRCodeDisplay', () => {
 
     expect(screen.getByText('HOME-MARKER')).toBeInTheDocument()
   })
+
+  it('error status maps a known ERR:: code to its translation key', () => {
+    Object.assign(login.state, {
+      qrStatus: 'error',
+      statusMessage: 'x ERR::VIDEO_NOT_FOUND y',
+    })
+    renderLogin()
+
+    expect(screen.getByText('video.video_not_found')).toBeInTheDocument()
+  })
+
+  it('error status falls back to the raw status message for unknown codes', () => {
+    Object.assign(login.state, {
+      qrStatus: 'error',
+      statusMessage: 'mystery failure',
+    })
+    renderLogin()
+
+    expect(screen.getByText('mystery failure')).toBeInTheDocument()
+  })
+
+  it('error status uses the generic failure text without a message', () => {
+    Object.assign(login.state, { qrStatus: 'error', statusMessage: '' })
+    renderLogin()
+
+    expect(screen.getByText('login.loginFailed')).toBeInTheDocument()
+  })
+
+  it('renders a polling error verbatim when it has no known code', () => {
+    Object.assign(login.state, {
+      qrStatus: 'waitingForScan',
+      qrCodeImage: 'data:image/png;base64,qr',
+      error: 'poll request failed',
+    })
+    renderLogin()
+
+    expect(screen.getByText('poll request failed')).toBeInTheDocument()
+  })
 })

--- a/src/features/updater/ui/UpdateNotification.test.tsx
+++ b/src/features/updater/ui/UpdateNotification.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * UpdateNotification suite.
+ *
+ * The dialog renders only while `updater.showDialog` is true; the real
+ * updaterSlice in the singleton store drives every body/footer branch
+ * (downloading / ready / error / release notes / spinner). The
+ * useUpdateDownload hook is mocked — its Started→Progress→Finished
+ * ladder is covered by useUpdateDownload.test.tsx.
+ */
+
+import { store } from '@/app/store'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const downloadHook = vi.hoisted(() => ({
+  handleUpdate: vi.fn(),
+  handleRetry: vi.fn(),
+  handleRestart: vi.fn(),
+}))
+
+vi.mock('@/features/updater', async (importActual) => {
+  const actual = await importActual<typeof import('@/features/updater')>()
+  return {
+    ...actual,
+    useUpdateDownload: () => downloadHook,
+  }
+})
+
+import {
+  resetUpdater,
+  setError,
+  setIsDownloading,
+  setIsUpdateReady,
+  setReleaseNotes,
+  setUpdateAvailable,
+} from '@/features/updater/model/updaterSlice'
+import { UpdateNotification } from './UpdateNotification'
+
+function renderDialog() {
+  return renderWithProviders(<UpdateNotification />)
+}
+
+/** Opens the dialog with an available update between two versions. */
+function openWithUpdate() {
+  store.dispatch(
+    setUpdateAvailable({
+      available: true,
+      latestVersion: '1.52.0',
+      currentVersion: '1.51.0',
+    }),
+  )
+}
+
+describe('UpdateNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.dispatch(resetUpdater())
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('renders nothing while the dialog is closed', () => {
+    renderDialog()
+
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+  })
+
+  it('shows both versions in the header when an update is available', async () => {
+    openWithUpdate()
+    renderDialog()
+
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('v1.51.0')).toBeInTheDocument()
+    // Title heading + latest badge both carry it
+    expect(screen.getAllByText('v1.52.0').length).toBeGreaterThan(0)
+  })
+
+  it('renders markdown release notes through the custom components', async () => {
+    openWithUpdate()
+    store.dispatch(setReleaseNotes('# Release 1.52\n\n**bold** and `code`'))
+    renderDialog()
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Release 1.52' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByText('code').tagName).toBe('CODE')
+  })
+
+  it('shows the spinner body while no notes are loaded yet', async () => {
+    openWithUpdate()
+    renderDialog()
+
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+    // Waiting branch: animated spinner, no notes container, no progress label
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+    expect(screen.queryByText('updater.downloading')).toBeNull()
+  })
+
+  it('locks the footer actions and swaps the label while downloading', () => {
+    openWithUpdate()
+    store.dispatch(setIsDownloading(true))
+    renderDialog()
+
+    expect(screen.getByText('updater.actions.downloading')).toBeInTheDocument()
+    const later = screen.getByRole('button', { name: 'updater.actions.later' })
+    const update = screen.getByRole('button', {
+      name: 'updater.actions.downloading',
+    })
+    expect(later).toBeDisabled()
+    expect(update).toBeDisabled()
+  })
+
+  it('offers restart once the update is ready', async () => {
+    openWithUpdate()
+    store.dispatch(setIsUpdateReady(true))
+    const { user } = renderDialog()
+
+    await user.click(
+      screen.getByRole('button', { name: 'updater.actions.restart' }),
+    )
+
+    expect(downloadHook.handleRestart).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the error body and wires the retry button', async () => {
+    openWithUpdate()
+    store.dispatch(setError('network unreachable'))
+    const { user } = renderDialog()
+
+    expect(screen.getByText('network unreachable')).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: 'updater.actions.retry' }),
+    )
+
+    expect(downloadHook.handleRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('closing the dialog hides it again', async () => {
+    openWithUpdate()
+    const { user } = renderDialog()
+    await screen.findByRole('alertdialog')
+
+    await user.click(
+      screen.getByRole('button', { name: 'updater.actions.later' }),
+    )
+
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+    expect(store.getState().updater.showDialog).toBe(false)
+  })
+})

--- a/src/features/video/api/fetchVideoInfo.test.ts
+++ b/src/features/video/api/fetchVideoInfo.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/features/video/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchBangumiPartQualities,
   fetchPartQualities,
   fetchSubtitlesForPart,
   fetchVideoInfo,
@@ -128,6 +129,42 @@ describe('fetchVideoInfo', () => {
 
       await expect(fetchPartQualities('BV1234567890', 123456)).rejects.toThrow(
         'Failed to fetch qualities',
+      )
+    })
+  })
+
+  describe('fetchBangumiPartQualities', () => {
+    it('returns the triple from fetch_bangumi_part_qualities', async () => {
+      const mockVideoQualities: VideoQuality[] = [{ quality: '1080p', id: 80 }]
+      const mockAudioQualities: AudioQuality[] = [{ quality: '64K', id: 30216 }]
+      mockInvoke.mockResolvedValue([
+        mockVideoQualities,
+        mockAudioQualities,
+        true,
+      ])
+
+      const result = await fetchBangumiPartQualities(3051843, 123456)
+
+      expect(mockInvoke).toHaveBeenCalledWith('fetch_bangumi_part_qualities', {
+        epId: 3051843,
+        cid: 123456,
+      })
+      expect(result).toEqual([mockVideoQualities, mockAudioQualities, true])
+    })
+
+    it('keeps isPreview null when the backend sends null', async () => {
+      mockInvoke.mockResolvedValue([[], [], null])
+
+      const result = await fetchBangumiPartQualities(3051843, 123456)
+
+      expect(result[2]).toBeNull()
+    })
+
+    it('should propagate errors from backend', async () => {
+      mockInvoke.mockRejectedValue(new Error('bangumi qualities failed'))
+
+      await expect(fetchBangumiPartQualities(3051843, 123456)).rejects.toThrow(
+        'bangumi qualities failed',
       )
     })
   })

--- a/src/features/video/api/videoApi.test.ts
+++ b/src/features/video/api/videoApi.test.ts
@@ -1,11 +1,53 @@
-import { describe, expect, it } from 'vitest'
-
 // Load the store before videoApi: videoApi -> tauriBaseQuery -> store/index
 // -> videoApi is a cycle that only resolves when store/index is entered
 // first (tauriBaseQuery references `store` lazily at call time).
-import '@/app/store'
+import { store } from '@/app/store'
+import { mockInvoke } from '@/test/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
 
-import { fetchContentFromUrl } from './videoApi'
+import { fetchContentFromUrl, videoApi } from './videoApi'
+
+describe('fetchContentInfo query builder', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset()
+    mockInvoke.mockResolvedValue({})
+  })
+
+  it('routes a video id to fetch_video_info', async () => {
+    await store.dispatch(
+      videoApi.endpoints.fetchContentInfo.initiate({
+        type: 'video',
+        id: 'BV1xx411c7XD',
+      }),
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_video_info', {
+      videoId: 'BV1xx411c7XD',
+    })
+  })
+
+  it('routes a bangumi id to fetch_bangumi_info with a numeric epId', async () => {
+    await store.dispatch(
+      videoApi.endpoints.fetchContentInfo.initiate({
+        type: 'bangumi',
+        epId: '3051843',
+      }),
+    )
+
+    expect(mockInvoke).toHaveBeenCalledWith('fetch_bangumi_info', {
+      epId: 3051843,
+    })
+  })
+
+  it('rejects a missing content id before any invoke', async () => {
+    const result = await store.dispatch(
+      videoApi.endpoints.fetchContentInfo.initiate(null as never),
+    )
+
+    expect(result.status).toBe('rejected')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
 
 describe('fetchContentFromUrl', () => {
   it('maps a video URL to video args', () => {

--- a/src/features/video/ui/PartDownloadProgress.test.tsx
+++ b/src/features/video/ui/PartDownloadProgress.test.tsx
@@ -1,6 +1,7 @@
 import { TooltipProvider } from '@/shared/animate-ui/radix/tooltip'
 import type { Progress } from '@/shared/progress/types'
 import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { error as logError } from '@tauri-apps/plugin-log'
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -185,5 +186,54 @@ describe('PartDownloadProgress', () => {
     expect(
       screen.queryByText('video.download_cancelled'),
     ).not.toBeInTheDocument()
+  })
+
+  it('reveals the finished file in the folder', async () => {
+    mockInvoke.mockResolvedValue(undefined)
+    const { user: actor } = setup(
+      createMockStatus({
+        isComplete: true,
+        outputPath: '/downloads/video.mp4',
+      }),
+    )
+
+    await actor.click(screen.getByRole('button', { name: 'video.open_folder' }))
+
+    expect(mockInvoke).toHaveBeenCalledWith('reveal_in_folder', {
+      path: '/downloads/video.mp4',
+    })
+  })
+
+  it('swallows an open_file rejection through the logger', async () => {
+    mockInvoke.mockRejectedValueOnce(new Error('no association'))
+    const { user: actor } = setup(
+      createMockStatus({
+        isComplete: true,
+        outputPath: '/downloads/video.mp4',
+      }),
+    )
+
+    // Must not throw out of the click handler
+    await actor.click(screen.getByRole('button', { name: 'video.open_file' }))
+
+    expect(logError).toHaveBeenCalledWith(
+      '[FE] Failed to open file: Error: no association',
+    )
+  })
+
+  it('swallows a reveal_in_folder rejection through the logger', async () => {
+    mockInvoke.mockRejectedValueOnce(new Error('finder error'))
+    const { user: actor } = setup(
+      createMockStatus({
+        isComplete: true,
+        outputPath: '/downloads/video.mp4',
+      }),
+    )
+
+    await actor.click(screen.getByRole('button', { name: 'video.open_folder' }))
+
+    expect(logError).toHaveBeenCalledWith(
+      '[FE] Failed to reveal in folder: Error: finder error',
+    )
   })
 })

--- a/src/features/video/ui/VideoForm1.test.tsx
+++ b/src/features/video/ui/VideoForm1.test.tsx
@@ -1,5 +1,6 @@
 import { store } from '@/app/store'
 import { useVideoInfo } from '@/features/video'
+import { expandShortUrl } from '@/features/video/api/expandShortUrl'
 import { setInput } from '@/features/video/model/inputSlice'
 import { clearQueue } from '@/shared/queue'
 import { renderWithProviders } from '@/test/test-utils'
@@ -102,5 +103,54 @@ describe('VideoForm1', () => {
 
     // lastFetchedUrl was reset by clear, so the resubmission is not skipped
     expect(onValid1).toHaveBeenCalledTimes(2)
+  })
+
+  describe('short-URL expansion', () => {
+    const SHORT = 'https://b23.tv/abc123'
+
+    // Real timers: the 500ms debounce elapses naturally, which keeps the
+    // shared userEvent instance (no advanceTimers wiring) usable.
+    const debounce = () => new Promise((resolve) => setTimeout(resolve, 700))
+
+    /** Types a short URL without submitting (the change handler drives expansion). */
+    async function typeShortUrl(url: string) {
+      const utils = setup()
+      const input = screen.getByPlaceholderText('video.url_placeholder_example')
+      await utils.user.type(input, url)
+      return { ...utils, input }
+    }
+
+    it('expands a b23.tv URL after the 500ms debounce and fetches it', async () => {
+      vi.mocked(expandShortUrl).mockResolvedValue(VALID_URL)
+      const { onValid1 } = await typeShortUrl(SHORT)
+
+      await debounce()
+      expect(expandShortUrl).toHaveBeenCalledWith(SHORT)
+      expect(onValid1).toHaveBeenCalledWith(VALID_URL)
+    })
+
+    it('keeps the last keystroke: an earlier debounce timer is cancelled', async () => {
+      vi.mocked(expandShortUrl).mockResolvedValue(VALID_URL)
+      const { user, input } = await typeShortUrl(SHORT)
+
+      // Extra keystroke before the first 500ms window closes: only the
+      // final value may expand
+      await user.type(input, '4')
+      await debounce()
+
+      expect(expandShortUrl).toHaveBeenCalledTimes(1)
+      expect(expandShortUrl).toHaveBeenCalledWith(`${SHORT}4`)
+    })
+
+    it('shows the inline error when expansion fails', async () => {
+      vi.mocked(expandShortUrl).mockRejectedValue(new Error('no redirect'))
+      await typeShortUrl(SHORT)
+
+      await debounce()
+
+      expect(
+        screen.getByText('validation.video.url.short_url_expand_failed'),
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/features/watch-history/lib/utils.test.ts
+++ b/src/features/watch-history/lib/utils.test.ts
@@ -1,0 +1,90 @@
+/**
+ * watch-history lib utils suite.
+ *
+ * Pure formatting functions. The setup i18next mock makes `i18n.t` an
+ * identity `t`, so i18n-backed formatters return their raw key —
+ * interpolation is only observable where the key itself carries
+ * {{placeholders}} (none do today).
+ *
+ * formatRelativeTime reads Date.now(), so timestamps are computed from a
+ * frozen "now" instead of hard-coded epoch values.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  calculateProgress,
+  formatDuration,
+  formatDurationShort,
+  formatRelativeTime,
+} from './utils'
+
+const NOW = new Date('2026-08-30T12:00:00Z').getTime()
+
+/** Seconds ago relative to the frozen NOW. */
+const secondsAgo = (s: number) => Math.floor(NOW / 1000) - s
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('falls back to justNow under one minute', () => {
+    expect(formatRelativeTime(secondsAgo(30))).toBe('watchHistory.time.justNow')
+  })
+
+  it('uses the minutes bucket for less than an hour', () => {
+    expect(formatRelativeTime(secondsAgo(90))).toBe(
+      'watchHistory.time.minutesAgo',
+    )
+  })
+
+  it('uses the hours bucket for less than a day', () => {
+    expect(formatRelativeTime(secondsAgo(2 * 3600))).toBe(
+      'watchHistory.time.hoursAgo',
+    )
+  })
+
+  it('uses the days bucket beyond 24h', () => {
+    expect(formatRelativeTime(secondsAgo(3 * 86400))).toBe(
+      'watchHistory.time.daysAgo',
+    )
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats without the hours part under one hour', () => {
+    expect(formatDuration(330)).toBe('watchHistory.time.durationMS')
+  })
+
+  it('keeps the hours part at one hour and above', () => {
+    expect(formatDuration(6711)).toBe('watchHistory.time.durationHMS')
+  })
+})
+
+describe('formatDurationShort', () => {
+  it('formats m:ss under one hour with zero-padded seconds', () => {
+    expect(formatDurationShort(205)).toBe('3:25')
+  })
+
+  it('formats h:mm:ss at one hour and above', () => {
+    expect(formatDurationShort(6713)).toBe('1:51:53')
+  })
+})
+
+describe('calculateProgress', () => {
+  it('returns 0 for a non-positive duration', () => {
+    expect(calculateProgress(50, 0)).toBe(0)
+    expect(calculateProgress(50, -10)).toBe(0)
+  })
+
+  it('clamps the ratio into 0-100', () => {
+    expect(calculateProgress(50, 100)).toBe(50)
+    expect(calculateProgress(150, 100)).toBe(100)
+    expect(calculateProgress(-10, 100)).toBe(0)
+  })
+})

--- a/src/features/watch-history/ui/WatchHistoryList.test.tsx
+++ b/src/features/watch-history/ui/WatchHistoryList.test.tsx
@@ -1,11 +1,11 @@
 /**
  * WatchHistoryList suite.
  *
- * Loading/empty states render synchronously. Like HistoryList, entries
- * go through react-virtuoso, which cannot compute a viewport under
- * happy-dom (zero-sized rects, no layout engine) — infinite-scroll
- * (endReached) and item rendering are therefore not exercised here;
- * per-entry behavior is covered by WatchHistoryItem.test.tsx.
+ * Loading/empty states render synchronously. happy-dom cannot give
+ * react-virtuoso a viewport, so the populated path runs through a
+ * Virtuoso stub that executes itemContent/endReached/components.Footer
+ * directly (same technique as FavoriteList.test.tsx). Per-entry
+ * behavior is covered by WatchHistoryItem.test.tsx.
  */
 
 import { renderWithProviders } from '@/test/test-utils'
@@ -13,6 +13,34 @@ import { screen } from '@testing-library/react'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import type { WatchHistoryEntry } from '../types'
 import { WatchHistoryList } from './WatchHistoryList'
+
+// Minimal Virtuoso stand-in: renders every item through itemContent,
+// mounts the Footer component and fires endReached once (deferred so
+// React has committed first).
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+    endReached,
+    components,
+  }: {
+    data: unknown[]
+    itemContent: (index: number, item: unknown) => React.ReactNode
+    endReached?: () => void
+    components?: { Footer?: () => React.ReactNode }
+  }) => {
+    Promise.resolve().then(() => endReached?.())
+    const Footer = components?.Footer
+    return (
+      <div data-virtuoso-scroller>
+        {data.map((item, i) => (
+          <div key={i}>{itemContent(i, item)}</div>
+        ))}
+        {Footer ? <Footer /> : null}
+      </div>
+    )
+  },
+}))
 
 const entry: WatchHistoryEntry = {
   title: 'A watched video',
@@ -24,6 +52,25 @@ const entry: WatchHistoryEntry = {
   duration: 100,
   progress: 10,
   url: 'https://www.bilibili.com/video/BV1zz',
+}
+
+function renderList(
+  overrides: Partial<Parameters<typeof WatchHistoryList>[0]> = {},
+) {
+  const onLoadMore = vi.fn()
+  const onDownload = vi.fn()
+  renderWithProviders(
+    <WatchHistoryList
+      entries={[entry]}
+      loading={false}
+      loadingMore={false}
+      hasMore={false}
+      onLoadMore={onLoadMore}
+      onDownload={onDownload}
+      {...overrides}
+    />,
+  )
+  return { onLoadMore, onDownload }
 }
 
 beforeAll(() => {
@@ -38,38 +85,60 @@ beforeAll(() => {
 })
 
 describe('WatchHistoryList', () => {
+  it('shows the loading spinner while the initial fetch runs', () => {
+    renderList({ loading: true })
+
+    expect(document.querySelector('[data-virtuoso-scroller]')).toBeNull()
+    expect(document.querySelector('svg')).not.toBeNull()
+  })
+
   it('shows the empty state when there are no entries', () => {
-    renderWithProviders(
-      <WatchHistoryList
-        entries={[]}
-        loading={false}
-        loadingMore={false}
-        hasMore={false}
-        onLoadMore={vi.fn()}
-        onDownload={vi.fn()}
-      />,
-    )
+    renderList({ entries: [] })
 
     expect(screen.getByText('watchHistory.empty')).toBeInTheDocument()
   })
 
-  it('mounts the virtualized scroller when entries exist', () => {
-    renderWithProviders(
-      <WatchHistoryList
-        entries={[entry]}
-        loading={false}
-        loadingMore={false}
-        hasMore={false}
-        onLoadMore={vi.fn()}
-        onDownload={vi.fn()}
-      />,
-    )
+  it('renders every entry and requests the next page at the end', async () => {
+    const { onLoadMore } = renderList({ hasMore: true })
 
-    expect(
-      document.querySelector('[data-virtuoso-scroller]'),
-    ).toBeInTheDocument()
+    // itemContent executed through the stub
+    expect(screen.getByText('A watched video')).toBeInTheDocument()
+    await vi.waitFor(() => expect(onLoadMore).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not request more pages while a page is loading', async () => {
+    const { onLoadMore } = renderList({ hasMore: true, loadingMore: true })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  it('does not request more pages when hasMore is false', async () => {
+    const { onLoadMore } = renderList({ hasMore: false })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  it('shows the footer spinner only while loading more', () => {
+    const props = {
+      entries: [entry],
+      loading: false,
+      loadingMore: true,
+      hasMore: true,
+      onLoadMore: vi.fn(),
+      onDownload: vi.fn(),
+    }
+    const { rerender } = renderWithProviders(<WatchHistoryList {...props} />)
+
+    // Footer renders a centered spinner block while loadingMore
+    expect(document.querySelector('.py-4')).not.toBeNull()
+
+    rerender(<WatchHistoryList {...props} loadingMore={false} />)
+
+    // Footer returns null otherwise: last child is the entry row itself
+    expect(document.querySelector('.py-4')).toBeNull()
+    const scroller = document.querySelector('[data-virtuoso-scroller]')!
+    expect(scroller.lastElementChild?.textContent).toContain('A watched video')
   })
 })
-
-// Skipped: loading-state spinner assert — the loading branch renders only a
-// CircleIndicator (shared/ui, no text) and is covered by its own suite.

--- a/src/pages/history/HistoryContent.test.tsx
+++ b/src/pages/history/HistoryContent.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { renderWithProviders } from '@/test/test-utils'
-import { save } from '@tauri-apps/plugin-dialog'
+import { confirm, save } from '@tauri-apps/plugin-dialog'
 import { writeTextFile } from '@tauri-apps/plugin-fs'
 import { screen, waitFor } from '@testing-library/react'
 import type { Mock } from 'vitest'
@@ -16,7 +16,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const historyHook = vi.hoisted(() => ({
   state: {
-    entries: [],
+    entries: [] as Array<{ id: string }>,
     loading: false,
     error: null,
     filters: { status: 'all' as const },
@@ -24,6 +24,8 @@ const historyHook = vi.hoisted(() => ({
   },
   setSearch: vi.fn(),
   updateFilters: vi.fn(),
+  remove: vi.fn(),
+  clear: vi.fn(),
   exportData: vi.fn().mockResolvedValue('[{"id":"1"}]'),
 }))
 
@@ -42,11 +44,14 @@ import { HistoryContent } from './index'
 
 const mockSave = save as unknown as Mock
 const mockWriteTextFile = writeTextFile as unknown as Mock
+const mockConfirm = confirm as unknown as Mock
 const toastSuccess = toast.success as unknown as Mock
+const toastError = toast.error as unknown as Mock
 
 describe('HistoryContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    historyHook.state.entries = []
     historyHook.exportData.mockResolvedValue('[{"id":"1"}]')
     mockSave.mockResolvedValue(null)
     mockWriteTextFile.mockResolvedValue(undefined)
@@ -97,5 +102,71 @@ describe('HistoryContent', () => {
     await waitFor(() => expect(mockSave).toHaveBeenCalled())
     expect(mockWriteTextFile).not.toHaveBeenCalled()
     expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('toasts the raw message when the export throws an Error', async () => {
+    mockSave.mockResolvedValue('/out/history.csv')
+    historyHook.exportData.mockRejectedValue(new Error('disk full'))
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'history.exportTitle' }),
+    )
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('disk full'))
+  })
+
+  it('toasts the generic message when the export rejects without Error', async () => {
+    mockSave.mockResolvedValue('/out/history.json')
+    historyHook.exportData.mockRejectedValue('boom')
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'history.exportTitle' }),
+    )
+    await user.click(screen.getByRole('button', { name: 'actions.submit' }))
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith('history.exportFailed'),
+    )
+  })
+
+  it('clears all entries only after the confirm dialog accepts', async () => {
+    historyHook.state.entries = [{ id: '1' }]
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    const clearButton = screen.getByRole('button', { name: 'history.clearAll' })
+    expect(clearButton).toBeEnabled()
+
+    mockConfirm.mockResolvedValueOnce(false)
+    await user.click(clearButton)
+    expect(historyHook.clear).not.toHaveBeenCalled()
+
+    mockConfirm.mockResolvedValueOnce(true)
+    await user.click(clearButton)
+    expect(historyHook.clear).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables clear-all while the history is empty', () => {
+    renderWithProviders(<HistoryContent />)
+
+    expect(
+      screen.getByRole('button', { name: 'history.clearAll' }),
+    ).toBeDisabled()
+  })
+
+  it('propagates filter changes to updateFilters', async () => {
+    const { user } = renderWithProviders(<HistoryContent />)
+
+    // HistoryFilters dropdown: trigger shows the active filter label
+    await user.click(screen.getByRole('button', { name: 'history.filterAll' }))
+    await user.click(
+      screen.getByRole('menuitem', { name: 'history.filterFailed' }),
+    )
+
+    expect(historyHook.updateFilters).toHaveBeenCalledWith({
+      status: 'failed',
+    })
   })
 })

--- a/src/pages/home/index.test.tsx
+++ b/src/pages/home/index.test.tsx
@@ -7,7 +7,7 @@ import type { Video, VideoPart } from '@/features/video/types'
 import HomeContent from '@/pages/home'
 import { renderWithProviders } from '@/test/test-utils'
 import { screen, within } from '@testing-library/react'
-import { Navigate, Route, Routes } from 'react-router'
+import { Navigate, Route, Routes, useLocation } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Leaf UI components are covered by their own F4 tests; here they are stubbed
@@ -95,6 +95,24 @@ function RedirectHarness() {
       <Route path="/" element={<Navigate to="/home" replace />} />
       <Route path="/home" element={<HomeContent />} />
       <Route path="/init" element={<div>init-route</div>} />
+    </Routes>
+  )
+}
+
+/** /home route with an echo of the search string so URL rewrites are observable. */
+function HomeWithSearchEcho() {
+  const { search } = useLocation()
+  return (
+    <Routes>
+      <Route
+        path="/home"
+        element={
+          <>
+            <HomeContent />
+            <div data-testid="search-echo">{search}</div>
+          </>
+        }
+      />
     </Routes>
   )
 }
@@ -264,5 +282,40 @@ describe('HomeContent', () => {
     renderWithProviders(<RedirectHarness />, { route: '/' })
 
     expect(await screen.findByText('init-route')).toBeInTheDocument()
+  })
+
+  it('strips a stale page param when a ?p= URL lands in the store', async () => {
+    store.dispatch(setInput(initialInput))
+    renderWithProviders(<HomeWithSearchEcho />, { route: '/home?page=2' })
+
+    // A multi-part URL arriving in the store invalidates the page param
+    store.dispatch(
+      setInput({
+        ...initialInput,
+        url: 'https://www.bilibili.com/video/BV1x?p=3',
+      }),
+    )
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId('search-echo').textContent).toBe(''),
+    )
+  })
+
+  it('keeps other search params when stripping the stale page param', async () => {
+    store.dispatch(setInput(initialInput))
+    renderWithProviders(<HomeWithSearchEcho />, {
+      route: '/home?page=2&foo=1',
+    })
+
+    store.dispatch(
+      setInput({
+        ...initialInput,
+        url: 'https://www.bilibili.com/video/BV1y?p=2',
+      }),
+    )
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId('search-echo').textContent).toBe('?foo=1'),
+    )
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #556 — coverage-gap closing pass. **1128 → 1180 tests (+52)**, line coverage **93.53% → 95.32%**, no production changes. Threshold stays at 92.

### New suites (3)

- `watch-history/lib/utils.test.ts` — time/duration formatters, all buckets, progress clamping (frozen clock via fake timers)
- `concat/ui/FileList.test.tsx` — DndContext capture stub drives every drag-end index-resolution branch (reorder / same item / drop outside / unknown id) plus remove + disabled states
- `updater/ui/UpdateNotification.test.tsx` — real updaterSlice drives all dialog body branches (downloading / ready / error / markdown release notes / spinner) and the update/retry/restart wiring

### Suite extensions (8)

- `WatchHistoryList` — loading spinner, endReached guard (`hasMore` × `loadingMore`), footer spinner, via the FavoriteList Virtuoso stub
- `HistoryContent` — clear-all confirm accept/reject, export failure paths (Error vs non-Error), filter dropdown wiring
- `videoApi` — `fetchContentInfo` routing (video / bangumi / null reject) through a real RTK `initiate`
- `QRCodeDisplay` — error status mapping (known `ERR::` code / raw message / generic) + verbatim polling error
- `fetchVideoInfo` — `fetchBangumiPartQualities` success / `isPreview: null` / failure
- `VideoForm1` — b23.tv short-URL debounce: expand + fetch, timer cancellation on retyping, inline error on failure (real timers)
- `PartDownloadProgress` — reveal-in-folder action and swallowed open/reveal failures routed through the logger
- `home` — stale `page` search param stripped when a `?p=` URL lands in the store (other params preserved)

### Skipped by design

- `App.tsx` `import.meta.env.DEV` context-menu guard — unreachable in the test environment, near-zero test value
- home login-benefits `Trans` buttons — the central identity `Trans` mock does not render `components` props; covering them needs a per-file react-i18next re-mock with poor cost/benefit

## Test plan

- [x] `npx vitest run` — 144 files / 1180 tests green, thresholds pass (lines 95.32%)
- [x] `npm run typecheck`, `npm run lint`, Prettier — clean
- [x] Review: code-reviewer no findings, code-simplifier 6 cleanups, doc-generator 0 additions

Related: #549, #550, #551, #555, #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)