### PR TITLE
test: close #563 coverage gaps (libPath patch, partial merge, sidebar persistence)

### DIFF
--- a/src-tauri/src/handlers/settings.rs
+++ b/src-tauri/src/handlers/settings.rs
@@ -239,6 +239,26 @@ mod tests {
     }
 
     #[test]
+    fn patch_updates_lib_path_via_serde_rename_key() {
+        // Pins the contract used by update_lib_path: it patches the
+        // camelCase serde rename `libPath`. If the sent key ever diverges
+        // from the rename, the patch silently no-ops (unknown keys are kept
+        // on disk but ignored by Settings), so the library path would never
+        // change.
+        let dir = tempdir();
+        write_settings(dir.path(), json!({"language": "en", "libPath": "/old/lib"}));
+
+        patch_settings_at(&settings_file(dir.path()), &json!({"libPath": "/new/lib"})).unwrap();
+
+        // On-disk document carries the renamed key...
+        assert_eq!(read_settings(dir.path())["libPath"], json!("/new/lib"));
+        // ...and the merged document still deserializes into Settings with
+        // the field populated.
+        let merged: Settings = serde_json::from_value(read_settings(dir.path())).unwrap();
+        assert_eq!(merged.lib_path.as_deref(), Some("/new/lib"));
+    }
+
+    #[test]
     fn patch_on_missing_file_creates_it_with_patch_only() {
         let dir = tempdir();
         patch_settings_at(&settings_file(dir.path()), &json!({"fontSize": 16})).unwrap();

--- a/src/features/settings/settingsSlice.test.ts
+++ b/src/features/settings/settingsSlice.test.ts
@@ -62,4 +62,18 @@ describe('settingsSlice', () => {
     // setSettings preserves UI-only state that the backend object lacks.
     expect(s.dialogOpen).toBe(true)
   })
+
+  it('merges a partial patch (issue #563) keeping untouched fields and dialogOpen', () => {
+    // Save paths now dispatch single-field patches; the reducer must
+    // shallow-merge them instead of replacing the whole state.
+    store.dispatch(setSettings({ dlOutputPath: '/downloads', language: 'ja' }))
+    store.dispatch(setOpenDialog(true))
+
+    store.dispatch(setSettings({ fontSize: 16 }))
+
+    expect(settings().fontSize).toBe(16)
+    expect(settings().language).toBe('ja')
+    expect(settings().dlOutputPath).toBe('/downloads')
+    expect(settings().dialogOpen).toBe(true)
+  })
 })

--- a/src/shared/animate-ui/radix/sidebar.test.tsx
+++ b/src/shared/animate-ui/radix/sidebar.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * SidebarProvider persistence suite (issue #563).
+ *
+ * Persisting the sidebar open/close state goes through the
+ * `patch_settings` field patch — this pins the payload shape so a
+ * regression to a whole-object save (or a broken key) cannot slip in
+ * unnoticed.
+ */
+
+import { store } from '@/app/store'
+import { mockInvoke, renderWithProviders } from '@/test/test-utils'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarProvider, useSidebar } from './sidebar'
+
+/** Renders a button inside the provider that closes the sidebar on click. */
+function Probe() {
+  const { setOpen } = useSidebar()
+  return (
+    <button type="button" onClick={() => setOpen(false)}>
+      close-sidebar
+    </button>
+  )
+}
+
+describe('SidebarProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvoke.mockResolvedValue(undefined)
+  })
+
+  it('persists open/close via patch_settings with only sidebarExpanded', async () => {
+    const { user } = renderWithProviders(
+      <SidebarProvider>
+        <Probe />
+      </SidebarProvider>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'close-sidebar' }))
+
+    // Field patch only (issue #563): never a whole-settings object, which
+    // would overwrite fields saved by another app instance.
+    expect(mockInvoke).toHaveBeenCalledWith('patch_settings', {
+      patch: { sidebarExpanded: false },
+    })
+    // The Redux sidebar state updates alongside the persistence call.
+    expect(store.getState().sidebar.sidebarOpen).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Test-only change closing the three coverage gaps left by PR #566 (issue #563):

- **Rust** `patch_updates_lib_path_via_serde_rename_key` — pins the wire-key contract used by `update_lib_path`: a `{"libPath": ...}` patch updates the on-disk document AND deserializes into `Settings::lib_path`. A key/rename divergence would otherwise be a **silent no-op** (unknown keys are kept on disk but ignored by Settings)
- **settingsSlice** `merges a partial patch` — a single-field patch shallow-merges, keeping untouched fields and the UI-only `dialogOpen` state (the reducer's `Partial<Settings>` signature shipped untested)
- **sidebar** `persists open/close via patch_settings` — closing the sidebar sends `{ patch: { sidebarExpanded: false } }` and syncs Redux. First test suite for the sidebar module

No production code changes.

## Related Issue

Refs #563 (implementation shipped in #566)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore
- [x] ✅ Tests

## Test Plan

- [x] `cargo test --lib` — 304 passed (+1)
- [x] `npm test` — 145 files / 1188 tests (+1 file, +2 tests)
- [x] `cargo clippy -D warnings`, `cargo fmt`, `npm run lint`, `npm run typecheck`, `prettier` all green

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None.

## Checklist

- [x] /review-all executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (N/A — no user-facing strings)
