### PR TITLE
fix(download): deregister cancel token via RAII guard on all exits

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -446,15 +446,10 @@ async fn download_bangumi_durl(
 
     // download_video already registered the cancellation token. Do NOT
     // re-register here (it would overwrite the existing token and lose an
-    // in-flight cancel). Just check the pre-cancel flag.
-    if DOWNLOAD_CANCEL_REGISTRY
-        .is_cancelled(&options.download_id)
-        .await
-    {
-        DOWNLOAD_CANCEL_REGISTRY
-            .clear_cancelled(&options.download_id)
-            .await;
-        DOWNLOAD_CANCEL_REGISTRY.remove(&options.download_id).await;
+    // in-flight cancel). Just check the pre-cancel flag; the
+    // CancelTokenGuard held by download_video deregisters on every return
+    // path from here (issue #561).
+    if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(&options.download_id) {
         return Err("ERR::CANCELLED".to_string());
     }
 
@@ -525,8 +520,9 @@ async fn download_bangumi_durl(
     let bd_cookie_header = cookie_header.to_string();
     let bd_download_id = options.download_id.clone();
     let bd_host_health = host_health.clone();
-    // Download directly. Capture the result so we always remove the token
-    // (success or error) to avoid a registry leak on the early-return path.
+    // Download directly. Capture the result so success and error are handled
+    // separately below (history save vs partial-file removal). Registry
+    // cleanup is handled by download_video's CancelTokenGuard.
     let result = retry_download(
         app,
         &options.download_id,
@@ -580,17 +576,9 @@ async fn download_bangumi_durl(
     )
     .await;
 
-    // Always clean up the registry (success or error): remove the token AND
-    // clear the pre-cancel flag. Mirrors the regular durl and DASH cleanup
-    // paths (remove + clear_cancelled). clear_cancelled matters here because
-    // cancel() records the id in cancelled_ids for the get_token-None
-    // fallback; without this, a cancelled bangumi-durl id would linger and
-    // could falsely trip download_video's start-up is_cancelled check on id
-    // reuse, and accumulate over long-running sessions.
-    DOWNLOAD_CANCEL_REGISTRY.remove(&options.download_id).await;
-    DOWNLOAD_CANCEL_REGISTRY
-        .clear_cancelled(&options.download_id)
-        .await;
+    // Registry cleanup (token removal + pre-cancel flag clear) is handled by
+    // the CancelTokenGuard download_video holds for this download_id (issue
+    // #561) — no explicit cleanup needed here on any return path.
 
     match result {
         Ok(()) => {
@@ -654,21 +642,24 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     let segment_concurrency = Settings::resolve_segment_concurrency(&settings);
 
     // If this part was cancelled (via cancel_all_downloads) before
-    // download_video started, reject immediately so it never runs.
-    if DOWNLOAD_CANCEL_REGISTRY
-        .is_cancelled(&options.download_id)
-        .await
-    {
-        DOWNLOAD_CANCEL_REGISTRY
-            .clear_cancelled(&options.download_id)
-            .await;
+    // download_video started, reject immediately so it never runs. The flag
+    // is cleared here because this runs BEFORE register() — no guard exists
+    // yet to clear it on Drop.
+    if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(&options.download_id) {
+        DOWNLOAD_CANCEL_REGISTRY.clear_cancelled(&options.download_id);
         return Err("ERR::CANCELLED".to_string());
     }
 
-    // Register cancellation token for this download
-    let cancel_token = DOWNLOAD_CANCEL_REGISTRY
-        .register(&options.download_id)
-        .await;
+    // Register the cancellation token for this download. The returned guard
+    // deregisters the token (remove + clear_cancelled) on EVERY exit path —
+    // including the early `?` returns below that previously leaked it
+    // (issue #561). Keep it alive until function return.
+    // Note: the `_` prefix only silences the unused-variable warning; unlike a
+    // bare `_` pattern, the binding lives to the end of the function, which is
+    // what makes the Drop cleanup fire. Rewriting it to `_` silently
+    // reintroduces the #561 leak.
+    let (cancel_token, _cancel_token_guard) =
+        DOWNLOAD_CANCEL_REGISTRY.register(&options.download_id);
 
     // Per-download CDN host health, shared by the video stream, audio
     // stream(s), every retry attempt, and their segment tasks. Dropping the
@@ -682,10 +673,6 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     //    return below.
     let reservation = reserve_output_path(&build_output_path(app, &options.filename).await?)?;
 
-    // TODO(#561): every `?` below returns before the function-final
-    // DOWNLOAD_CANCEL_REGISTRY cleanup, leaking the cancel token registered
-    // above. The reservation's Drop covers the staging file, but the token
-    // needs its own guard — tracked separately.
     // 2. Get cookies (WBI signing enables non-logged-in usage)
     let cookies = read_cookie(app)?.unwrap_or_default();
     let cookie_header = build_cookie_header(&cookies);
@@ -741,8 +728,9 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     })?;
 
     // Regular video durl format (audio embedded in MP4). Wrapped in a block so
-    // all early returns funnel through the cleanup below — this path otherwise
-    // bypasses download_video's final cleanup (remove + clear_cancelled).
+    // all early returns funnel through reservation.complete() (staging-file
+    // finalize). Registry cleanup is handled by the CancelTokenGuard held in
+    // download_video.
     if data.dash.is_none() {
         let result: Result<String, String> = async {
             let durl_segments = data
@@ -854,17 +842,11 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
         .await;
 
         // Finalize: rename the completed staging file to its final name; on
-        // error the reservation's Drop removes the staging file.
+        // error the reservation's Drop removes the staging file. Registry
+        // cleanup is handled by the CancelTokenGuard held in download_video.
         let result = result
             .and_then(|_| reservation.complete())
             .map(|p| p.to_string_lossy().into_owned());
-
-        // Cleanup: remove token and clear the pre-cancel flag (this path
-        // bypasses download_video's final cleanup).
-        DOWNLOAD_CANCEL_REGISTRY.remove(&options.download_id).await;
-        DOWNLOAD_CANCEL_REGISTRY
-            .clear_cancelled(&options.download_id)
-            .await;
 
         return result;
     }
@@ -1228,12 +1210,8 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     }
     .await;
 
-    // Cleanup: Remove cancellation token from registry and clear any
-    // pre-cancel flag so cancelled_ids doesn't accumulate.
-    DOWNLOAD_CANCEL_REGISTRY.remove(&options.download_id).await;
-    DOWNLOAD_CANCEL_REGISTRY
-        .clear_cancelled(&options.download_id)
-        .await;
+    // Registry cleanup (token removal + pre-cancel flag clear) is handled by
+    // the CancelTokenGuard acquired at register() above (issue #561).
 
     // On error, clean up temp files
     if result.is_err() {

--- a/src-tauri/src/handlers/concurrency.rs
+++ b/src-tauri/src/handlers/concurrency.rs
@@ -6,8 +6,8 @@
 
 use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-use tokio::sync::{Mutex, Semaphore};
+use std::sync::{Arc, Mutex};
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 /// Default maximum number of concurrent video downloads.
@@ -76,6 +76,12 @@ pub static DOWNLOAD_CANCEL_REGISTRY: Lazy<Arc<DownloadCancelRegistry>> =
 /// Each active download registers a `CancellationToken` that can be used
 /// to signal cancellation. The token is stored until the download completes
 /// or is explicitly removed.
+///
+/// Why std::sync::Mutex (not tokio::sync::Mutex): every critical section is
+///   a plain map/set mutation with no `.await` inside, and the registry must
+///   be callable from a Drop guard — `Drop` cannot await (issue #561). This
+///   follows tokio's own guidance: use the std mutex when guards are never
+///   held across an await point.
 #[derive(Debug, Default)]
 pub struct DownloadCancelRegistry {
     /// Maps download ID to its cancellation token
@@ -84,6 +90,32 @@ pub struct DownloadCancelRegistry {
     /// children that are not in `tokens` yet). `download_video` checks this
     /// on start and rejects immediately so cancelled pending parts never run.
     cancelled_ids: Mutex<HashSet<String>>,
+}
+
+/// RAII guard returned by [`DownloadCancelRegistry::register`].
+///
+/// Why: `download_video`'s early-return `?` paths (path resolution, cookie
+/// read, stream selection, disk-space check, ...) return BEFORE the
+/// function-final registry cleanup, leaking the token in the registry
+/// (issue #561). A leaked token lets a later `cancel_download` on the dead
+/// id return `true` and emit a spurious `download_cancelled` event, and the
+/// map grows without bound in long sessions. The guard deregisters on every
+/// scope exit — early return, panic unwind, or normal completion — exactly
+/// like `OutputReservation` covers the staging file.
+///
+/// Hold the guard for the whole download; dropping it performs
+/// `remove` + `clear_cancelled` (both idempotent, so double cleanup with
+/// any explicit call is harmless).
+pub struct CancelTokenGuard {
+    registry: Arc<DownloadCancelRegistry>,
+    download_id: String,
+}
+
+impl Drop for CancelTokenGuard {
+    fn drop(&mut self) {
+        self.registry.remove(&self.download_id);
+        self.registry.clear_cancelled(&self.download_id);
+    }
 }
 
 impl DownloadCancelRegistry {
@@ -95,10 +127,14 @@ impl DownloadCancelRegistry {
         }
     }
 
-    /// Registers a new cancellation token for a download.
+    /// Registers a new cancellation token for a download and returns it
+    /// together with an RAII guard that deregisters the token when dropped.
     ///
-    /// Returns the created token which should be used to check for cancellation.
-    /// If a token already exists for this download ID, it is replaced.
+    /// The caller passes the token into the download flow and keeps the
+    /// guard alive until the download function returns on ANY path — the
+    /// guard's Drop performs the registry cleanup, so early `?` returns can
+    /// no longer leak the token (issue #561). If a token already exists for
+    /// this download ID, it is replaced.
     ///
     /// # Arguments
     ///
@@ -106,12 +142,18 @@ impl DownloadCancelRegistry {
     ///
     /// # Returns
     ///
-    /// The created `CancellationToken`
-    pub async fn register(&self, download_id: &str) -> CancellationToken {
+    /// The created `CancellationToken` and its [`CancelTokenGuard`]
+    pub fn register(self: &Arc<Self>, download_id: &str) -> (CancellationToken, CancelTokenGuard) {
         let token = CancellationToken::new();
-        let mut tokens = self.tokens.lock().await;
+        let mut tokens = self.tokens.lock().unwrap();
         tokens.insert(download_id.to_string(), token.clone());
-        token
+        (
+            token,
+            CancelTokenGuard {
+                registry: Arc::clone(self),
+                download_id: download_id.to_string(),
+            },
+        )
     }
 
     /// Signals cancellation for a specific download and removes its token
@@ -134,20 +176,20 @@ impl DownloadCancelRegistry {
     /// `true` if the token existed and was cancelled (and removed), `false`
     /// if the download was not found (never started, already completed, or
     /// already cancelled by a previous call)
-    pub async fn cancel(&self, download_id: &str) -> bool {
+    pub fn cancel(&self, download_id: &str) -> bool {
         // Remove the token (not just flag it) so a duplicate cancel_download
         // returns false. Hold the tokens lock only for the Map mutation and
         // release it before locking cancelled_ids. Holding two mutexes at
         // once is a deadlock hazard in general, so we keep each guard in its
         // own scope even though no current caller nests them.
         let token_opt = {
-            let mut tokens = self.tokens.lock().await;
+            let mut tokens = self.tokens.lock().unwrap();
             tokens.remove(download_id)
         };
         if let Some(token) = token_opt {
             token.cancel();
             log::info!("[BE] download cancelled: id={}", download_id);
-            let mut ids = self.cancelled_ids.lock().await;
+            let mut ids = self.cancelled_ids.lock().unwrap();
             ids.insert(download_id.to_string());
             true
         } else {
@@ -170,8 +212,8 @@ impl DownloadCancelRegistry {
     /// # Returns
     ///
     /// Number of downloads cancelled (the count captured before clearing)
-    pub async fn cancel_all(&self) -> usize {
-        let mut tokens = self.tokens.lock().await;
+    pub fn cancel_all(&self) -> usize {
+        let mut tokens = self.tokens.lock().unwrap();
         let count = tokens.len();
         for token in tokens.values() {
             token.cancel();
@@ -199,8 +241,8 @@ impl DownloadCancelRegistry {
     /// # Arguments
     ///
     /// * `download_id` - Unique identifier for the download to remove
-    pub async fn remove(&self, download_id: &str) {
-        let mut tokens = self.tokens.lock().await;
+    pub fn remove(&self, download_id: &str) {
+        let mut tokens = self.tokens.lock().unwrap();
         tokens.remove(download_id);
     }
 
@@ -214,8 +256,8 @@ impl DownloadCancelRegistry {
     ///
     /// `true` if the download is registered, `false` otherwise
     #[allow(dead_code)]
-    pub async fn is_registered(&self, download_id: &str) -> bool {
-        let tokens = self.tokens.lock().await;
+    pub fn is_registered(&self, download_id: &str) -> bool {
+        let tokens = self.tokens.lock().unwrap();
         tokens.contains_key(download_id)
     }
 
@@ -230,8 +272,8 @@ impl DownloadCancelRegistry {
     /// # Returns
     ///
     /// `Some(token)` if found, `None` otherwise
-    pub async fn get_token(&self, download_id: &str) -> Option<CancellationToken> {
-        let tokens = self.tokens.lock().await;
+    pub fn get_token(&self, download_id: &str) -> Option<CancellationToken> {
+        let tokens = self.tokens.lock().unwrap();
         tokens.get(download_id).cloned()
     }
 
@@ -240,35 +282,35 @@ impl DownloadCancelRegistry {
     /// # Returns
     ///
     /// Vector of all registered download IDs
-    pub async fn get_all_ids(&self) -> Vec<String> {
-        let tokens = self.tokens.lock().await;
+    pub fn get_all_ids(&self) -> Vec<String> {
+        let tokens = self.tokens.lock().unwrap();
         tokens.keys().cloned().collect()
     }
 
     /// Marks a download ID as cancelled before it started (pending parts not
     /// yet registered as tokens). `download_video` checks this on start.
-    pub async fn mark_cancelled(&self, download_id: &str) {
-        let mut ids = self.cancelled_ids.lock().await;
+    pub fn mark_cancelled(&self, download_id: &str) {
+        let mut ids = self.cancelled_ids.lock().unwrap();
         ids.insert(download_id.to_string());
     }
 
     /// Marks multiple download IDs as cancelled at once.
-    pub async fn mark_cancelled_many(&self, download_ids: &[String]) {
-        let mut ids = self.cancelled_ids.lock().await;
+    pub fn mark_cancelled_many(&self, download_ids: &[String]) {
+        let mut ids = self.cancelled_ids.lock().unwrap();
         for id in download_ids {
             ids.insert(id.clone());
         }
     }
 
     /// Returns true if the download ID was cancelled before it started.
-    pub async fn is_cancelled(&self, download_id: &str) -> bool {
-        let ids = self.cancelled_ids.lock().await;
+    pub fn is_cancelled(&self, download_id: &str) -> bool {
+        let ids = self.cancelled_ids.lock().unwrap();
         ids.contains(download_id)
     }
 
     /// Clears the pre-cancelled flag for a download ID.
-    pub async fn clear_cancelled(&self, download_id: &str) {
-        let mut ids = self.cancelled_ids.lock().await;
+    pub fn clear_cancelled(&self, download_id: &str) {
+        let mut ids = self.cancelled_ids.lock().unwrap();
         ids.remove(download_id);
     }
 }
@@ -280,15 +322,15 @@ mod tests {
     /// The core fix: a second cancel for the same id must return false so
     /// cancel_download does not emit a duplicate `download_cancelled` event
     /// (the "cancelled" toast showing twice on double-click).
-    #[tokio::test]
-    async fn cancel_is_idempotent_on_second_call() {
-        let registry = DownloadCancelRegistry::new();
+    #[test]
+    fn cancel_is_idempotent_on_second_call() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
         let id = "test-id-idempotent";
 
-        registry.register(id).await;
-        assert!(registry.cancel(id).await, "first cancel should return true");
+        let (_token, _guard) = registry.register(id);
+        assert!(registry.cancel(id), "first cancel should return true");
         assert!(
-            !registry.cancel(id).await,
+            !registry.cancel(id),
             "second cancel should return false (idempotent — token was removed)"
         );
     }
@@ -296,53 +338,100 @@ mod tests {
     /// cancel() must record the id in cancelled_ids so download_url's
     /// get_token-None fallback (retry backoff, playurl fetch, bangumi-durl)
     /// can still detect the cancel via is_cancelled.
-    #[tokio::test]
-    async fn cancel_records_id_in_cancelled_ids_for_fallback() {
-        let registry = DownloadCancelRegistry::new();
+    #[test]
+    fn cancel_records_id_in_cancelled_ids_for_fallback() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
         let id = "test-id-fallback";
 
-        registry.register(id).await;
+        let (_token, _guard) = registry.register(id);
         assert!(
-            !registry.is_cancelled(id).await,
+            !registry.is_cancelled(id),
             "freshly registered id should not be cancelled"
         );
 
-        registry.cancel(id).await;
+        registry.cancel(id);
         assert!(
-            registry.is_cancelled(id).await,
+            registry.is_cancelled(id),
             "cancel() should record the id so the get_token-None fallback can detect it"
         );
     }
 
     /// Guards against cancel-all × per-part cancel duplicate emit: once
     /// cancel_all has cleared the tokens, a per-id cancel must return false.
-    #[tokio::test]
-    async fn cancel_after_cancel_all_returns_false() {
-        let registry = DownloadCancelRegistry::new();
+    #[test]
+    fn cancel_after_cancel_all_returns_false() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
         let id = "test-id-cancel-all";
 
-        registry.register(id).await;
-        registry.cancel_all().await;
+        let (_token, _guard) = registry.register(id);
+        registry.cancel_all();
         assert!(
-            !registry.cancel(id).await,
+            !registry.cancel(id),
             "per-id cancel after cancel_all should return false (no duplicate emit)"
         );
     }
 
     /// Prerequisite for the get_token-None fallback path: cancel() must
     /// remove the token so get_token returns None for in-flight callers.
-    #[tokio::test]
-    async fn cancel_removes_token_so_get_token_returns_none() {
-        let registry = DownloadCancelRegistry::new();
+    #[test]
+    fn cancel_removes_token_so_get_token_returns_none() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
         let id = "test-id-get-token";
 
-        registry.register(id).await;
-        assert!(registry.get_token(id).await.is_some());
+        let (_token, _guard) = registry.register(id);
+        assert!(registry.get_token(id).is_some());
 
-        registry.cancel(id).await;
+        registry.cancel(id);
         assert!(
-            registry.get_token(id).await.is_none(),
+            registry.get_token(id).is_none(),
             "cancel() should remove the token so get_token returns None"
+        );
+    }
+
+    /// The issue #561 core fix: dropping the guard (scope exit — the same
+    /// thing an early `?` return does in download_video) must deregister the
+    /// token, so nothing leaks into the registry map.
+    #[test]
+    fn guard_drop_removes_token_from_registry() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
+        let id = "test-id-guard-drop";
+
+        {
+            let (token, _guard) = registry.register(id);
+            assert!(!token.is_cancelled());
+            assert!(
+                registry.get_token(id).is_some(),
+                "token must be registered while the guard is alive"
+            );
+        } // early-return equivalent: guard drops here
+
+        assert!(
+            registry.get_token(id).is_none(),
+            "guard drop must remove the token (no leak on early return)"
+        );
+        assert!(
+            !registry.cancel(id),
+            "a later cancel on the dead id must return false (no spurious event)"
+        );
+    }
+
+    /// Guard drop must also clear the cancelled_ids flag — otherwise a
+    /// cancelled-then-finished download leaves a stale flag that the
+    /// get_token-None fallback would read as a fresh cancel.
+    #[test]
+    fn guard_drop_clears_cancelled_flag() {
+        let registry = Arc::new(DownloadCancelRegistry::new());
+        let id = "test-id-guard-flag";
+
+        {
+            let (_token, _guard) = registry.register(id);
+            registry.cancel(id);
+            assert!(registry.is_cancelled(id), "cancel() flags the id");
+        } // normal-completion equivalent: guard drops after the cancel path
+
+        assert!(
+            !registry.is_cancelled(id),
+            "guard drop must clear the stale cancelled flag"
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -670,7 +670,7 @@ async fn cancel_download(app: AppHandle, download_id: String) -> Result<bool, St
     use tauri::Emitter;
 
     // Signal cancellation
-    let was_found = DOWNLOAD_CANCEL_REGISTRY.cancel(&download_id).await;
+    let was_found = DOWNLOAD_CANCEL_REGISTRY.cancel(&download_id);
 
     if was_found {
         // Emit cancellation event to frontend
@@ -690,7 +690,7 @@ async fn cancel_download(app: AppHandle, download_id: String) -> Result<bool, St
         // second toast), and for a pending child the frontend's pending
         // reducer has already finalized the row to 'cancelled' — so an emit
         // here is redundant in every case.
-        DOWNLOAD_CANCEL_REGISTRY.mark_cancelled(&download_id).await;
+        DOWNLOAD_CANCEL_REGISTRY.mark_cancelled(&download_id);
     }
 
     Ok(was_found)
@@ -718,16 +718,14 @@ async fn cancel_all_downloads(app: AppHandle, download_ids: Vec<String>) -> Resu
 
     // Mark all requested IDs (including not-yet-started pending children) as
     // cancelled so download_video rejects them on start.
-    DOWNLOAD_CANCEL_REGISTRY
-        .mark_cancelled_many(&download_ids)
-        .await;
+    DOWNLOAD_CANCEL_REGISTRY.mark_cancelled_many(&download_ids);
 
     // Force-cancel every registered token. Per-ID cancel() can miss an
     // in-flight download due to timing, so cancel_all() is more reliable for
     // stopping a running download. Serial-download assumption means there is
     // effectively one parent at a time, so the blast radius is bounded.
-    let active_ids = DOWNLOAD_CANCEL_REGISTRY.get_all_ids().await;
-    let count = DOWNLOAD_CANCEL_REGISTRY.cancel_all().await;
+    let active_ids = DOWNLOAD_CANCEL_REGISTRY.get_all_ids();
+    let count = DOWNLOAD_CANCEL_REGISTRY.cancel_all();
 
     // Emit cancellation events for each active download
     for download_id in active_ids {

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -437,10 +437,10 @@ async fn resolve_cancel_token(
     let Some(id) = download_id else {
         return Ok(None);
     };
-    match DOWNLOAD_CANCEL_REGISTRY.get_token(id).await {
+    match DOWNLOAD_CANCEL_REGISTRY.get_token(id) {
         Some(t) => Ok(Some(t)),
         None => {
-            if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(id).await {
+            if DOWNLOAD_CANCEL_REGISTRY.is_cancelled(id) {
                 log::info!("[BE] {}: token absent but pre-cancelled: id={}", ctx, id);
                 return Err(anyhow::anyhow!("ERR::CANCELLED"));
             }


### PR DESCRIPTION
## Summary

`download_video`'s early-return paths (path resolution, cookie read, bangumi player fetch, stream selection, disk-space check — 9 `?` sites, plus 4 more inside `download_bangumi_durl`) returned before the function-final registry cleanup, leaking the cancel token in `DOWNLOAD_CANCEL_REGISTRY` (#561). A leaked token let a later `cancel_download` on the dead id return `true` and emit a spurious `download_cancelled` event (wrong toast), and the map grew without bound in long sessions.

- Convert the registry's two mutexes to `std::sync::Mutex` (every critical section is an await-free map/set mutation — tokio's own guidance) and make all methods sync; Drop cannot await, which the guard requires
- `register()` now returns `(CancellationToken, CancelTokenGuard)`; the guard's Drop runs `remove` + `clear_cancelled` (both idempotent)
- `download_video` holds the guard for its whole body — every exit path (early `?`, panic unwind, normal completion) cleans up, mirroring `OutputReservation`'s staging-file Drop
- Delete the now-redundant explicit cleanup blocks (bangumi-durl, regular durl, function-final) and the `TODO(#561)` comment
- Tests: existing 4 rewritten sync; new `guard_drop_removes_token_from_registry` and `guard_drop_clears_cancelled_flag` cover the RAII contract

Sibling of #562 (per-chunk cancel detection) — together both cancel-latency and cancel-cleanup paths are closed.

## Related Issue

Closes #561

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `cargo build` / `cargo clippy` / `cargo fmt` clean, `cargo test` 318 passed (2 new)
- [x] Manual: two consecutive downloads with immediate cancel — cancel propagates within the same second both times, no spurious `download_cancelled` for the dead id, next download starts clean (app.log verified)

## Screenshots / Videos (Optional)

N/A (backend behavior)

## Breaking Changes

None — Tauri command signatures and frontend contract unchanged.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no user-facing text changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)