### PR TITLE
test: serve E2E fixture video info under E2E_TESTING and notify only on failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,8 +83,11 @@ jobs:
           retention-days: 7
 
       - name: Comment screenshots on PR
+        # Only comment (and thus notify) when E2E failed — commenting on
+        # every successful run spams PR notifications (issue #565).
+        # Success screenshots remain available as workflow artifacts.
         if: >-
-          always()
+          failure()
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7

--- a/e2e-tests/test/app-launch.e2e.ts
+++ b/e2e-tests/test/app-launch.e2e.ts
@@ -7,7 +7,9 @@
  * - Navigation to /home
  * - Sidebar verification
  * - Settings dialog open/close
- * - Video URL input and info fetch (real API)
+ * - Video URL input and info fetch (backend serves a bundled fixture
+ *   under E2E_TESTING — CI runner IPs are blocked by Bilibili, issue
+ *   #565; see e2e_mock_video_info in src-tauri/src/handlers/bilibili.rs)
  * - Video part cards display
  */
 
@@ -22,11 +24,11 @@ import {
 import * as S from '../helpers/selectors'
 
 /**
- * URL of a stable, well-known Bilibili official video used as the
- * test fixture for video info fetch and part card rendering.
+ * URL submitted through the URL input form.
  *
- * Chosen for its reliability and longevity as an official upload,
- * reducing flakiness from takedown or geo-restrictions.
+ * Under E2E_TESTING the backend answers fetch_video_info with a
+ * bundled fixture regardless of the video ID, so any valid URL shape
+ * works; this is simply a realistic one (issue #565).
  */
 const TEST_VIDEO_URL = 'https://www.bilibili.com/video/BV1i3411y7xB'
 
@@ -174,7 +176,7 @@ describe('bilibili-downloader-gui E2E', () => {
     await saveScreenshot('settings', '01-dialog-closed')
   })
 
-  // -- Phase 3: Video URL Input & Info Fetch (Real API) --
+  // -- Phase 3: Video URL Input & Info Fetch (E2E fixture response) --
 
   it('should accept a video URL in the input field', async () => {
     const input = await browser.$(S.URL_INPUT)
@@ -191,6 +193,8 @@ describe('bilibili-downloader-gui E2E', () => {
     // The form submits on blur (handleFormBlur in VideoForm1).
     // WKWebView's WebDriver doesn't propagate focus changes on
     // click, so we explicitly blur the active element via JS.
+    // Under E2E_TESTING the backend answers fetch_video_info with
+    // a bundled fixture (Bilibili blocks CI runner IPs, issue #565).
     await browser.execute(() => {
       const el = document.activeElement
       if (el instanceof HTMLElement) el.blur()
@@ -206,6 +210,10 @@ describe('bilibili-downloader-gui E2E', () => {
   it('should display video part cards', async () => {
     const firstPart = await browser.$(S.DATA_PART_INDEX(0))
     expect(await firstPart.isExisting()).to.be.true
+
+    // Fixture provides two parts; both should render
+    const secondPart = await browser.$(S.DATA_PART_INDEX(1))
+    expect(await secondPart.isExisting()).to.be.true
 
     await saveScreenshot('video', '02-part-cards')
   })

--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1262,6 +1262,24 @@ fn cleanup_subtitle_files(lib_path: &std::path::Path, download_id: &str) {
 mod tests {
     use super::*;
 
+    /// Tests the E2E fixture `Video` mapping used under E2E_TESTING.
+    ///
+    /// Verifies the bundled 2-page fixture maps to a Video with both
+    /// parts and the requested bvid, matching what E2E specs assert
+    /// (part indices 0 and 1).
+    #[test]
+    fn test_e2e_mock_video_info() {
+        let video = e2e_mock_video_info("BV1i3411y7xB").expect("fixture maps");
+        assert_eq!(video.bvid, "BV1i3411y7xB");
+        assert_eq!(video.content_type, "video");
+        assert!(!video.title.is_empty());
+        assert_eq!(video.parts.len(), 2);
+        assert_eq!(video.parts[0].cid, 146224527);
+        assert_eq!(video.parts[0].page, 1);
+        assert_eq!(video.parts[1].cid, 146225172);
+        assert_eq!(video.parts[1].page, 2);
+    }
+
     /// Tests quality ID to human-readable string conversion.
     ///
     /// Verifies that known quality IDs produce expected display names
@@ -2565,6 +2583,14 @@ pub fn build_cookie_header_from_cache(app: &AppHandle) -> Result<String, String>
 pub async fn fetch_video_info(app: &AppHandle, id: &str) -> Result<Video, String> {
     log::info!("[BE] fetch_video_info: requesting video info for id={}", id);
 
+    // E2E mode: CI runner IPs are blocked by Bilibili's risk control
+    // (issue #565), so serve the bundled fixture instead of the live
+    // view API. Same env-var pattern as qr_login's secure-storage bypass.
+    if crate::handlers::qr_login::is_e2e_testing() {
+        log::info!("[BE] fetch_video_info: returning E2E_TESTING fixture");
+        return e2e_mock_video_info(id);
+    }
+
     let cookies = read_cookie(app)?.unwrap_or_default();
     let cookie_header = build_cookie_header(&cookies);
     let is_limited_quality = cookie_header.is_empty();
@@ -2601,6 +2627,31 @@ pub async fn fetch_video_info(app: &AppHandle, id: &str) -> Result<Video, String
         auto_rename,
         is_limited_quality,
     ))
+}
+
+/// Builds the E2E fixture `Video` from the bundled view-API fixture JSON.
+///
+/// Parses `tests/fixtures/web_interface_view.json` (a 2-page view
+/// response) and runs it through the production `Video` mapping so the
+/// E2E flow exercises the same shaping logic as the live path.
+fn e2e_mock_video_info(id: &str) -> Result<Video, String> {
+    // Note: The fixture JSON is pinned by assertions elsewhere — the cid/page
+    // pairs in test_e2e_mock_video_info and the 2-part assertion in
+    // e2e-tests/test/app-launch.e2e.ts both fail if the fixture is swapped
+    // for a different video, so update all three together.
+    const FIXTURE: &str = include_str!("../../tests/fixtures/web_interface_view.json");
+    let body: WebInterfaceApiResponse =
+        serde_json::from_str(FIXTURE).map_err(|e| format!("E2E fixture parse failed: {e}"))?;
+    let data = body.data.as_ref().ok_or("E2E fixture has no data")?;
+    // Why: is_limited_quality=true mirrors the live path's cookie-less case —
+    // E2E_TESTING bypasses session storage (qr_login::is_e2e_testing), so CI
+    // never has a cookie header (live path: is_limited_quality = cookie_header
+    // .is_empty()).
+    // Note: The fixture is a snapshot of BV1GJ411x7h7 (added for the serde
+    // contract tests, commit 6a23fbc8), not of the BV typed in the E2E spec
+    // (BV1i3411y7xB). The mapping overrides bvid with the requested id, so the
+    // UI shows the snapshot video's title/parts for whatever URL was entered.
+    Ok(web_interface_data_to_video(data, id, None, true, true))
 }
 
 /// Maps a WebInterface view response into the frontend `Video` DTO.


### PR DESCRIPTION
## Summary

- Serve a bundled fixture (tests/fixtures/web_interface_view.json) from `fetch_video_info` when the `E2E_TESTING` env var is set, mapped through the production `web_interface_data_to_video` — same `is_e2e_testing()` pattern already used by `qr_login`
- Gate the "Comment screenshots on PR" step in `e2e.yml` with `failure()` so successful runs no longer post a PR comment (which was the source of email/push notifications on every green run); screenshots remain available as workflow artifacts
- E2E spec: assert both fixture parts render and refresh stale comments (the URL is no longer fetched live)

## Context

Bilibili's risk control blocks GitHub Actions runner IPs, so the live view API call has failed with `ERR::API_ERROR` on every E2E run since 2026-09-02 (#565). An earlier attempt to patch `window.__TAURI_INTERNALS__.invoke` from the test side proved impossible: Tauri defines the property non-writable and non-configurable, so the backend env-var branch is the workable seam.

## Verification

- `cargo test e2e_mock_video_info` — PASS
- Full E2E suite locally: all Phase 3 (video info) tests pass with the fixture; part 0 and part 1 cards render, download button enabled
- One pre-existing local-only failure remains (`login benefits alert`): local Firefox cookies make the app logged-in, so the alert never renders. CI has no cookies, so this test is unaffected there

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)