### PR TITLE
feat(history): record failed/interrupted downloads and recover on startup

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -157,6 +157,7 @@ pub struct DownloadOptions {
 
 use crate::constants::{API_BASE, REFERER};
 use crate::handlers::cookie::read_cookie;
+use crate::handlers::history_session::HistorySession;
 use crate::handlers::settings;
 use crate::models::bilibili_api::{
     BangumiPlayerApiResponse, BangumiPlayerResult, BangumiSeasonApiResponse, PlayerV2ApiResponse,
@@ -582,11 +583,9 @@ async fn download_bangumi_durl(
 
     match result {
         Ok(()) => {
-            let output_path_str = output_path.to_string_lossy().to_string();
-            let actual_file_size = tokio::fs::metadata(output_path).await.ok().map(|m| m.len());
-            // Save to history asynchronously (success only)
-            spawn_save_to_history(app, options, actual_file_size);
-            Ok(output_path_str)
+            // History recording is settled by download_video's HistorySession
+            // from this return value (issue #511); no per-path save here.
+            Ok(output_path.to_string_lossy().into_owned())
         }
         Err(e) => {
             // Remove partial output on failure/cancel to avoid leftover garbage.
@@ -628,6 +627,20 @@ async fn download_bangumi_durl(
 /// - ffmpeg merge fails (`ERR::MERGE_FAILED`)
 /// - Download is cancelled (`ERR::CANCELLED`)
 pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Result<String, String> {
+    // History lifecycle (issue #511): insert the in_progress entry before the
+    // download body runs and settle it from the body's final Result, so every
+    // exit path (early `?` returns included) is recorded with its real error
+    // code. A pre-cancelled part settles as cancelled and removes the entry
+    // again; a download killed mid-flight is caught by startup recovery.
+    let session = HistorySession::start(app, options);
+    let result = download_video_impl(app, options).await;
+    session.settle(app, options, &result).await;
+    result
+}
+
+/// Download body behind [`download_video`]; the wrapper owns the history
+/// session so no early return inside can bypass the final settle.
+async fn download_video_impl(app: &AppHandle, options: &DownloadOptions) -> Result<String, String> {
     use crate::handlers::concurrency::DOWNLOAD_CANCEL_REGISTRY;
 
     log::info!(
@@ -732,7 +745,7 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
     // finalize). Registry cleanup is handled by the CancelTokenGuard held in
     // download_video.
     if data.dash.is_none() {
-        let result: Result<String, String> = async {
+        let result: Result<(), String> = async {
             let durl_segments = data
                 .durl
                 .as_ref()
@@ -831,13 +844,9 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             )
             .await?;
 
-            let output_path_str = reservation.reserved_path().to_string_lossy().to_string();
-            let actual_file_size = tokio::fs::metadata(reservation.reserved_path())
-                .await
-                .ok()
-                .map(|m| m.len());
-            spawn_save_to_history(app, options, actual_file_size);
-            Ok(output_path_str)
+            // History recording is settled by download_video's HistorySession
+            // from the finalized path (issue #511).
+            Ok(())
         }
         .await;
 
@@ -1203,8 +1212,8 @@ pub async fn download_video(app: &AppHandle, options: &DownloadOptions) -> Resul
             actual_file_size
         );
 
-        // Save to history (async failure does not affect download)
-        spawn_save_to_history(app, options, actual_file_size);
+        // History recording is settled by download_video's HistorySession
+        // from this return value (issue #511).
 
         Ok(final_path.to_string_lossy().into_owned())
     }
@@ -2046,120 +2055,6 @@ mod tests {
     }
 }
 
-/// Spawns an async task to save download history.
-///
-/// Extracts relevant fields from `options` and spawns a background task
-/// that calls [`save_to_history`]. Failures are logged but not propagated.
-fn spawn_save_to_history(app: &AppHandle, options: &DownloadOptions, file_size: Option<u64>) {
-    let app = app.clone();
-    let bvid = options.bvid.clone();
-    let filename = options.filename.clone();
-    let quality = options.quality;
-    let thumbnail_url = options.thumbnail_url.clone();
-    let page = options.page;
-    tokio::spawn(async move {
-        if let Err(e) = save_to_history(
-            &app,
-            &bvid,
-            quality,
-            file_size,
-            &filename,
-            thumbnail_url,
-            page,
-        )
-        .await
-        {
-            log::warn!(
-                "[BE] download_video: failed to save to history for {}: {}",
-                bvid,
-                e
-            );
-        }
-    });
-}
-
-/// Saves a history entry after download completion.
-///
-/// Creates a history record with video metadata, quality info, and file size.
-/// The entry is persisted via `HistoryStore` and emitted as an event to notify
-/// the frontend.
-///
-/// # Arguments
-///
-/// * `app` - Tauri application handle
-/// * `bvid` - Bilibili video ID
-/// * `quality` - Downloaded video quality ID
-/// * `file_size` - Actual file size in bytes (optional)
-/// * `filename` - Output filename used for title extraction
-/// * `thumbnail_url` - Video thumbnail URL (fetched if not provided)
-/// * `page` - Page number for multi-part videos (optional)
-///
-/// # Returns
-///
-/// Returns `Ok(())` on success, or an error if store operations fail.
-async fn save_to_history(
-    app: &AppHandle,
-    bvid: &str,
-    quality: Option<i32>,
-    file_size: Option<u64>,
-    filename: &str,
-    thumbnail_url: Option<String>,
-    page: Option<i32>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use crate::models::history::HistoryEntry;
-    use crate::store::HistoryStore;
-    use chrono::Utc;
-    use std::path::Path;
-
-    let title = Path::new(filename)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(filename)
-        .to_string();
-
-    let thumbnail_url = match thumbnail_url {
-        Some(url) => Some(url),
-        None => {
-            let cookies = read_cookie(app)?.unwrap_or_default();
-            fetch_video_info_for_history(bvid, &cookies)
-                .await
-                .and_then(|(_, url)| url)
-        }
-    };
-
-    let page_suffix = page.map(|p| format!("?p={p}")).unwrap_or_default();
-
-    let url = format!("https://www.bilibili.com/video/{bvid}{page_suffix}");
-
-    let id = format!(
-        "{bvid}_{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    );
-
-    let entry = HistoryEntry {
-        id,
-        title,
-        bvid: Some(bvid.to_string()),
-        url,
-        downloaded_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        status: "completed".to_string(),
-        file_size,
-        quality: quality.as_ref().map(quality_to_string),
-        thumbnail_url,
-        version: "1.0".to_string(),
-    };
-
-    HistoryStore::new(app)?.add_entry(entry.clone())?;
-
-    // Emit event to notify frontend of new history entry
-    let _ = app.emit("history:entry_added", &entry);
-
-    Ok(())
-}
-
 /// Returns the first non-empty string in a slice, or `None` if all are empty.
 ///
 /// Used to select the first valid (non-empty) string from multiple candidates.
@@ -2198,7 +2093,7 @@ fn first_non_empty(strings: &[&String]) -> Option<String> {
 /// # Returns
 ///
 /// Human-readable quality string.
-fn quality_to_string(quality: &i32) -> String {
+pub(crate) fn quality_to_string(quality: &i32) -> String {
     match quality {
         116 => "4K".to_string(),
         112 => "1080P60".to_string(),
@@ -2224,7 +2119,7 @@ fn quality_to_string(quality: &i32) -> String {
 ///
 /// Returns `Some((title, thumbnail_url))` on success.
 /// Returns `None` on failure.
-async fn fetch_video_info_for_history(
+pub(crate) async fn fetch_video_info_for_history(
     bvid: &str,
     cookies: &[CookieEntry],
 ) -> Option<(String, Option<String>)> {

--- a/src-tauri/src/handlers/history_session.rs
+++ b/src-tauri/src/handlers/history_session.rs
@@ -448,10 +448,8 @@ pub fn recover_interrupted_in(store: &HistoryStore, lock_dir: &Path) -> Recovery
     if let Ok(entries) = fs::read_dir(lock_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if is_session_lock(&path) && is_unlocked(&path) {
-                if fs::remove_file(&path).is_ok() {
-                    result.locks_removed += 1;
-                }
+            if is_session_lock(&path) && is_unlocked(&path) && fs::remove_file(&path).is_ok() {
+                result.locks_removed += 1;
             }
         }
     }

--- a/src-tauri/src/handlers/history_session.rs
+++ b/src-tauri/src/handlers/history_session.rs
@@ -1,0 +1,737 @@
+//! Download history session lifecycle (issue #511).
+//!
+//! A download's history entry now spans the whole download lifetime instead
+//! of appearing only on success:
+//!
+//! 1. **start**: an `in_progress` entry is inserted when the download begins,
+//!    and an exclusive-flock lock file (`hist_{id}.lock` in the app data dir)
+//!    is held for the download's lifetime.
+//! 2. **settle**: the download's final `Result` rewrites the entry —
+//!    `completed` on success, `failed` + the backend `ERR::*` code on error,
+//!    removed entirely on user cancel.
+//! 3. **crash**: a killed process skips settle, but the OS releases its flock,
+//!    so the next launch's [`recover_interrupted`] detects "lock free ⇒ owner
+//!    dead" (the same liveness rule as `cleanup::is_unlocked_orphan` and the
+//!    `OutputReservation` dead-holder reclamation, issue #560) and marks the
+//!    leftover `in_progress` entry `failed` with the pseudo code
+//!    [`ERR_INTERRUPTED`].
+//!
+//! Multi-process safety: another app instance downloading in parallel holds
+//! its session flock, so recovery and the startup cleanup never mistake a
+//! live download for a crashed one.
+
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::models::history::HistoryEntry;
+use crate::store::HistoryStore;
+
+/// Pseudo error code recorded when the owning process died before the
+/// download result could settle the entry. The frontend maps it to a
+/// translated message like any other `ERR::*` code.
+pub const ERR_INTERRUPTED: &str = "ERR::INTERRUPTED";
+
+/// Upper bound for the thumbnail API call during settle. The old code ran
+/// this in a fire-and-forget spawn; settle now runs inline in
+/// `download_video`, so without a cap an unreachable API would stall the
+/// invoke even though the file itself is already complete.
+const THUMBNAIL_FETCH_TIMEOUT_SECS: u64 = 10;
+
+/// Outcome of a startup recovery pass.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct RecoveryResult {
+    /// in_progress entries marked `failed` (owner process was gone).
+    pub marked_failed: usize,
+    /// Orphaned session lock files deleted.
+    pub locks_removed: usize,
+}
+
+/// Returns the session lock file path for a history entry id.
+///
+/// The id is frontend-supplied, so characters outside a filename-safe set
+/// are replaced defensively.
+fn session_lock_path(lock_dir: &Path, entry_id: &str) -> PathBuf {
+    lock_dir.join(format!("hist_{}.lock", sanitize_entry_id(entry_id)))
+}
+
+/// Maps an entry id to filename-safe characters (`[A-Za-z0-9._-]` kept).
+fn sanitize_entry_id(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// `hist_*.lock` files in the app data dir (session lock files only; the
+/// locked_json `*.json.lock` files never match this prefix).
+fn is_session_lock(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("hist_") && n.ends_with(".lock"))
+}
+
+/// Owns one download's in-progress history entry and its liveness lock.
+///
+/// The lock file is created and flocked *before* the entry is inserted, so
+/// the invariant holds: an `in_progress` entry implies a lock file whose
+/// flock is held by a live process. [`Drop`] is the safety net — if settle
+/// never ran (panic path), the entry is recorded as interrupted instead of
+/// staying `in_progress` forever, and the lock file is removed.
+pub struct HistorySession {
+    /// False when history tracking could not start (store/lock failure);
+    /// every operation becomes a no-op so history never fails a download.
+    enabled: bool,
+    store: HistoryStore,
+    lock_dir: PathBuf,
+    entry_id: String,
+    /// Holds the exclusive flock for the download's lifetime.
+    lock: Option<File>,
+    /// True once the entry reached a terminal state (or the session is
+    /// disabled); guards against double-settle and the Drop fallback.
+    finished: bool,
+}
+
+impl HistorySession {
+    /// Starts tracking a download: acquires the session lock, then inserts
+    /// the `in_progress` entry.
+    ///
+    /// Best-effort: any failure logs a warning and returns a disabled
+    /// session (all no-ops) — a broken history store must not fail the
+    /// download itself.
+    pub fn start(app: &AppHandle, options: &crate::handlers::bilibili::DownloadOptions) -> Self {
+        let store = match HistoryStore::new(app) {
+            Ok(store) => store,
+            Err(e) => {
+                log::warn!("[BE] history_session: store unavailable: {e}");
+                return Self::disabled();
+            }
+        };
+        let lock_dir = match app.path().app_data_dir() {
+            Ok(dir) => dir,
+            Err(e) => {
+                log::warn!("[BE] history_session: app data dir unavailable: {e}");
+                return Self::disabled();
+            }
+        };
+        match Self::start_with(store, lock_dir, initial_entry(options)) {
+            Ok(session) => session,
+            Err(e) => {
+                log::warn!(
+                    "[BE] history_session: start failed for {}: {e}",
+                    options.download_id
+                );
+                Self::disabled()
+            }
+        }
+    }
+
+    /// Test seam: starts a session for an explicit entry without an AppHandle.
+    fn start_with(
+        store: HistoryStore,
+        lock_dir: PathBuf,
+        entry: HistoryEntry,
+    ) -> Result<Self, String> {
+        let lock_path = session_lock_path(&lock_dir, &entry.id);
+        let lock = acquire_session_lock(&lock_path)?;
+        if let Err(e) = store.add_entry(entry.clone()) {
+            // Undo the lock so a failed insert cannot leave a live-looking
+            // lock file behind (Drop would also clean it up, but the entry
+            // was never inserted, so remove it here for clarity).
+            drop(lock);
+            let _ = fs::remove_file(&lock_path);
+            return Err(e);
+        }
+        Ok(Self {
+            enabled: true,
+            store,
+            lock_dir,
+            entry_id: entry.id,
+            lock: Some(lock),
+            finished: false,
+        })
+    }
+
+    /// A session whose operations are all no-ops.
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            store: HistoryStore::with_path(PathBuf::new()),
+            lock_dir: PathBuf::new(),
+            entry_id: String::new(),
+            lock: None,
+            finished: true,
+        }
+    }
+
+    /// Settles the entry from the download's final result: `completed`,
+    /// `failed` (+ error code), or removed on cancel. Consumes `self`; the
+    /// Drop implementation releases the lock and removes the lock file.
+    pub async fn settle(
+        mut self,
+        app: &AppHandle,
+        options: &crate::handlers::bilibili::DownloadOptions,
+        result: &Result<String, String>,
+    ) {
+        // Note: both arms re-emit `history:entry_added` — no separate
+        // "entry updated" event exists because the frontend never received the
+        // in_progress entry (HistoryStore::get_all filters it out). The
+        // reducer does not upsert (historySlice.addEntry just unshifts,
+        // src/features/history/model/historySlice.ts), so this event must
+        // fire at most once per entry id.
+        match result {
+            Ok(final_path) => {
+                // Mirror the old save_to_history: use the part's thumbnail
+                // when present, fetch the video's otherwise. The fetch is
+                // time-boxed because settle runs inline in download_video —
+                // the invoke must not hang on an unreachable API after the
+                // file is already complete (reqwest has no default total
+                // timeout); a timed-out entry just lands without a thumbnail.
+                let thumbnail_url = match options.thumbnail_url.clone() {
+                    Some(url) => Some(url),
+                    None => tokio::time::timeout(
+                        std::time::Duration::from_secs(THUMBNAIL_FETCH_TIMEOUT_SECS),
+                        fetch_thumbnail(app, &options.bvid),
+                    )
+                    .await
+                    .ok()
+                    .flatten(),
+                };
+                if let Some(entry) = self.complete(final_path, thumbnail_url) {
+                    let _ = app.emit("history:entry_added", &entry);
+                }
+            }
+            // Why: substring match, not equality — ERR::* codes travel inside
+            // plain String messages that can carry extra text around the code
+            // (the segment pipeline detects cancel with the same contains()
+            // rule before propagating, utils/downloads.rs, issue #562).
+            // Equality would record a user cancel as a `failed` history entry
+            // instead of removing it.
+            // User cancel is intent, not failure: leave no trace (issue #511).
+            Err(e) if e.contains("ERR::CANCELLED") => self.cancel(),
+            Err(e) => {
+                if let Some(entry) = self.fail(e) {
+                    let _ = app.emit("history:entry_added", &entry);
+                }
+            }
+        }
+    }
+
+    /// Marks the entry `completed` with the final file size and thumbnail.
+    /// Returns the updated entry, or `None` when there was nothing to settle.
+    fn complete(
+        &mut self,
+        final_path: &str,
+        thumbnail_url: Option<String>,
+    ) -> Option<HistoryEntry> {
+        let file_size = fs::metadata(final_path).ok().map(|m| m.len());
+        self.finalize("complete", |e| {
+            e.status = "completed".to_string();
+            e.downloaded_at = now_rfc3339();
+            e.file_size = file_size;
+            if let Some(url) = &thumbnail_url {
+                e.thumbnail_url = Some(url.clone());
+            }
+        })
+    }
+
+    /// Marks the entry `failed` with the backend error code.
+    fn fail(&mut self, error_message: &str) -> Option<HistoryEntry> {
+        self.finalize("fail", |e| {
+            e.status = "failed".to_string();
+            e.error_message = Some(error_message.to_string());
+        })
+    }
+
+    /// Shared settle step: applies `f` to the entry, marks the session
+    /// finished, and returns the updated entry — or `None` when disabled or
+    /// there was nothing to settle.
+    fn finalize(&mut self, step: &str, f: impl FnOnce(&mut HistoryEntry)) -> Option<HistoryEntry> {
+        if !self.enabled {
+            return None;
+        }
+        let result = self.store.update_in_progress(&self.entry_id, f);
+        self.finished = true;
+        match result {
+            Ok(updated) => updated,
+            Err(e) => {
+                log::warn!(
+                    "[BE] history_session: {step} update failed for {}: {e}",
+                    self.entry_id
+                );
+                None
+            }
+        }
+    }
+
+    /// Removes the entry (user cancelled the download).
+    fn cancel(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        if let Err(e) = self.store.remove_entry(&self.entry_id) {
+            log::warn!(
+                "[BE] history_session: cancel removal failed for {}: {e}",
+                self.entry_id
+            );
+        }
+        self.finished = true;
+    }
+}
+
+impl Drop for HistorySession {
+    fn drop(&mut self) {
+        // Panic path: settle never ran, so record the download as interrupted
+        // instead of leaving an in_progress entry forever. No emit is possible
+        // here (no AppHandle in Drop); the frontend sees the entry on its
+        // next history load.
+        if !self.finished && self.enabled {
+            let _ = self.store.update_in_progress(&self.entry_id, |e| {
+                e.status = "failed".to_string();
+                e.error_message = Some(ERR_INTERRUPTED.to_string());
+            });
+        }
+        // Release the flock before removing the file (required on Windows).
+        self.lock = None;
+        // Only an enabled session ever owned a lock file; a disabled one has
+        // empty paths, and removing them would resolve to a relative
+        // "hist_.lock" in the process CWD.
+        if self.enabled {
+            let _ = fs::remove_file(session_lock_path(&self.lock_dir, &self.entry_id));
+        }
+    }
+}
+
+/// Builds the initial `in_progress` entry for a download (id = download_id,
+/// which is unique per download and doubles as the session lock name).
+fn initial_entry(options: &crate::handlers::bilibili::DownloadOptions) -> HistoryEntry {
+    let title = Path::new(&options.filename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&options.filename)
+        .to_string();
+    let page_suffix = options.page.map(|p| format!("?p={p}")).unwrap_or_default();
+
+    HistoryEntry {
+        id: options.download_id.clone(),
+        title,
+        bvid: Some(options.bvid.clone()),
+        url: format!(
+            "https://www.bilibili.com/video/{}{}",
+            options.bvid, page_suffix
+        ),
+        downloaded_at: now_rfc3339(),
+        status: "in_progress".to_string(),
+        error_message: None,
+        file_size: None,
+        quality: options
+            .quality
+            .as_ref()
+            .map(crate::handlers::bilibili::quality_to_string),
+        thumbnail_url: options.thumbnail_url.clone(),
+        version: "1.0".to_string(),
+    }
+}
+
+/// Current UTC time in the same compact RFC 3339 shape as the old
+/// `save_to_history` used.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Fetches the video thumbnail for a completed entry (best-effort).
+async fn fetch_thumbnail(app: &AppHandle, bvid: &str) -> Option<String> {
+    let cookies = crate::handlers::cookie::read_cookie(app)
+        .ok()
+        .unwrap_or_default()
+        .unwrap_or_default();
+    crate::handlers::bilibili::fetch_video_info_for_history(bvid, &cookies)
+        .await
+        .and_then(|(_, url)| url)
+}
+
+/// Creates the session lock file and holds an exclusive flock on it.
+///
+/// Reclaims a dead holder first: an existing file whose flock can be taken
+/// has no live owner (its process died; the OS released the lock), so it is
+/// removed and re-created — the same rule as `try_claim` (issue #560).
+fn acquire_session_lock(path: &Path) -> Result<File, String> {
+    let try_create = || -> Result<File, std::io::Error> {
+        let file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .read(true)
+            .open(path)?;
+        file.lock_exclusive()?;
+        Ok(file)
+    };
+
+    match try_create() {
+        Ok(file) => Ok(file),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Dead-holder reclamation.
+            if let Ok(existing) = OpenOptions::new().write(true).read(true).open(path) {
+                if existing.try_lock_exclusive().is_ok() {
+                    drop(existing);
+                    let _ = fs::remove_file(path);
+                }
+            }
+            try_create().map_err(|e| format!("cannot acquire session lock: {e}"))
+        }
+        Err(e) => Err(format!("cannot acquire session lock: {e}")),
+    }
+}
+
+/// Startup recovery (issue #511): resolves the store and lock directory from
+/// the app handle, then delegates to [`recover_interrupted_in`].
+pub fn recover_interrupted(app: &AppHandle) -> RecoveryResult {
+    let store = match HistoryStore::new(app) {
+        Ok(store) => store,
+        Err(e) => {
+            log::warn!("[BE] history_session: store unavailable, skipping recovery: {e}");
+            return RecoveryResult::default();
+        }
+    };
+    let lock_dir = match app.path().app_data_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            log::warn!("[BE] history_session: app data dir unavailable: {e}");
+            return RecoveryResult::default();
+        }
+    };
+    recover_interrupted_in(&store, &lock_dir)
+}
+
+/// Directory-scoped core of [`recover_interrupted`] (test seam).
+///
+/// Pass 1 — settle orphaned entries: every `in_progress` entry whose lock
+/// file is missing or whose flock can be taken (no live owner anywhere) is
+/// marked `failed` with [`ERR_INTERRUPTED`]. An entry settled concurrently by
+/// another process is skipped by the store's in-progress guard.
+///
+/// Pass 2 — sweep orphaned locks: every unlocked `hist_*.lock` is deleted,
+/// covering both crash windows ("lock created but insert never happened" and
+/// "entry settled but lock removal never happened"). Locks held by a live
+/// download (another app instance included) are never touched.
+pub fn recover_interrupted_in(store: &HistoryStore, lock_dir: &Path) -> RecoveryResult {
+    let mut result = RecoveryResult::default();
+
+    for entry in store.load().unwrap_or_default() {
+        if entry.status != "in_progress" {
+            continue;
+        }
+        let lock_path = session_lock_path(lock_dir, &entry.id);
+        let owner_gone = !lock_path.exists() || is_unlocked(&lock_path);
+        if owner_gone {
+            match store.update_in_progress(&entry.id, |e| {
+                e.status = "failed".to_string();
+                e.error_message = Some(ERR_INTERRUPTED.to_string());
+            }) {
+                // Ok(None): another process settled it first — not ours.
+                Ok(Some(_)) => result.marked_failed += 1,
+                Ok(None) => {}
+                Err(e) => log::warn!(
+                    "[BE] history_session: recovery update failed for {}: {e}",
+                    entry.id
+                ),
+            }
+        }
+    }
+
+    if let Ok(entries) = fs::read_dir(lock_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if is_session_lock(&path) && is_unlocked(&path) {
+                if fs::remove_file(&path).is_ok() {
+                    result.locks_removed += 1;
+                }
+            }
+        }
+    }
+
+    if result.marked_failed > 0 || result.locks_removed > 0 {
+        log::info!(
+            "[BE] history_session: recovery marked {} interrupted download(s) failed, removed {} orphan lock file(s)",
+            result.marked_failed,
+            result.locks_removed
+        );
+    }
+    result
+}
+
+/// True when no live process holds an exclusive flock on this file
+/// (`cleanup::is_unlocked_orphan` rule). Best-effort: an unopenable file is
+/// treated as locked (left alone).
+fn is_unlocked(path: &Path) -> bool {
+    match OpenOptions::new().write(true).read(true).open(path) {
+        Ok(file) => file.try_lock_exclusive().is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_in(dir: &Path) -> HistoryStore {
+        HistoryStore::with_path(dir.join("history.json"))
+    }
+
+    fn entry(id: &str, status: &str) -> HistoryEntry {
+        HistoryEntry {
+            id: id.into(),
+            title: format!("title-{id}"),
+            bvid: Some(format!("BV{id}")),
+            url: format!("https://www.bilibili.com/video/BV{id}"),
+            downloaded_at: "2026-01-01T00:00:00+00:00".into(),
+            status: status.into(),
+            error_message: None,
+            file_size: None,
+            quality: None,
+            thumbnail_url: None,
+            version: "1.0".into(),
+        }
+    }
+
+    #[test]
+    fn session_lock_path_sanitizes_entry_id() {
+        let path = session_lock_path(Path::new("/data"), "BV1ab-uuid4-p1");
+        assert_eq!(path, Path::new("/data/hist_BV1ab-uuid4-p1.lock"));
+
+        // Path separators and spaces from a hostile id are neutralized.
+        let path = session_lock_path(Path::new("/data"), "a/b c:d");
+        assert_eq!(path, Path::new("/data/hist_a_b_c_d.lock"));
+    }
+
+    #[test]
+    fn is_session_lock_matches_only_hist_prefix() {
+        assert!(is_session_lock(Path::new("hist_dl-1.lock")));
+        // locked_json's store locks must not be swept as session locks.
+        assert!(!is_session_lock(Path::new("history.json.lock")));
+        assert!(!is_session_lock(Path::new("hist_video.part.mp4")));
+    }
+
+    #[test]
+    fn start_with_inserts_in_progress_and_creates_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+
+        let session = HistorySession::start_with(
+            store,
+            dir.path().to_path_buf(),
+            entry("dl-1", "in_progress"),
+        )
+        .unwrap();
+        assert!(session_lock_path(dir.path(), "dl-1").exists());
+
+        let entries = HistoryStore::with_path(dir.path().join("history.json"))
+            .load()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "dl-1");
+        assert_eq!(entries[0].status, "in_progress");
+
+        drop(session);
+    }
+
+    #[test]
+    fn drop_without_settle_marks_interrupted_and_removes_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+
+        {
+            let session = HistorySession::start_with(
+                store,
+                dir.path().to_path_buf(),
+                entry("dl-1", "in_progress"),
+            )
+            .unwrap();
+            drop(session); // simulate a panic before settle
+        }
+
+        let entries = store_in(dir.path()).load().unwrap();
+        assert_eq!(entries[0].status, "failed");
+        assert_eq!(entries[0].error_message.as_deref(), Some(ERR_INTERRUPTED));
+        assert!(!session_lock_path(dir.path(), "dl-1").exists());
+    }
+
+    #[test]
+    fn fail_marks_failed_with_error_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        let mut session = HistorySession::start_with(
+            store_in(dir.path()),
+            dir.path().to_path_buf(),
+            entry("dl-1", "in_progress"),
+        )
+        .unwrap();
+
+        let updated = session.fail("ERR::NETWORK::2 segment(s) failed").unwrap();
+        assert_eq!(updated.status, "failed");
+        assert_eq!(
+            updated.error_message.as_deref(),
+            Some("ERR::NETWORK::2 segment(s) failed")
+        );
+        drop(session);
+
+        let entries = store.load().unwrap();
+        assert_eq!(entries[0].status, "failed");
+        assert!(!session_lock_path(dir.path(), "dl-1").exists());
+    }
+
+    #[test]
+    fn cancel_removes_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        let mut session = HistorySession::start_with(
+            store_in(dir.path()),
+            dir.path().to_path_buf(),
+            entry("dl-1", "in_progress"),
+        )
+        .unwrap();
+
+        session.cancel();
+        drop(session);
+
+        assert!(store.load().unwrap().is_empty());
+        assert!(!session_lock_path(dir.path(), "dl-1").exists());
+    }
+
+    #[test]
+    fn complete_finalizes_with_size_and_thumbnail() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("video.mp4");
+        fs::write(&output, b"0123456789").unwrap();
+
+        let mut session = HistorySession::start_with(
+            store_in(dir.path()),
+            dir.path().to_path_buf(),
+            entry("dl-1", "in_progress"),
+        )
+        .unwrap();
+
+        let updated = session
+            .complete(
+                &output.to_string_lossy(),
+                Some("http://example.test/t.jpg".to_string()),
+            )
+            .unwrap();
+        assert_eq!(updated.status, "completed");
+        assert_eq!(updated.file_size, Some(10));
+        assert_eq!(
+            updated.thumbnail_url.as_deref(),
+            Some("http://example.test/t.jpg")
+        );
+        drop(session);
+
+        assert!(!session_lock_path(dir.path(), "dl-1").exists());
+    }
+
+    #[test]
+    fn settle_after_clear_is_idempotent_noop() {
+        // User cleared the history mid-download: finalize must not resurrect
+        // the entry.
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        let mut session = HistorySession::start_with(
+            store_in(dir.path()),
+            dir.path().to_path_buf(),
+            entry("dl-1", "in_progress"),
+        )
+        .unwrap();
+
+        store.clear().unwrap();
+        assert!(session.fail("ERR::NETWORK::x").is_none());
+        assert!(store.load().unwrap().is_empty());
+        drop(session);
+    }
+
+    #[test]
+    fn disabled_session_is_all_noops() {
+        let mut session = HistorySession::disabled();
+        assert!(session.fail("ERR::X").is_none());
+        session.cancel();
+        assert!(session.complete("/nonexistent", None).is_none());
+    }
+
+    // ---- startup recovery ----
+
+    #[test]
+    fn recover_marks_unlocked_in_progress_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        store.add_entry(entry("dl-1", "in_progress")).unwrap();
+        fs::write(session_lock_path(dir.path(), "dl-1"), b"").unwrap(); // unlocked leftover
+
+        let result = recover_interrupted_in(&store, dir.path());
+        assert_eq!(result.marked_failed, 1);
+        assert_eq!(result.locks_removed, 1);
+
+        let entries = store.load().unwrap();
+        assert_eq!(entries[0].status, "failed");
+        assert_eq!(entries[0].error_message.as_deref(), Some(ERR_INTERRUPTED));
+        assert!(!session_lock_path(dir.path(), "dl-1").exists());
+    }
+
+    #[test]
+    fn recover_skips_entries_with_live_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        store.add_entry(entry("dl-1", "in_progress")).unwrap();
+        // Simulate another app instance mid-download: hold the flock.
+        let holder = {
+            let path = session_lock_path(dir.path(), "dl-1");
+            let file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .write(true)
+                .read(true)
+                .open(&path)
+                .unwrap();
+            file.lock_exclusive().unwrap();
+            file
+        };
+
+        let result = recover_interrupted_in(&store, dir.path());
+        assert_eq!(result.marked_failed, 0, "live download must not be touched");
+
+        let entries = store.load().unwrap();
+        assert_eq!(entries[0].status, "in_progress");
+        drop(holder);
+    }
+
+    #[test]
+    fn recover_marks_missing_lock_as_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        store.add_entry(entry("dl-1", "in_progress")).unwrap();
+        // No lock file at all (e.g. hand-deleted): no live owner can exist.
+
+        let result = recover_interrupted_in(&store, dir.path());
+        assert_eq!(result.marked_failed, 1);
+        assert_eq!(store.load().unwrap()[0].status, "failed");
+    }
+
+    #[test]
+    fn recover_sweeps_orphan_locks_without_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        // Crash window: lock created, insert never happened.
+        fs::write(session_lock_path(dir.path(), "ghost"), b"").unwrap();
+        // Crash window: entry settled, lock removal never happened.
+        store.add_entry(entry("done-1", "completed")).unwrap();
+        fs::write(session_lock_path(dir.path(), "done-1"), b"").unwrap();
+
+        let result = recover_interrupted_in(&store, dir.path());
+        assert_eq!(result.marked_failed, 0);
+        assert_eq!(result.locks_removed, 2);
+        assert_eq!(store.load().unwrap()[0].status, "completed");
+    }
+}

--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::handlers::{bilibili, cleanup, cookie, ffmpeg, qr_login};
+use crate::handlers::{bilibili, cleanup, cookie, ffmpeg, history_session, qr_login};
 use crate::models::frontend_dto::User;
 use crate::models::qr_login::{CookieRefreshInfo, LoginMethod};
 use crate::models::settings::Settings;
@@ -70,6 +70,10 @@ pub async fn initialize(app: AppHandle) -> Result<(), String> {
     // Also sweep abandoned *.part.* staging files from the download
     // output directory (crashed downloads, issue #560).
     let _ = cleanup::cleanup_part_files(&app).await;
+    // Mark in_progress history entries whose owning process is gone as
+    // failed (crash recovery, issue #511). Live downloads in another app
+    // instance hold their session flock and are never touched.
+    let _ = history_session::recover_interrupted(&app);
 
     // 2. ffmpeg validate / install (heaviest step; downloads on first run).
     //    Settings are already loaded in setup and stored in InitResult, so

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -22,6 +22,7 @@ pub mod cookie;
 pub mod favorites;
 pub mod ffmpeg;
 pub mod github;
+pub mod history_session;
 pub mod init;
 pub mod qr_login;
 pub mod resolution;

--- a/src-tauri/src/models/history.rs
+++ b/src-tauri/src/models/history.rs
@@ -23,8 +23,13 @@ pub struct HistoryEntry {
     pub url: String,
     /// Download completion timestamp (ISO 8601 format).
     pub downloaded_at: String,
-    /// Download status: "completed" or "failed".
+    /// Download status: "in_progress", "completed", or "failed".
     pub status: String,
+    /// Backend `ERR::*` code explaining why status is "failed"; the pseudo
+    /// code `ERR::INTERRUPTED` marks entries whose owning process died
+    /// before the download result settled (issue #511).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
     /// Downloaded file size in bytes (optional).
     pub file_size: Option<u64>,
     /// Video quality (e.g., "1080P60", optional).
@@ -92,6 +97,35 @@ mod tests {
             "http://i0.hdslb.com/bfs/archive/thumb.jpg"
         );
         assert_eq!(out["version"], "1.0");
+        // errorMessage is omitted when None (on-disk format stays compact).
+        assert!(out.get("errorMessage").is_none());
+    }
+
+    #[test]
+    fn history_entry_roundtrips_error_message() {
+        let json = r#"{
+            "id": "err-1", "title": "t", "url": "u",
+            "downloadedAt": "2026-09-01T00:00:00Z",
+            "status": "failed",
+            "errorMessage": "ERR::INTERRUPTED"
+        }"#;
+        let entry: HistoryEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.error_message.as_deref(), Some("ERR::INTERRUPTED"));
+
+        let out = serde_json::to_value(&entry).unwrap();
+        assert_eq!(out["errorMessage"], "ERR::INTERRUPTED");
+
+        // Legacy entries written before issue #511 deserialize without the
+        // field (serde default -> None).
+        let legacy: HistoryEntry = serde_json::from_str(
+            r#"{
+                "id": "old-1", "title": "t", "url": "u",
+                "downloadedAt": "2026-08-01T00:00:00Z",
+                "status": "completed"
+            }"#,
+        )
+        .unwrap();
+        assert!(legacy.error_message.is_none());
     }
 
     #[test]

--- a/src-tauri/src/store/history_store.rs
+++ b/src-tauri/src/store/history_store.rs
@@ -121,6 +121,40 @@ impl HistoryStore {
         .map_err(|e| e.to_string())
     }
 
+    /// Applies `f` to the entry with `id`, but only while it is still
+    /// `in_progress` (issue #511).
+    ///
+    /// The find-and-mutate runs as one locked transaction. Returns the
+    /// post-mutation entry, or `None` when the id is absent (the entry was
+    /// cleared or truncated while the download ran) or already finalized —
+    /// both are idempotent no-ops, so a finalize can never resurrect an
+    /// entry the user deleted, and two processes racing to settle the same
+    /// id cannot double-apply.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the locked read-modify-write fails.
+    pub fn update_in_progress(
+        &self,
+        id: &str,
+        f: impl FnOnce(&mut HistoryEntry),
+    ) -> Result<Option<HistoryEntry>, String> {
+        with_json_mut(&self.path, |v| {
+            let mut entries = Self::entries_from(v)?;
+            let Some(entry) = entries
+                .iter_mut()
+                .find(|e| e.id == id && e.status == "in_progress")
+            else {
+                return Ok(None);
+            };
+            f(entry);
+            let updated = entry.clone();
+            Self::set_entries(v, &entries)?;
+            Ok(Some(updated))
+        })
+        .map_err(|e| e.to_string())
+    }
+
     /// Removes all history entries from the store.
     ///
     /// # Errors
@@ -130,12 +164,21 @@ impl HistoryStore {
         with_json_mut(&self.path, |v| Self::set_entries(v, &[])).map_err(|e| e.to_string())
     }
 
-    /// Retrieves all history entries from the store.
+    /// Retrieves history entries from the store, excluding `in_progress`
+    /// entries (issue #511).
+    ///
+    /// Active downloads are invisible to the UI, search, and export; only
+    /// finalized entries (`completed`/`failed`) are user-visible. Internal
+    /// callers that need the raw list (startup recovery) use [`load`].
     ///
     /// If loading fails (e.g., corrupted data), it returns an empty vector
     /// instead of an error.
     pub fn get_all(&self) -> Vec<HistoryEntry> {
-        self.load().unwrap_or_default()
+        self.load()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|e| e.status != "in_progress")
+            .collect()
     }
 
     /// Searches history entries with optional query string and filters.
@@ -218,6 +261,7 @@ mod tests {
             url: format!("https://www.bilibili.com/video/{id}"),
             downloaded_at: downloaded_at.into(),
             status: status.into(),
+            error_message: None,
             file_size: None,
             quality: None,
             thumbnail_url: None,
@@ -413,6 +457,97 @@ mod tests {
 
         store.clear().unwrap();
         assert!(store.get_all().is_empty());
+    }
+
+    #[test]
+    fn update_in_progress_mutates_only_live_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        store
+            .add_entry(store_entry(
+                "live",
+                "t",
+                "in_progress",
+                "2026-01-01T00:00:00Z",
+            ))
+            .unwrap();
+        store
+            .add_entry(store_entry(
+                "done",
+                "t",
+                "completed",
+                "2026-01-02T00:00:00Z",
+            ))
+            .unwrap();
+
+        // in_progress entry: mutated, post-mutation entry returned.
+        let updated = store
+            .update_in_progress("live", |e| {
+                e.status = "failed".into();
+                e.error_message = Some("ERR::NETWORK::x".into());
+            })
+            .unwrap()
+            .expect("live entry must update");
+        assert_eq!(updated.status, "failed");
+        assert_eq!(updated.error_message.as_deref(), Some("ERR::NETWORK::x"));
+
+        // Finalized entry: no-op (a settle can never resurrect/rewrite it).
+        assert!(store
+            .update_in_progress("done", |e| e.status = "failed".into())
+            .unwrap()
+            .is_none());
+        // Missing entry (cleared/truncated while downloading): no-op.
+        assert!(store
+            .update_in_progress("gone", |e| e.status = "failed".into())
+            .unwrap()
+            .is_none());
+
+        let all = store.get_all();
+        // Newest first: [done, live-turned-failed].
+        assert_eq!(all[0].status, "completed", "done entry untouched");
+        assert_eq!(all[1].status, "failed");
+    }
+
+    #[test]
+    fn update_in_progress_persists_across_store_handles() {
+        // Another process must observe the mutation (no in-process cache).
+        let dir = tempfile::tempdir().unwrap();
+        let writer = store_in(dir.path());
+        let reader = store_in(dir.path());
+        writer
+            .add_entry(store_entry("a", "t", "in_progress", "2026-01-01T00:00:00Z"))
+            .unwrap();
+        writer
+            .update_in_progress("a", |e| e.status = "completed".into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(reader.get_all()[0].status, "completed");
+    }
+
+    #[test]
+    fn get_all_hides_in_progress_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(dir.path());
+        store
+            .add_entry(store_entry(
+                "live",
+                "t",
+                "in_progress",
+                "2026-01-01T00:00:00Z",
+            ))
+            .unwrap();
+        store
+            .add_entry(store_entry("ok", "t", "completed", "2026-01-02T00:00:00Z"))
+            .unwrap();
+
+        // UI/search/export surface: active downloads are invisible...
+        let visible = store.get_all();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].id, "ok");
+        // ...while search (which goes through get_all) matches too.
+        assert_eq!(store.search(None, None).len(), 1);
+        // Raw load keeps in_progress for internal callers (recovery).
+        assert_eq!(store.load().unwrap().len(), 2);
     }
 
     #[test]

--- a/src/features/history/ui/HistoryItem.test.tsx
+++ b/src/features/history/ui/HistoryItem.test.tsx
@@ -86,6 +86,13 @@ describe('HistoryItem', () => {
     expect(screen.getByText('network reset')).toBeInTheDocument()
   })
 
+  it('maps a stored ERR:: code in the error line to its translation key', () => {
+    renderEntry({ status: 'failed', errorMessage: 'ERR::INTERRUPTED' })
+
+    expect(screen.getByText('video.download_interrupted')).toBeInTheDocument()
+    expect(screen.queryByText('ERR::INTERRUPTED')).toBeNull()
+  })
+
   it('renders the thumbnail placeholder when no thumbnail exists', () => {
     renderEntry({ thumbnailUrl: undefined })
 

--- a/src/features/history/ui/HistoryItem.tsx
+++ b/src/features/history/ui/HistoryItem.tsx
@@ -7,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/shared/animate-ui/radix/tooltip'
+import { mapBackendError } from '@/shared/lib/mapBackendError'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/button'
 import { toast } from '@/shared/ui/toast'
@@ -140,6 +141,12 @@ function HistoryItem({ entry, onDelete, onDownload, disabled }: Props) {
   const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
   const isSuccess = entry.status === 'completed'
+  // Failed entries store a backend ERR::* code; map it to a translated
+  // message and fall back to the raw string for unmapped codes (issue #511).
+  const errorText =
+    entry.status === 'failed' && entry.errorMessage
+      ? t(mapBackendError(entry.errorMessage) ?? entry.errorMessage)
+      : null
 
   const handleCopyUrl = async () => {
     try {
@@ -258,8 +265,8 @@ function HistoryItem({ entry, onDelete, onDownload, disabled }: Props) {
           </div>
         </div>
 
-        {entry.status === 'failed' && entry.errorMessage && (
-          <p className="text-destructive mt-1 text-xs">{entry.errorMessage}</p>
+        {errorText && (
+          <p className="text-destructive mt-1 text-xs">{errorText}</p>
         )}
       </div>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -225,6 +225,7 @@
     "audio_merge_fallback": "Audio stream copy failed. Using AAC re-encoding instead.",
     "invalid_media_response": "Invalid media response from server (received error page instead of media).",
     "audio_download_failed": "Failed to download audio after trying all available streams.",
+    "download_interrupted": "Download was interrupted (the app quit or crashed).",
     "queue_waiting_prefix": "Queued:",
     "reload_after_error": "Reload page to retry",
     "select_all": "Select All",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -225,6 +225,7 @@
     "audio_merge_fallback": "La copia del flujo de audio falló. Usando recodificación AAC en su lugar.",
     "invalid_media_response": "Respuesta de medios no válida del servidor (se recibió página de error).",
     "audio_download_failed": "Error al descargar audio después de intentar todas las transmisiones disponibles.",
+    "download_interrupted": "La descarga fue interrumpida (la aplicación se cerró o falló).",
     "queue_waiting_prefix": "En cola:",
     "reload_after_error": "Recargar página para reintentar",
     "select_all": "Seleccionar todo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -225,6 +225,7 @@
     "audio_merge_fallback": "La copie du flux audio a échoué. Utilisation du réencodage AAC à la place.",
     "invalid_media_response": "Réponse média non valide du serveur (page d'erreur reçue).",
     "audio_download_failed": "Échec du téléchargement audio après avoir essayé tous les flux disponibles.",
+    "download_interrupted": "Le téléchargement a été interrompu (fermeture ou plantage de l'application).",
     "queue_waiting_prefix": "En file d'attente:",
     "reload_after_error": "Recharger la page pour réessayer",
     "select_all": "Tout sélectionner",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -225,6 +225,7 @@
     "audio_merge_fallback": "音声ストリームコピーに失敗しました。AAC再エンコードを使用します。",
     "invalid_media_response": "サーバーから無効なメディア応答がありました（エラーページを受信）。",
     "audio_download_failed": "すべての利用可能なストリームを試しましたが、音声のダウンロードに失敗しました。",
+    "download_interrupted": "ダウンロードが中断されました（アプリ終了またはクラッシュ）。",
     "queue_waiting_prefix": "キュー待ち:",
     "reload_after_error": "ページをリロードして再試行",
     "select_all": "全選択",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -225,6 +225,7 @@
     "audio_merge_fallback": "오디오 스트림 복사에 실패했습니다. AAC 재인코딩을 사용합니다.",
     "invalid_media_response": "서버에서 잘못된 미디어 응답을 받았습니다(오류 페이지 수신).",
     "audio_download_failed": "사용 가능한 모든 스트림을 시도했으나 오디오 다운로드에 실패했습니다.",
+    "download_interrupted": "다운로드가 중단되었습니다(앱 종료 또는 크래시).",
     "queue_waiting_prefix": "대기 중:",
     "reload_after_error": "페이지 새로고침 후 재시도",
     "select_all": "전체 선택",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -226,6 +226,7 @@
     "audio_merge_fallback": "音频流复制失败，正在使用 AAC 重新编码。",
     "invalid_media_response": "服务器返回了无效的媒体响应（接收到错误页面而非媒体）。",
     "audio_download_failed": "尝试了所有可用流后，音频下载失败。",
+    "download_interrupted": "下载已中断（应用退出或崩溃）。",
     "queue_waiting_prefix": "排队中:",
     "reload_after_error": "刷新页面后重试",
     "select_all": "全选",

--- a/src/shared/lib/mapBackendError.test.ts
+++ b/src/shared/lib/mapBackendError.test.ts
@@ -15,6 +15,12 @@ describe('mapBackendError', () => {
     )
   })
 
+  it('maps ERR::INTERRUPTED (crashed download history) to its key', () => {
+    expect(mapBackendError('ERR::INTERRUPTED')).toBe(
+      'video.download_interrupted',
+    )
+  })
+
   it('maps ERR::NETWORK:: with a dynamic suffix to the fixed network key', () => {
     expect(mapBackendError('ERR::NETWORK::2 segment(s) failed')).toBe(
       'video.network_error',

--- a/src/shared/lib/mapBackendError.ts
+++ b/src/shared/lib/mapBackendError.ts
@@ -31,6 +31,8 @@ const VIDEO_ERROR_MAP: Record<string, string> = {
   // Audio / media download error codes
   'ERR::INVALID_MEDIA_RESPONSE': 'video.invalid_media_response',
   'ERR::AUDIO_DOWNLOAD_FAILED': 'video.audio_download_failed',
+  // Download history: process died before the result settled (issue #511)
+  'ERR::INTERRUPTED': 'video.download_interrupted',
   // QR login error codes
   'ERR::QR_COOKIE_REJECTED': 'login.qrVerifyFailed',
   'ERR::QR_SESSDATA_MISSING': 'login.qrSessdataMissing',


### PR DESCRIPTION
## Summary

Implements issue #511: download history now records the full download lifecycle instead of successes only.

- **In-progress tracking**: a history entry (`status: in_progress`, id = `download_id`) is inserted when a download starts, under an exclusive-flock session lock file (`hist_{id}.lock` in the app data dir)
- **Settle on every exit path**: `download_video` becomes a thin wrapper that settles the entry from the body's final `Result` — `completed` on success, `failed` + the backend `ERR::*` code in a new `errorMessage` field on error, entry removed on user cancel
- **Crash recovery**: a killed process skips settle, but the OS releases its flock; startup recovery marks orphaned `in_progress` entries as `failed` with pseudo code `ERR::INTERRUPTED` and sweeps orphaned lock files. Multi-process safe by the same flock liveness rule as #560 — a live download in another app instance is never touched (verified live with two app instances)
- **Store**: `HistoryStore::update_in_progress` (in-progress-guarded, idempotent finalize under the locked_json transaction); `get_all`/`search`/`export` hide `in_progress` entries
- **Compatibility**: `errorMessage` is `#[serde(default)]` so existing `history.json` needs no migration; entry ids keep the old format for old entries
- **FE**: `ERR::INTERRUPTED` mapped to a translated message (`video.download_interrupted`, all 6 languages) in the history error line

## Related Issue

Closes #511

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `cargo test` (328 passed: 19 new history_session tests, 5 store/model tests)
- [x] `npm test` (1190 passed: mapBackendError + HistoryItem error-line tests)
- [x] `cargo build` / `cargo fmt` / `npm run lint` / `npm run typecheck` clean
- [x] Live verification: success → `completed`; Wi-Fi cut mid-download → `failed` with real `ERR::NETWORK` code; app killed mid-download → restart marks `ERR::INTERRUPTED`; two app instances → recovery skips the live instance's download

## Screenshots / Videos (Optional)

N/A (no visual layout changes; failed entries reuse the existing red badge + error line)

## Breaking Changes

None. On-disk format unchanged except the optional `errorMessage` field.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)