### PR TITLE
refactor(video): remove codec from options summary label

### DIFF
--- a/src/features/video/lib/constants.ts
+++ b/src/features/video/lib/constants.ts
@@ -41,27 +41,6 @@ export const AUDIO_QUALITIES_ORDER: number[] = [
 ]
 
 /**
- * Video codec IDs as defined by Bilibili DASH API.
- *
- * References:
- * - AVC: https://en.wikipedia.org/wiki/Advanced_Video_Coding
- * - HEVC: https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding
- * - AV1: https://en.wikipedia.org/wiki/AV1
- */
-export const CODECID_AVC: number = 7
-export const CODECID_HEVC: number = 12
-export const CODECID_AV1: number = 13
-
-/**
- * Mapping of video codec IDs to display labels.
- */
-export const VIDEO_CODEC_MAP: Record<number, string> = {
-  [CODECID_AVC]: 'AVC',
-  [CODECID_HEVC]: 'HEVC',
-  [CODECID_AV1]: 'AV1',
-}
-
-/**
  * Number of parts displayed per page in the paginated part list.
  *
  * Also bounds the default selection when a URL does not identify a

--- a/src/features/video/ui/VideoPartCard.test.tsx
+++ b/src/features/video/ui/VideoPartCard.test.tsx
@@ -439,7 +439,9 @@ describe('VideoPartCard', () => {
     })
 
     const trigger = screen.getByRole('button', { name: /video.options/ })
-    expect(trigger).toHaveTextContent('1080p(AVC)')
+    // Codec is no longer part of the summary (global setting governs it)
+    expect(trigger).toHaveTextContent('1080p')
+    expect(trigger).not.toHaveTextContent('(AVC)')
     expect(trigger).toHaveTextContent('192K')
     // More than two languages collapse into a count
     expect(trigger).toHaveTextContent('video.subtitle_n_languages')

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -17,7 +17,6 @@ import { usePartDownloadStatus } from '@/features/video/hooks/usePartDownloadSta
 import {
   AUDIO_QUALITIES_MAP,
   AUDIO_QUALITIES_ORDER,
-  VIDEO_CODEC_MAP,
   VIDEO_QUALITIES_MAP,
 } from '@/features/video/lib/constants'
 import { buildVideoFormSchema2 } from '@/features/video/lib/formSchema'
@@ -257,15 +256,13 @@ const VideoPartCard = memo(function VideoPartCard({
     const parts: string[] = []
 
     if (resolvedQuality) {
+      // WHY codec is omitted: the codec is chosen by the global
+      // videoCodecPriority setting, not per download, and most users cannot
+      // act on it — the summary stays focused on the selected quality.
       const videoLabel =
         VIDEO_QUALITIES_MAP[resolvedQuality.videoQuality] ||
         String(resolvedQuality.videoQuality)
-      // Append codec in parentheses so the video attributes (quality + codec)
-      // read as a single unit, visually separate from the audio quality.
-      const codecLabel =
-        VIDEO_CODEC_MAP[resolvedQuality.videoCodecid] ||
-        String(resolvedQuality.videoCodecid)
-      parts.push(`${videoLabel}(${codecLabel})`)
+      parts.push(videoLabel)
 
       if (resolvedQuality.audioQuality !== null) {
         const audioLabel =
@@ -296,15 +293,16 @@ const VideoPartCard = memo(function VideoPartCard({
    * due to the originally requested quality being unavailable.
    * Drives the warning icon in the accordion trigger.
    *
-   * WHY: codec fallback is excluded. The preferred codec being absent from
-   * the manifest leaves no alternative to choose, and the summary label
-   * already shows the actual codec (e.g. "1080p(AVC)"), so warning on it
-   * would fire on nearly every AVC-only video with pure noise.
+   * WHY: codec fallback is excluded. The codec is governed by the global
+   * videoCodecPriority setting, and the preferred codec being absent from
+   * the manifest leaves no alternative to choose, so warning on it would
+   * fire on nearly every AVC-only video with pure noise.
    */
-  // Caution: with codec fallback excluded here, `videoCodecFallback` (sent by the
-  // backend download-quality-resolved event and stored via inputSlice
-  // setResolvedQuality) is no longer read anywhere in the UI. Introduced in
-  // PR #460 (a17c8da); keep-or-remove it end-to-end as a deliberate decision.
+  // Caution: `videoCodecFallback` (sent by the backend
+  // download-quality-resolved event and stored via inputSlice
+  // setResolvedQuality) is deliberately kept end-to-end despite being
+  // unread by the UI today — it may feed a future codec indication.
+  // Introduced in PR #460 (a17c8da); removal decided against 2026-09.
   const hasFallback = useMemo(() => {
     if (!resolvedQuality) return false
     return (


### PR DESCRIPTION
## Summary

Remove the codec suffix (e.g. `1080p(AVC)`) from the options accordion summary label. The codec is governed by the global `videoCodecPriority` setting rather than chosen per download, so the suffix is noise for most users — and unmapped codec ids rendered as raw numbers (e.g. `1080p(7)`).

- Summary now reads `1080p / 192K` (video quality + audio quality + subtitle info)
- Delete the orphaned `CODECID_*` / `VIDEO_CODEC_MAP` constants
- Keep the `videoCodecid` / `videoCodecFallback` payload fields end-to-end (documented in-code) for a possible future codec indication

## Related Issue

None (no open issue covers this; codec priority behavior itself came from #460 and is unchanged)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `npm run lint` / `npm run typecheck` clean
- [x] `npm test` — 143 files, 1183 tests pass
- [x] Updated `VideoPartCard.test.tsx` asserts the codec suffix is gone from the trigger

## Breaking Changes

None — display-only change; download behavior and codec selection are untouched.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no i18n keys touched

<!-- This PR was created with Claude Code -->