### PR TITLE
feat(video): add omitDuplicatePartTitle setting to dedupe part filenames

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -1970,11 +1970,12 @@ mod tests {
     #[test]
     fn web_interface_data_to_video_single_part_falls_back_to_title() {
         let data = view_data("Main Title", "http://pic", 7, Some(vec![]));
-        let video = web_interface_data_to_video(&data, "BV1x", None, false, true);
+        let video = web_interface_data_to_video(&data, "BV1x", None, false, true, true);
         assert_eq!(video.parts.len(), 1);
         assert_eq!(video.parts[0].cid, 7);
         assert_eq!(video.parts[0].part, "Main Title");
         assert_eq!(video.parts[0].sanitized_part.as_deref(), Some("Main Title"));
+        assert_eq!(video.parts[0].default_title, "Main Title");
         assert_eq!(video.parts[0].thumbnail.url, "http://pic");
         assert!(video.is_limited_quality);
         assert_eq!(video.content_type, "video");
@@ -1987,10 +1988,13 @@ mod tests {
             page(2, 2, "", 30), // empty part name -> main title; no first_frame -> pic
         ];
         let data = view_data("T", "http://pic", 0, Some(pages));
-        let video = web_interface_data_to_video(&data, "BV1x", None, false, false);
+        let video = web_interface_data_to_video(&data, "BV1x", None, false, true, false);
         assert_eq!(video.parts.len(), 2);
         assert_eq!(video.parts[0].part, "Part A");
+        assert_eq!(video.parts[0].default_title, "T Part A");
+        // Empty part name falls back to the title, which then gets omitted
         assert_eq!(video.parts[1].part, "T");
+        assert_eq!(video.parts[1].default_title, "T");
         assert_eq!(video.parts[1].thumbnail.url, "http://pic");
         assert_eq!(video.parts[1].duration, 30);
     }
@@ -1999,9 +2003,12 @@ mod tests {
     fn web_interface_data_to_video_resolves_duplicate_sanitized_names() {
         let pages = vec![page(1, 1, "same", 1), page(2, 2, "same", 1)];
         let data = view_data("T", "p", 0, Some(pages));
-        let video = web_interface_data_to_video(&data, "BV1x", None, true, false);
+        let video = web_interface_data_to_video(&data, "BV1x", None, true, true, false);
         assert_eq!(video.parts[0].sanitized_part.as_deref(), Some("same"));
         assert_eq!(video.parts[1].sanitized_part.as_deref(), Some("same (1)"));
+        // Suffix from duplicate resolution breaks the title match, so both combine
+        assert_eq!(video.parts[0].default_title, "T same");
+        assert_eq!(video.parts[1].default_title, "T same (1)");
     }
 
     #[test]
@@ -2009,9 +2016,27 @@ mod tests {
         use crate::models::settings::TitleReplacement;
         let data = view_data("a:b", "p", 1, Some(vec![]));
         let rules = [TitleReplacement::new(":", "_", true)];
-        let video = web_interface_data_to_video(&data, "BV1x", Some(&rules), false, false);
+        let video = web_interface_data_to_video(&data, "BV1x", Some(&rules), false, true, false);
         assert_eq!(video.title, "a_b");
         assert_eq!(video.parts[0].sanitized_part.as_deref(), Some("a_b"));
+        // Sanitized strings match, so the part name is omitted
+        assert_eq!(video.parts[0].default_title, "a_b");
+    }
+
+    #[test]
+    fn web_interface_data_to_video_omits_part_matching_title_after_trim() {
+        // Part name equals the title except for surrounding whitespace
+        let pages = vec![page(1, 1, " My Song ", 60)];
+        let data = view_data("My Song", "http://pic", 0, Some(pages));
+        let video = web_interface_data_to_video(&data, "BV1x", None, false, true, false);
+        assert_eq!(video.parts[0].default_title, "My Song");
+    }
+
+    #[test]
+    fn web_interface_data_to_video_keeps_duplicate_title_when_omission_off() {
+        let data = view_data("Main Title", "http://pic", 7, Some(vec![]));
+        let video = web_interface_data_to_video(&data, "BV1x", None, false, false, false);
+        assert_eq!(video.parts[0].default_title, "Main Title Main Title");
     }
 
     /// Whitelist for retryable ERR:: codes (issue #484): only
@@ -2554,12 +2579,17 @@ pub async fn fetch_video_info(app: &AppHandle, id: &str) -> Result<Video, String
         .as_ref()
         .and_then(|s| s.auto_rename_duplicates)
         .unwrap_or(true);
+    let omit_duplicate = settings
+        .as_ref()
+        .and_then(|s| s.omit_duplicate_part_title)
+        .unwrap_or(true);
 
     Ok(web_interface_data_to_video(
         data,
         id,
         replacements,
         auto_rename,
+        omit_duplicate,
         is_limited_quality,
     ))
 }
@@ -2586,7 +2616,23 @@ fn e2e_mock_video_info(id: &str) -> Result<Video, String> {
     // contract tests, commit 6a23fbc8), not of the BV typed in the E2E spec
     // (BV1i3411y7xB). The mapping overrides bvid with the requested id, so the
     // UI shows the snapshot video's title/parts for whatever URL was entered.
-    Ok(web_interface_data_to_video(data, id, None, true, true))
+    Ok(web_interface_data_to_video(
+        data, id, None, true, true, true,
+    ))
+}
+
+/// Fills each part's `default_title` from the sanitized video title.
+///
+/// Must run after duplicate-title resolution so a suffixed part name
+/// (e.g., "Title (1)") no longer matches the title.
+fn fill_default_part_titles(parts: &mut [VideoPart], sanitized_title: &str, omit_duplicate: bool) {
+    use crate::utils::sanitize::build_default_part_title;
+
+    for part in parts.iter_mut() {
+        let sanitized_part = part.sanitized_part.as_deref().unwrap_or(&part.part);
+        part.default_title =
+            build_default_part_title(sanitized_title, sanitized_part, omit_duplicate);
+    }
 }
 
 /// Maps a WebInterface view response into the frontend `Video` DTO.
@@ -2599,6 +2645,7 @@ fn web_interface_data_to_video(
     id: &str,
     replacements: Option<&[crate::models::settings::TitleReplacement]>,
     auto_rename: bool,
+    omit_duplicate: bool,
     is_limited_quality: bool,
 ) -> Video {
     use crate::utils::sanitize::{apply_title_replacements, resolve_duplicate_titles};
@@ -2612,6 +2659,7 @@ fn web_interface_data_to_video(
             page: 1,
             part: data.title.clone(),
             sanitized_part: Some(sanitized_title.clone()),
+            default_title: String::new(),
             duration: 0,
             thumbnail: Thumbnail {
                 url: data.pic.clone(),
@@ -2644,6 +2692,7 @@ fn web_interface_data_to_video(
                     page: page.page,
                     part: part_name.to_string(),
                     sanitized_part: Some(sanitized_part),
+                    default_title: String::new(),
                     duration: page.duration,
                     thumbnail: Thumbnail {
                         url: thumb_url.to_string(),
@@ -2674,6 +2723,8 @@ fn web_interface_data_to_video(
             }
         }
     }
+
+    fill_default_part_titles(&mut parts, &sanitized_title, omit_duplicate);
 
     Video {
         title: sanitized_title,
@@ -4286,6 +4337,10 @@ pub async fn fetch_bangumi_info(app: &AppHandle, ep_id: i64) -> Result<Video, St
         .as_ref()
         .and_then(|s| s.auto_rename_duplicates)
         .unwrap_or(true);
+    let omit_duplicate = settings
+        .as_ref()
+        .and_then(|s| s.omit_duplicate_part_title)
+        .unwrap_or(true);
 
     // Convert episodes to VideoParts
     let mut parts: Vec<VideoPart> = result
@@ -4304,6 +4359,7 @@ pub async fn fetch_bangumi_info(app: &AppHandle, ep_id: i64) -> Result<Video, St
                 page: (idx + 1) as i32,
                 part: original_part,
                 sanitized_part: Some(sanitized_part),
+                default_title: String::new(),
                 duration: ep.duration / 1000, // Convert ms to seconds
                 thumbnail: Thumbnail {
                     url: ep.cover.clone(),
@@ -4338,6 +4394,8 @@ pub async fn fetch_bangumi_info(app: &AppHandle, ep_id: i64) -> Result<Video, St
 
     // Apply title replacement to main title
     let sanitized_title = apply_title_replacements(&result.title, replacements);
+
+    fill_default_part_titles(&mut parts, &sanitized_title, omit_duplicate);
 
     Ok(Video {
         title: sanitized_title,

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -77,6 +77,11 @@ pub struct VideoPart {
     /// Sanitized part name with special character replacement and duplicate avoidance (for download filename)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sanitized_part: Option<String>,
+    /// Default download filename combining the sanitized video title and
+    /// part name. When they match (trim-exact), the part name is omitted
+    /// per the `omitDuplicatePartTitle` setting.
+    #[serde(default)]
+    pub default_title: String,
     pub duration: i64,
     pub thumbnail: Thumbnail,
     pub video_qualities: Vec<Quality>,
@@ -283,6 +288,7 @@ mod tests {
                 page: 1,
                 part: "P1".into(),
                 sanitized_part: None,
+                default_title: "t P1".into(),
                 duration: 60,
                 thumbnail: Thumbnail {
                     url: "http://thumb".into(),
@@ -326,6 +332,7 @@ mod tests {
         let part = &out["parts"][0];
         assert_eq!(part["cid"], 11);
         assert_eq!(part["sanitizedPart"], serde_json::Value::Null);
+        assert_eq!(part["defaultTitle"], "t P1");
         assert_eq!(part["subtitles"][0]["subtitleUrl"], "http://sub.bcc");
         assert_eq!(part["subtitles"][0]["aiType"], 0);
 
@@ -350,6 +357,8 @@ mod tests {
         assert!(video.season_title.is_none());
         assert!(video.parts[0].subtitles.is_empty());
         assert!(video.parts[0].sanitized_part.is_none());
+        // default_title falls back to an empty string when absent
+        assert_eq!(video.parts[0].default_title, "");
     }
 
     #[test]

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -122,6 +122,14 @@ pub struct Settings {
         skip_serializing_if = "Option::is_none"
     )]
     pub auto_rename_duplicates: Option<bool>,
+    /// Whether to omit the part name in the default download filename when
+    /// it matches the video title. Defaults to true.
+    #[serde(
+        rename = "omitDuplicatePartTitle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub omit_duplicate_part_title: Option<bool>,
     /// Whether to show GitHub stars in the app bar. Defaults to true.
     #[serde(
         rename = "showGithubStars",

--- a/src-tauri/src/utils/sanitize.rs
+++ b/src-tauri/src/utils/sanitize.rs
@@ -72,6 +72,52 @@ pub fn resolve_duplicate_titles(titles: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Builds the default download filename for a part from the sanitized
+/// video title and part name.
+///
+/// When `omit_duplicate` is true and the two sanitized strings match after
+/// trimming surrounding whitespace, the part name is omitted so the
+/// filename does not repeat the title (e.g., "My Song My Song"). Otherwise
+/// the filename is `"{title} {part}"`.
+///
+/// Why trim comparison: bilibili sometimes returns part names that equal the
+/// video title except for surrounding whitespace, which previously defeated
+/// the frontend's strict-equality check.
+///
+/// # Arguments
+///
+/// * `sanitized_title` - Sanitized video title
+/// * `sanitized_part` - Sanitized part name (after duplicate-title suffixing)
+/// * `omit_duplicate` - Whether to omit a part name identical to the title
+///
+/// # Returns
+///
+/// The default download filename for the part.
+///
+/// # Examples
+///
+/// Why: doctests compile as separate crates, so bare/unqualified item names do not
+/// resolve — import via the lib crate name (this PR's doctest policy)
+/// ```
+/// use bilibili_downloader_gui_lib::utils::sanitize::build_default_part_title;
+///
+/// assert_eq!(build_default_part_title("My Song", "My Song", true), "My Song");
+/// assert_eq!(build_default_part_title("My Song", " My Song ", true), "My Song");
+/// assert_eq!(build_default_part_title("My Song", "My Song", false), "My Song My Song");
+/// assert_eq!(build_default_part_title("My Song", "Cover", true), "My Song Cover");
+/// ```
+pub fn build_default_part_title(
+    sanitized_title: &str,
+    sanitized_part: &str,
+    omit_duplicate: bool,
+) -> String {
+    if omit_duplicate && sanitized_title.trim() == sanitized_part.trim() {
+        sanitized_title.to_string()
+    } else {
+        format!("{} {}", sanitized_title, sanitized_part)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,5 +225,40 @@ mod tests {
         let titles = vec!["single".to_string()];
         let result = resolve_duplicate_titles(&titles);
         assert_eq!(result, vec!["single".to_string()]);
+    }
+
+    #[test]
+    fn test_build_default_part_title_omits_matching_part() {
+        // Identical sanitized strings -> title only
+        assert_eq!(
+            build_default_part_title("My Song", "My Song", true),
+            "My Song"
+        );
+        // Surrounding whitespace is ignored
+        assert_eq!(
+            build_default_part_title("My Song", " My Song ", true),
+            "My Song"
+        );
+    }
+
+    #[test]
+    fn test_build_default_part_title_combines_when_different() {
+        assert_eq!(
+            build_default_part_title("My Song", "Cover", true),
+            "My Song Cover"
+        );
+        // Inner whitespace difference is NOT trimmed
+        assert_eq!(
+            build_default_part_title("My Song", "My  Song", true),
+            "My Song My  Song"
+        );
+    }
+
+    #[test]
+    fn test_build_default_part_title_setting_off_always_combines() {
+        assert_eq!(
+            build_default_part_title("My Song", "My Song", false),
+            "My Song My Song"
+        );
     }
 }

--- a/src/features/settings/dialog/SettingsForm.test.tsx
+++ b/src/features/settings/dialog/SettingsForm.test.tsx
@@ -457,6 +457,10 @@ describe('SettingsForm', () => {
     ['settings.skip_splash_animation_label', { skipSplashAnimation: true }],
     ['settings.taskbar_progress_label', { showTaskbarProgress: false }],
     [
+      'settings.omit_duplicate_part_title_label',
+      { omitDuplicatePartTitle: false },
+    ],
+    [
       'settings.flash_taskbar_on_complete_label',
       { flashTaskbarOnComplete: false },
     ],

--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -587,6 +587,27 @@ function SettingsForm() {
           </RadioGroup>
         </div>
         <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>{t('settings.omit_duplicate_part_title_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.omit_duplicate_part_title_description')}
+            </p>
+          </div>
+          {/* Constraint: the `?? true` default must stay in sync with the Rust
+              default (`unwrap_or(true)` in fetch_video_info /
+              fetch_bangumi_info); a divergence would make the toggle display a
+              state the backend does not implement. */}
+          <Switch
+            checked={settings.omitDuplicatePartTitle ?? true}
+            onCheckedChange={(checked) => {
+              saveByForm({ omitDuplicatePartTitle: checked })
+              // Clear video cache so new setting applies on next fetch
+              store.dispatch(videoApi.util.resetApiState())
+            }}
+          />
+        </div>
+        <Separator />
         <TitleReplacementSettings />
         <Separator />
         <div className="space-y-2">

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -16,6 +16,7 @@ const initialState: SettingsState = {
   language: 'en',
   dialogOpen: false,
   autoRenameDuplicates: true,
+  omitDuplicatePartTitle: true,
   showGithubStars: true,
   fontSize: FONT_SIZE_DEFAULT,
   trimMode: 'copy',

--- a/src/features/settings/type.ts
+++ b/src/features/settings/type.ts
@@ -47,6 +47,12 @@ export interface Settings {
    */
   autoRenameDuplicates?: boolean
   /**
+   * Whether to omit the part name in the default download filename when it
+   * matches the video title (trim-exact comparison of sanitized strings).
+   * Defaults to true if not specified.
+   */
+  omitDuplicatePartTitle?: boolean
+  /**
    * Whether to show GitHub stars in the app bar.
    *
    * Defaults to true if not specified.

--- a/src/features/video/context/VideoInfoContext.test.tsx
+++ b/src/features/video/context/VideoInfoContext.test.tsx
@@ -52,6 +52,7 @@ function partOf(overrides: Partial<Video['parts'][number]>) {
   return {
     part: 'Part 1',
     sanitizedPart: 'Part 1',
+    defaultTitle: 'Test Video Part 1',
     page: 1,
     cid: 100,
     duration: 60,
@@ -70,7 +71,13 @@ const videoPayload: Video = {
   contentType: 'video',
   parts: [
     partOf({ page: 1, cid: 100, part: 'Part 1', sanitizedPart: 'Part 1' }),
-    partOf({ page: 2, cid: 200, part: 'Part 2', sanitizedPart: 'Part 2' }),
+    partOf({
+      page: 2,
+      cid: 200,
+      part: 'Part 2',
+      sanitizedPart: 'Part 2',
+      defaultTitle: 'Test Video Part 2',
+    }),
   ],
 }
 
@@ -85,6 +92,7 @@ const bangumiPayload: Video = {
       epId: 3051842,
       part: 'Episode 1',
       sanitizedPart: 'Episode 1',
+      defaultTitle: 'Test Video Episode 1',
     }),
     partOf({
       page: 2,
@@ -92,6 +100,7 @@ const bangumiPayload: Video = {
       epId: 3051843,
       part: 'Episode 2',
       sanitizedPart: 'Episode 2',
+      defaultTitle: 'Test Video Episode 2',
     }),
   ],
 }
@@ -165,6 +174,33 @@ describe('onValid1', () => {
     expect(parts[0]?.subtitle).toEqual({ mode: 'off', selectedLans: [] })
     expect(ctx.isForm1Valid).toBe(true)
     expect(ctx.isFetching).toBe(false)
+  })
+
+  it('uses the backend default title without duplicating a matching part name', async () => {
+    // Part name identical to the video title; the backend omits the
+    // duplication from defaultTitle (omitDuplicatePartTitle setting).
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'fetch_video_info')
+        return Promise.resolve({
+          ...videoPayload,
+          parts: [
+            partOf({
+              part: 'Test Video',
+              sanitizedPart: 'Test Video',
+              defaultTitle: 'Test Video',
+            }),
+          ],
+        })
+      return Promise.resolve(undefined)
+    })
+
+    renderProvider()
+
+    await act(async () => {
+      await ctx.onValid1(VIDEO_URL)
+    })
+
+    expect(store.getState().input.partInputs[0]?.title).toBe('Test Video')
   })
 
   it('selects only the ?p= part for a part URL', async () => {

--- a/src/features/video/context/VideoInfoContext.tsx
+++ b/src/features/video/context/VideoInfoContext.tsx
@@ -169,10 +169,13 @@ export function VideoInfoProvider({ children }: VideoInfoProviderProps) {
     const partInputs = v.parts.map((p, index) => ({
       cid: p.cid,
       page: p.page,
-      title:
-        v.title === p.part
-          ? v.title
-          : `${v.title} ${p.sanitizedPart ?? p.part}`,
+      // Why: the previous inline `v.title === p.part` check compared the
+      // sanitized title against the raw part name, so title-replacement rules
+      // (issue #233) broke the match and filenames came out as "Title Title".
+      // The backend now owns the assembly (build_default_part_title in
+      // src-tauri/src/utils/sanitize.rs) — FE stays presentation-only.
+      // Filename precomputed by the backend (dedup vs video title included)
+      title: p.defaultTitle,
       videoQuality: '',
       audioQuality: '',
       selected: shouldSelectPart(p, index, {

--- a/src/features/video/lib/partSelection.test.ts
+++ b/src/features/video/lib/partSelection.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 /** Minimal VideoPart factory for tests. */
 const makePart = (overrides: Partial<VideoPart> = {}): VideoPart => ({
   part: 'Part',
+  defaultTitle: 'Part',
   page: 1,
   cid: 100,
   duration: 60,

--- a/src/features/video/model/videoSlice.test.ts
+++ b/src/features/video/model/videoSlice.test.ts
@@ -18,6 +18,7 @@ const video: Video = {
   parts: [
     {
       part: 'Part 1',
+      defaultTitle: 'Test Video Part 1',
       page: 1,
       cid: 123,
       duration: 120,

--- a/src/features/video/types.ts
+++ b/src/features/video/types.ts
@@ -104,6 +104,12 @@ export type VideoPart = {
   part: string
   /** Sanitized part name with special character replacement and duplicate avoidance (for download filename) */
   sanitizedPart?: string
+  /**
+   * Default download filename combining the sanitized video title and part
+   * name. When they match (trim-exact), the part name is omitted per the
+   * `omitDuplicatePartTitle` setting.
+   */
+  defaultTitle: string
   /** Page number (1-indexed) */
   page: number
   /** Part CID (unique identifier) */

--- a/src/features/video/ui/VideoPartCard.test.tsx
+++ b/src/features/video/ui/VideoPartCard.test.tsx
@@ -56,6 +56,7 @@ const video: Video = {
   parts: [
     {
       part: 'Part 1',
+      defaultTitle: 'My Video Part 1',
       page: 1,
       cid: 111,
       duration: 125,
@@ -170,7 +171,7 @@ const shortVideo: Video = {
 /** Single part whose name equals the video title. */
 const sameTitleVideo: Video = {
   ...video,
-  parts: [{ ...video.parts[0]!, part: 'My Video' }],
+  parts: [{ ...video.parts[0]!, part: 'My Video', defaultTitle: 'My Video' }],
 }
 
 /** Bangumi episode with an epId (qualities load per-episode). */

--- a/src/features/video/ui/VideoPartCard.tsx
+++ b/src/features/video/ui/VideoPartCard.tsx
@@ -84,36 +84,6 @@ type Props = {
   isDuplicate?: boolean
 }
 
-/**
- * Computes the default title for a video part.
- *
- * Returns the video title for single-part videos, or combines video
- * title with part name for multi-part videos. Uses sanitizedPart if
- * available (for download filename), falls back to the original part name.
- *
- * @param video - The video object containing title and parts
- * @param videoPart - The specific video part with part name and optional sanitized name
- * @returns The computed default title string
- *
- * @example
- * ```typescript
- * const video = { title: "My Video", parts: [...] };
- * const part = { part: "Episode 1", sanitizedPart: "Episode 1" };
- * computeDefaultTitle(video, part); // "My Video Episode 1"
- * ```
- */
-function computeDefaultTitle(
-  video: Video,
-  videoPart: { part: string; sanitizedPart?: string },
-): string {
-  const hasValidParts = video?.parts.length && video.parts[0].cid !== 0
-  if (!hasValidParts) return ''
-  const displayName = videoPart.sanitizedPart ?? videoPart.part
-  return video.title === videoPart.part
-    ? video.title
-    : `${video.title} ${displayName}`
-}
-
 /** Props for the UnavailableEpisodeWarning component. */
 type UnavailableEpisodeWarningProps = {
   /** Episode status code. 13 = VIP-only, others = unavailable. */
@@ -588,10 +558,13 @@ const VideoPartCard = memo(function VideoPartCard({
 
   const schema2 = useMemo(() => buildVideoFormSchema2(t), [t])
 
-  const initialTitle = useMemo(
-    () => partInput?.title ?? computeDefaultTitle(video, videoPart),
-    [partInput?.title, video, videoPart],
-  )
+  // Why: defaultTitle is assembled by the backend (build_default_part_title in
+  // src-tauri/src/utils/sanitize.rs, honoring omitDuplicatePartTitle). Do not
+  // re-derive it here: the removed computeDefaultTitle compared the sanitized
+  // title against the raw part name and missed real duplicates.
+  // Plain const: defaultValues are only read on mount, and strings have
+  // no referential identity for useMemo to preserve.
+  const initialTitle = partInput?.title ?? videoPart.defaultTitle
 
   const form = useForm<z.infer<typeof schema2>>({
     resolver: zodResolver(schema2),
@@ -605,7 +578,7 @@ const VideoPartCard = memo(function VideoPartCard({
   useEffect(() => {
     if (!video || video.parts.length === 0 || video.parts[0].cid === 0) return
 
-    const title = partInput?.title ?? computeDefaultTitle(video, videoPart)
+    const title = partInput?.title ?? videoPart.defaultTitle
     form.setValue('title', title, { shouldValidate: true })
   }, [video, partInput?.title, form, videoPart])
 
@@ -624,8 +597,7 @@ const VideoPartCard = memo(function VideoPartCard({
     const needsVideoQuality = !partInput?.videoQuality
     const needsAudioQuality = hasAudioQualities && !partInput?.audioQuality
     if (needsVideoQuality || needsAudioQuality) {
-      const title =
-        partInput?.title ?? videoPart.sanitizedPart ?? videoPart.part
+      const title = partInput?.title ?? videoPart.defaultTitle
       form.trigger().then((isValid) => {
         if (isValid) {
           onValid2(page - 1, title, videoQuality, audioQuality)
@@ -641,8 +613,7 @@ const VideoPartCard = memo(function VideoPartCard({
     form,
     onValid2,
     page,
-    videoPart.sanitizedPart,
-    videoPart.part,
+    videoPart.defaultTitle,
   ])
 
   /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "Auto-rename duplicate parts",
     "auto_rename_duplicates_description": "Automatically add numbers when parts have the same name (e.g., Part Name → Part Name (1))",
+    "omit_duplicate_part_title_label": "Omit duplicate part name",
+    "omit_duplicate_part_title_description": "When a part name matches the video title, the download filename uses the title alone instead of repeating it (e.g., Title Title → Title)",
     "title_replacement": {
       "section_label": "Title Character Replacement",
       "description": "Customize how special characters in video titles are replaced in filenames.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "Renombrar automáticamente partes duplicadas",
     "auto_rename_duplicates_description": "Añade números automáticamente cuando las partes tienen el mismo nombre (ej: Nombre → Nombre (1))",
+    "omit_duplicate_part_title_label": "Omitir nombre de parte duplicado",
+    "omit_duplicate_part_title_description": "Cuando el nombre de una parte coincide con el título del video, el nombre del archivo evita repetirlo (p. ej., Título Título → Título)",
     "title_replacement": {
       "section_label": "Reemplazo de caracteres del título",
       "description": "Personaliza cómo los caracteres especiales en los títulos de videos se reemplazan en los nombres de archivo.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "Renommer automatiquement les parties dupliquées",
     "auto_rename_duplicates_description": "Ajoute automatiquement des numéros quand les parties ont le même nom (ex: Nom → Nom (1))",
+    "omit_duplicate_part_title_label": "Omettre le nom de partie dupliqué",
+    "omit_duplicate_part_title_description": "Quand le nom d'une partie est identique au titre de la vidéo, le nom de fichier téléchargé évite de le répéter (p. ex., Titre Titre → Titre)",
     "title_replacement": {
       "section_label": "Remplacement de caractères du titre",
       "description": "Personnalisez comment les caractères spéciaux dans les titres de vidéos sont remplacés dans les noms de fichiers.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "重複パート名を自動リネーム",
     "auto_rename_duplicates_description": "同じ名前のパートがある場合、自動で番号を付与します（例: パート名 → パート名 (1)）",
+    "omit_duplicate_part_title_label": "重複パート名を省略",
+    "omit_duplicate_part_title_description": "パート名が動画タイトルと同一の場合、ダウンロードファイル名の重複を省略します（例: タイトル タイトル → タイトル）",
     "title_replacement": {
       "section_label": "タイトル文字置換",
       "description": "動画タイトルに含まれる特殊文字をファイル名でどのように置換するか設定します。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "중복 파트 이름 자동 변경",
     "auto_rename_duplicates_description": "같은 이름의 파트가 있을 때 자동으로 번호를 추가합니다 (예: 파트 이름 → 파트 이름 (1))",
+    "omit_duplicate_part_title_label": "중복 파트명 생략",
+    "omit_duplicate_part_title_description": "파트 이름이 영상 제목과 같으면 다운로드 파일명에 중복을 생략합니다 (예: 제목 제목 → 제목)",
     "title_replacement": {
       "section_label": "제목 문자 치환",
       "description": "비디오 제목의 특수 문자가 파일명에서 어떻게 치환되는지 사용자 정의합니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -440,6 +440,8 @@
     },
     "auto_rename_duplicates_label": "自动重命名重复分P",
     "auto_rename_duplicates_description": "当分P名称相同时自动添加编号（例如：分P名称 → 分P名称 (1)）",
+    "omit_duplicate_part_title_label": "省略重复分P名",
+    "omit_duplicate_part_title_description": "当分P名与视频标题相同时，下载文件名不再重复拼接（例如：标题 标题 → 标题）",
     "title_replacement": {
       "section_label": "标题字符替换",
       "description": "自定义视频标题中的特殊字符在文件名中如何替换。",

--- a/src/pages/home/index.test.tsx
+++ b/src/pages/home/index.test.tsx
@@ -44,6 +44,7 @@ const initialInput = {
 function makePart(index: number): VideoPart {
   return {
     part: `Part ${index + 1}`,
+    defaultTitle: `Test Video Part ${index + 1}`,
     page: index + 1,
     cid: 1000 + index,
     duration: 60,


### PR DESCRIPTION
## Summary

- Add a new `omitDuplicatePartTitle` setting (default: on). When a part (page/episode) name equals the video title, the default download filename no longer repeats it (e.g. `Title Title` → `Title`)
- Move the default filename assembly into the Rust backend: `build_default_part_title` computes a `defaultTitle` per `VideoPart` with a **trim-exact comparison of sanitized strings**, run **after** `resolve_duplicate_titles` suffixing so suffixed parts (e.g. `Title (1)`) still combine correctly
- Remove the duplicated frontend logic (`computeDefaultTitle` and the inline ternary in `initInputsForVideo`); the frontend now consumes `partInput.title ?? videoPart.defaultTitle` (presentation-only)
- Applies to both video and bangumi paths
- Settings switch is placed immediately before the Title Character Replacement section and resets the video cache on change

## Why the old check failed

The previous frontend-only check compared the **sanitized** video title against the **raw** part name, so:

- title-replacement rules (e.g. `:` → `_`) broke the match, producing `Title Title` filenames, and
- part names equal to the title except surrounding whitespace also slipped through

## Testing

- Rust: unit tests for `build_default_part_title` (match / trim-diff / setting-off), updated `web_interface_data_to_video` tests (single-part fallback, suffix interaction, trim match, omission off), doctest — `cargo test` green (333 + doctests)
- Frontend: switch persistence row in `SettingsForm.test.tsx`, backend-title consumption tests in `VideoInfoContext.test.tsx`, all `VideoPart` fixtures updated — `npm test` green (143 files / 1185 tests)
- `npm run typecheck`, `npm run lint`, `cargo build`, `cargo clippy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)