### PR TITLE
docs(settings): describe off-state behavior of part-name settings

### DIFF
--- a/src/features/settings/dialog/SettingsForm.tsx
+++ b/src/features/settings/dialog/SettingsForm.tsx
@@ -529,23 +529,6 @@ function SettingsForm() {
           )}
         />
         <Separator />
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label>{t('settings.auto_rename_duplicates_label')}</Label>
-            <p className="text-muted-foreground text-sm">
-              {t('settings.auto_rename_duplicates_description')}
-            </p>
-          </div>
-          <Switch
-            checked={settings.autoRenameDuplicates ?? true}
-            onCheckedChange={(checked) => {
-              saveByForm({ autoRenameDuplicates: checked })
-              // Clear video cache so new setting applies on next fetch
-              store.dispatch(videoApi.util.resetApiState())
-            }}
-          />
-        </div>
-        <Separator />
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <Label>{t('settings.download_parallelism_label')}</Label>
@@ -585,6 +568,23 @@ function SettingsForm() {
               </div>
             ))}
           </RadioGroup>
+        </div>
+        <Separator />
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label>{t('settings.auto_rename_duplicates_label')}</Label>
+            <p className="text-muted-foreground text-sm">
+              {t('settings.auto_rename_duplicates_description')}
+            </p>
+          </div>
+          <Switch
+            checked={settings.autoRenameDuplicates ?? true}
+            onCheckedChange={(checked) => {
+              saveByForm({ autoRenameDuplicates: checked })
+              // Clear video cache so new setting applies on next fetch
+              store.dispatch(videoApi.util.resetApiState())
+            }}
+          />
         </div>
         <Separator />
         <div className="flex items-center justify-between">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "When enabled, the app behaves as if you are not logged in (for testing purposes)."
     },
     "auto_rename_duplicates_label": "Auto-rename duplicate parts",
-    "auto_rename_duplicates_description": "Automatically add numbers when parts have the same name (e.g., Part Name → Part Name (1))",
+    "auto_rename_duplicates_description": "Adds numbers to parts with the same name (e.g., Part Name → Part Name (1)). When off, duplicate part names are shown as-is and only renamed at save time if needed to avoid file collisions",
     "omit_duplicate_part_title_label": "Omit duplicate part name",
-    "omit_duplicate_part_title_description": "When a part name matches the video title, the download filename uses the title alone instead of repeating it (e.g., Title Title → Title)",
+    "omit_duplicate_part_title_description": "When a part name matches the video title, the download filename omits the repetition (e.g., Title Title → Title). When off, the filename keeps the \"Title Part Name\" form",
     "title_replacement": {
       "section_label": "Title Character Replacement",
       "description": "Customize how special characters in video titles are replaced in filenames.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "Cuando está habilitado, la aplicación funciona como si no hubieras iniciado sesión (para pruebas)."
     },
     "auto_rename_duplicates_label": "Renombrar automáticamente partes duplicadas",
-    "auto_rename_duplicates_description": "Añade números automáticamente cuando las partes tienen el mismo nombre (ej: Nombre → Nombre (1))",
+    "auto_rename_duplicates_description": "Añade números automáticamente cuando las partes tienen el mismo nombre (ej: Nombre → Nombre (1)). Desactivado, los nombres duplicados se muestran tal cual y solo se renombran al guardar si es necesario para evitar colisiones de archivos",
     "omit_duplicate_part_title_label": "Omitir nombre de parte duplicado",
-    "omit_duplicate_part_title_description": "Cuando el nombre de una parte coincide con el título del video, el nombre del archivo evita repetirlo (p. ej., Título Título → Título)",
+    "omit_duplicate_part_title_description": "Cuando el nombre de una parte coincide con el título del video, el nombre del archivo evita repetirlo (p. ej., Título Título → Título). Desactivado, el nombre conserva la forma «Título Nombre de la parte»",
     "title_replacement": {
       "section_label": "Reemplazo de caracteres del título",
       "description": "Personaliza cómo los caracteres especiales en los títulos de videos se reemplazan en los nombres de archivo.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "Lorsqu'activé, l'application se comporte comme si vous n'étiez pas connecté (à des fins de test)."
     },
     "auto_rename_duplicates_label": "Renommer automatiquement les parties dupliquées",
-    "auto_rename_duplicates_description": "Ajoute automatiquement des numéros quand les parties ont le même nom (ex: Nom → Nom (1))",
+    "auto_rename_duplicates_description": "Ajoute automatiquement des numéros quand les parties ont le même nom (ex: Nom → Nom (1)). Désactivé, les noms dupliqués s'affichent tels quels et ne sont renommés qu'à l'enregistrement si nécessaire pour éviter les collisions de fichiers",
     "omit_duplicate_part_title_label": "Omettre le nom de partie dupliqué",
-    "omit_duplicate_part_title_description": "Quand le nom d'une partie est identique au titre de la vidéo, le nom de fichier téléchargé évite de le répéter (p. ex., Titre Titre → Titre)",
+    "omit_duplicate_part_title_description": "Quand le nom d'une partie est identique au titre de la vidéo, le nom de fichier téléchargé évite de le répéter (p. ex., Titre Titre → Titre). Désactivé, le nom conserve la forme « Titre Nom de la partie »",
     "title_replacement": {
       "section_label": "Remplacement de caractères du titre",
       "description": "Personnalisez comment les caractères spéciaux dans les titres de vidéos sont remplacés dans les noms de fichiers.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "有効にすると、アプリはログインしていない状態として動作します（テスト用）。"
     },
     "auto_rename_duplicates_label": "重複パート名を自動リネーム",
-    "auto_rename_duplicates_description": "同じ名前のパートがある場合、自動で番号を付与します（例: パート名 → パート名 (1)）",
+    "auto_rename_duplicates_description": "同じ名前のパートに番号を付与します（例: パート名 → パート名 (1)）。オフの場合はパート名が重複したまま表示され、保存時に同名ファイルとの衝突を避けるため必要に応じて別名になります",
     "omit_duplicate_part_title_label": "重複パート名を省略",
-    "omit_duplicate_part_title_description": "パート名が動画タイトルと同一の場合、ダウンロードファイル名の重複を省略します（例: タイトル タイトル → タイトル）",
+    "omit_duplicate_part_title_description": "パート名が動画タイトルと同一の場合、ダウンロードファイル名の重複を省略します（例: タイトル タイトル → タイトル）。オフの場合は「タイトル パート名」の形式のままになります",
     "title_replacement": {
       "section_label": "タイトル文字置換",
       "description": "動画タイトルに含まれる特殊文字をファイル名でどのように置換するか設定します。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "활성화하면 앱이 로그인하지 않은 상태로 실행됩니다(테스트용)."
     },
     "auto_rename_duplicates_label": "중복 파트 이름 자동 변경",
-    "auto_rename_duplicates_description": "같은 이름의 파트가 있을 때 자동으로 번호를 추가합니다 (예: 파트 이름 → 파트 이름 (1))",
+    "auto_rename_duplicates_description": "같은 이름의 파트가 있을 때 자동으로 번호를 추가합니다 (예: 파트 이름 → 파트 이름 (1)). 끄면 파트 이름이 중복된 채로 표시되며, 저장 시 동일한 파일명과의 충돌을 피하기 위해 필요한 경우에만 다른 이름으로 저장됩니다",
     "omit_duplicate_part_title_label": "중복 파트명 생략",
-    "omit_duplicate_part_title_description": "파트 이름이 영상 제목과 같으면 다운로드 파일명에 중복을 생략합니다 (예: 제목 제목 → 제목)",
+    "omit_duplicate_part_title_description": "파트 이름이 영상 제목과 같으면 다운로드 파일명에 중복을 생략합니다 (예: 제목 제목 → 제목). 끄면 '제목 파트 이름' 형식이 그대로 유지됩니다",
     "title_replacement": {
       "section_label": "제목 문자 치환",
       "description": "비디오 제목의 특수 문자가 파일명에서 어떻게 치환되는지 사용자 정의합니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -439,9 +439,9 @@
       "simulate_logout_description": "启用后，应用将以未登录状态运行（用于测试）。"
     },
     "auto_rename_duplicates_label": "自动重命名重复分P",
-    "auto_rename_duplicates_description": "当分P名称相同时自动添加编号（例如：分P名称 → 分P名称 (1)）",
+    "auto_rename_duplicates_description": "当分P名称相同时自动添加编号（例如：分P名称 → 分P名称 (1)）。关闭时，分P名称保持重复显示，仅在保存时为避免同名文件冲突而按需改名",
     "omit_duplicate_part_title_label": "省略重复分P名",
-    "omit_duplicate_part_title_description": "当分P名与视频标题相同时，下载文件名不再重复拼接（例如：标题 标题 → 标题）",
+    "omit_duplicate_part_title_description": "当分P名与视频标题相同时，下载文件名不再重复拼接（例如：标题 标题 → 标题）。关闭时，文件名保持「标题 分P名」的形式",
     "title_replacement": {
       "section_label": "标题字符替换",
       "description": "自定义视频标题中的特殊字符在文件名中如何替换。",


### PR DESCRIPTION
## Summary

- Append what happens when each toggle is **off** to the `autoRenameDuplicates` and `omitDuplicatePartTitle` setting descriptions (all 6 locales), since the previous copy only described the on-state
  - `autoRenameDuplicates` off: duplicate part names are shown as-is and only renamed at save time if needed to avoid file collisions (backend `reserve_output_path` behavior)
  - `omitDuplicatePartTitle` off: the filename keeps the "Title Part Name" form
- Move the `autoRenameDuplicates` settings block adjacent to `omitDuplicatePartTitle` so the two related part-name settings sit together (full settings-screen reorganization is tracked in #398)

## Related Issue

None (partial overlap with #398 for placement, but the full categorization stays there)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `npm run lint` / `npm run typecheck` clean
- [x] `npm test` — 143 files / 1185 tests pass (incl. i18n key-parity test)
- [x] Manually verified in `npm run tauri dev`: the two part-name settings render adjacent after "Download parallelism", and both descriptions show the off-state sentence in the switched language

## Screenshots / Videos (Optional)

N/A (text-only change)

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)