### PR TITLE
fix(notifications): show merge-fallback toast only once per download

### DIFF
--- a/src/app/providers/ListenerContext.test.tsx
+++ b/src/app/providers/ListenerContext.test.tsx
@@ -108,31 +108,31 @@ describe('progress event', () => {
     expect(queue().find((q) => q.downloadId === 'd1')!.status).toBe('pending')
   })
 
-  it('merge-fallback stage shows the audio-merge-fallback toast', async () => {
+  it('merge-fallback stage shows the audio-merge-fallback toast once', async () => {
     await mount()
     act(() => {
       emitTauriEvent('progress', { ...progressBase, stage: 'merge-fallback' })
     })
+    expect(toast.info).toHaveBeenCalledTimes(1)
     expect(toast.info).toHaveBeenCalledWith('video.audio_merge_fallback', {
       duration: 6000,
     })
   })
 
-  it.each(['warn-video-quality-fallback', 'warn-audio-quality-fallback'])(
-    '%s shows the matching warning toast',
-    async (stage) => {
-      await mount()
-      act(() => {
-        emitTauriEvent('progress', { ...progressBase, stage })
+  it('repeated merge-fallback progress events do not re-toast (issue #586)', async () => {
+    await mount()
+    // The backend ticker re-emits stage="merge-fallback" every 500ms during
+    // the whole AAC re-encode; only the first event may toast.
+    act(() => {
+      emitTauriEvent('progress', { ...progressBase, stage: 'merge-fallback' })
+      emitTauriEvent('progress', {
+        ...progressBase,
+        stage: 'merge-fallback',
+        percentage: 20,
       })
-      expect(toast.warning).toHaveBeenCalledWith(
-        stage.startsWith('warn-video')
-          ? 'video.video_quality_fallback'
-          : 'video.audio_quality_fallback',
-        { duration: 6000 },
-      )
-    },
-  )
+    })
+    expect(toast.info).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('history:entry_added', () => {

--- a/src/app/providers/ListenerContext.tsx
+++ b/src/app/providers/ListenerContext.tsx
@@ -67,7 +67,7 @@ const ListenerContext = createContext<boolean>(false)
  *
  * Sets up listeners for events emitted from the Tauri Rust backend:
  * - `progress` - Download progress updates dispatched to Redux state,
- *   with toast notifications for quality fallback warnings
+ *   with a one-time toast notification for the AAC merge fallback
  * - `history:entry_added` - New history entries dispatched to Redux state
  * - `download_cancelled` - Clears queue items and progress, shows info toast
  * - `download-quality-resolved` - Updates resolved video/audio quality in state
@@ -101,6 +101,27 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
       unlistenProgress = await listen('progress', (event) => {
         const payload = event.payload as Progress
         const { stage, downloadId } = payload
+
+        // Why: `set_stage("merge-fallback")` persists the stage in the
+        //   backend progress state, so the 500ms progress ticker re-emits
+        //   stage="merge-fallback" for the whole AAC re-encode (issue #586).
+        //   Detect the *first* occurrence by checking the store before this
+        //   dispatch creates the `${downloadId}:merge-fallback` entry —
+        //   entry presence means the toast already fired.
+        // Note: the `${downloadId}:${stage}` id format comes from
+        //   computeInternalId in src/shared/progress/progressSlice.ts and is
+        //   duplicated here as a literal — changing it there silently breaks
+        //   this dedupe and the toast spam returns. No other stage maps to
+        //   this id ('complete' reuses `${downloadId}:merge`), so the entry
+        //   survives until clearProgress/clearProgressByDownloadId.
+        const isFirstMergeFallback =
+          stage === 'merge-fallback' &&
+          !store
+            .getState()
+            .progress.some(
+              (p) => p.internalId === `${downloadId}:merge-fallback`,
+            )
+
         store.dispatch(setProgress(payload))
 
         // Update queue status based on progress stage
@@ -114,33 +135,18 @@ export const ListenerProvider: FC<{ children: ReactNode }> = ({ children }) => {
           store.dispatch(updateQueueStatus({ downloadId, status: 'running' }))
         }
 
-        // Why: the backend emits the `merge-fallback` stage (Emits::set_stage
+        // Why: the backend sets the `merge-fallback` stage (Emits::set_stage
         //   in merge_avs, src-tauri/src/handlers/ffmpeg.rs) only when the
         //   fast/lossless `-c:a copy` path fails and it falls back to AAC
         //   re-encoding. Surfacing it as a toast keeps the user informed that
         //   this merge will run slower than the usual stream-copy fast path
-        //   (Issue #492).
-        // Note: this is the merge *codec* fallback, distinct from the *quality*
-        //   fallback handled below (warn-*-quality-fallback), which is about
-        //   the CDN serving a lower-than-requested quality. Keep this stage
-        //   string in sync with the Rust emitter if it is renamed.
-        // Show toast for audio fallback during merge
-        if (stage === 'merge-fallback') {
+        //   (Issue #492). One toast per download is enough — the entry
+        //   persists until cancel/clear, so a retry that falls back again
+        //   stays silent intentionally.
+        // Note: keep this stage string in sync with the Rust emitter if it
+        //   is renamed.
+        if (isFirstMergeFallback) {
           toast.info(i18n.t('video.audio_merge_fallback'), {
-            duration: 6000,
-          })
-        }
-
-        // Show toast for quality fallback warnings
-        const isFallbackWarning =
-          stage === 'warn-video-quality-fallback' ||
-          stage === 'warn-audio-quality-fallback'
-        if (isFallbackWarning) {
-          const key =
-            stage === 'warn-video-quality-fallback'
-              ? 'video.video_quality_fallback'
-              : 'video.audio_quality_fallback'
-          toast.warning(i18n.t(key, { from: 'selected', to: 'fallback' }), {
             duration: 6000,
           })
         }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -221,8 +221,6 @@
     "video_not_found": "Video not found. Please check the URL.",
     "api_error": "Failed to fetch video information.",
     "rate_limited": "Too many requests. Please wait a moment and try again.",
-    "video_quality_fallback": "Selected video quality ({{from}}) unavailable. Using {{to}}.",
-    "audio_quality_fallback": "Selected audio quality ({{from}}) unavailable. Using {{to}}.",
     "audio_merge_fallback": "Audio stream copy failed. Using AAC re-encoding instead.",
     "invalid_media_response": "Invalid media response from server (received error page instead of media).",
     "audio_download_failed": "Failed to download audio after trying all available streams.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -221,8 +221,6 @@
     "video_not_found": "Video no encontrado. Por favor, verifica la URL.",
     "api_error": "Error al obtener información del video.",
     "rate_limited": "Demasiadas solicitudes. Por favor, espere un momento e inténtelo de nuevo.",
-    "video_quality_fallback": "La calidad de video seleccionada ({{from}}) no está disponible. Usando {{to}}.",
-    "audio_quality_fallback": "La calidad de audio seleccionada ({{from}}) no está disponible. Usando {{to}}.",
     "audio_merge_fallback": "La copia del flujo de audio falló. Usando recodificación AAC en su lugar.",
     "invalid_media_response": "Respuesta de medios no válida del servidor (se recibió página de error).",
     "audio_download_failed": "Error al descargar audio después de intentar todas las transmisiones disponibles.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -221,8 +221,6 @@
     "video_not_found": "Vidéo non trouvée. Veuillez vérifier l'URL.",
     "api_error": "Échec de la récupération des informations de la vidéo.",
     "rate_limited": "Trop de requêtes. Veuillez patienter un instant et réessayer.",
-    "video_quality_fallback": "La qualité vidéo sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
-    "audio_quality_fallback": "La qualité audio sélectionnée ({{from}}) est indisponible. Utilisation de {{to}}.",
     "audio_merge_fallback": "La copie du flux audio a échoué. Utilisation du réencodage AAC à la place.",
     "invalid_media_response": "Réponse média non valide du serveur (page d'erreur reçue).",
     "audio_download_failed": "Échec du téléchargement audio après avoir essayé tous les flux disponibles.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -221,8 +221,6 @@
     "video_not_found": "動画が見つかりませんでした。URLを確認してください。",
     "api_error": "動画情報の取得に失敗しました。",
     "rate_limited": "リクエストが多すぎます。しばらく待ってから再試行してください。",
-    "video_quality_fallback": "選択した画質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
-    "audio_quality_fallback": "選択した音質 ({{from}}) が利用できないため {{to}} にフォールバックしました。",
     "audio_merge_fallback": "音声ストリームコピーに失敗しました。AAC再エンコードを使用します。",
     "invalid_media_response": "サーバーから無効なメディア応答がありました（エラーページを受信）。",
     "audio_download_failed": "すべての利用可能なストリームを試しましたが、音声のダウンロードに失敗しました。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -221,8 +221,6 @@
     "video_not_found": "비디오를 찾을 수 없습니다. URL을 확인하세요.",
     "api_error": "비디오 정보를 가져오지 못했습니다.",
     "rate_limited": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
-    "video_quality_fallback": "선택한 화질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
-    "audio_quality_fallback": "선택한 음질 ({{from}}) 을(를) 사용할 수 없어 {{to}} 로 대체했습니다.",
     "audio_merge_fallback": "오디오 스트림 복사에 실패했습니다. AAC 재인코딩을 사용합니다.",
     "invalid_media_response": "서버에서 잘못된 미디어 응답을 받았습니다(오류 페이지 수신).",
     "audio_download_failed": "사용 가능한 모든 스트림을 시도했으나 오디오 다운로드에 실패했습니다.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -222,8 +222,6 @@
     "video_not_found": "未找到视频。请检查链接。",
     "api_error": "获取视频信息失败。",
     "rate_limited": "请求过于频繁，请稍后再试。",
-    "video_quality_fallback": "选定的视频清晰度 ({{from}}) 不可用，已使用 {{to}}。",
-    "audio_quality_fallback": "选定的音频音质 ({{from}}) 不可用，已使用 {{to}}。",
     "audio_merge_fallback": "音频流复制失败，正在使用 AAC 重新编码。",
     "invalid_media_response": "服务器返回了无效的媒体响应（接收到错误页面而非媒体）。",
     "audio_download_failed": "尝试了所有可用流后，音频下载失败。",


### PR DESCRIPTION
## Summary

- Show the AAC merge-fallback toast only once per download. `Emits::set_stage("merge-fallback")` persists the stage in the backend progress state, so the 500ms progress ticker re-emits `stage: "merge-fallback"` for the entire AAC re-encode and the frontend toasted on every event (issue #586)
- Fix: check the Redux store for an existing `${downloadId}:merge-fallback` progress entry **before** dispatching `setProgress` (which creates that entry) and toast only on the first occurrence. No new state; the existing progress slice doubles as the "already notified" flag. A retry that falls back again stays silent intentionally — documented in-code
- Remove the dead `warn-video/audio-quality-fallback` toast branch: the backend stopped emitting those stages in 039f2c3 (quality fallback now surfaces via the `download-quality-resolved` event + warning icon), so the branch could never fire. Also removes its orphaned i18n keys (`video.video_quality_fallback`, `video.audio_quality_fallback`) from all 6 languages

## Related Issue

Closes #586

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `npm run lint` / `npm run typecheck` / `npx prettier --check .` pass
- [x] `npm test` — 1199 passed, including two new cases: first `merge-fallback` event toasts once, and a repeated event does not re-toast
- [x] Manual: normal 1080p download completes with no toast anomalies (stream copy succeeds in practice, so the fallback path itself cannot be triggered without a non-AAC audio source — the dedupe behavior is covered by unit tests instead)
- [ ] i18n 6-locale parity test passes

## Screenshots / Videos (Optional)

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)
