### PR TITLE
🚀 Release v1.56.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilibili-downloader-gui",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "identifier": "com.bilibili-downloader-gui.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Version bump to **v1.56.0** (minor release).

## Highlights (v1.55.0 → v1.56.0)

### ✨ New Features
- Enable 4K / HDR10 / Dolby Vision / 8K downloads for VIP accounts — request all DASH streams via `fnval=4048`/`qn=127` and fix quality ID labels to the official qn table (#585, fixes #584)
- Auto-fetch video info silently after a short pause in URL input (#583)
- GitHub Pages site now features a demo video (#582)

### 🐛 Bug Fixes
- Show the AAC merge-fallback toast only once per download instead of repeating every 500ms during re-encode (#588, fixes #586)
- Calculate download percentage from raw total bytes (#587)

### 📝 Docs
- README demo images refreshed (static screenshot + animated webp)

## Related Issue

N/A (release)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] All merged PRs passed CI individually (#582, #583, #585, #587, #588)
- [x] Version file updated (`src-tauri/tauri.conf.json` 1.55.0 → 1.56.0)

## Breaking Changes

None.

## Checklist

- [ ] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)
