### PR TITLE
refactor(video): drop redundant wts push in WBI query builders

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -2003,7 +2003,16 @@ mod tests {
         // 0.6 has no param-exists matcher and w_rid is a dynamic digest).
         let query = view_req.url.query().unwrap_or_default();
         assert!(query.contains("w_rid="), "query missing w_rid: {query}");
-        assert!(query.contains("wts="), "query missing wts: {query}");
+        // Why: exactly one wts pair — generate_wbi_signature already inserts
+        // wts into `params` (src-tauri/src/utils/wbi.rs), so an extra
+        // query.push would put the pair on the wire twice; wbi endpoints
+        // return v_voucher when wts/w_rid are missing or wrong
+        // (references/bilibili-API-collect/docs/misc/sign/wbi.md)
+        assert_eq!(
+            query.split('&').filter(|p| p.starts_with("wts=")).count(),
+            1,
+            "wts pair must appear exactly once (0 = missing, 2 = duplicated): {query}"
+        );
         server.verify().await;
     }
 
@@ -2958,12 +2967,16 @@ async fn fetch_wbi_view(api: &BiliApi, bvid: &str) -> Result<WebInterfaceApiResp
     let mut params = BTreeMap::from([("bvid".to_string(), bvid.to_string())]);
     let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
 
+    // Why: generate_wbi_signature already inserts wts into `params`
+    // (src-tauri/src/utils/wbi.rs) and this query is built from `params`, so
+    // pushing wts again would send the pair twice; wbi endpoints return
+    // v_voucher when wts/w_rid are missing or wrong
+    // (references/bilibili-API-collect/docs/misc/sign/wbi.md)
     let mut query: Vec<(&str, String)> = params
         .iter()
         .map(|(k, v)| (k.as_str(), v.clone()))
         .collect();
     query.push(("w_rid", signature.w_rid));
-    query.push(("wts", signature.wts));
 
     let body: WebInterfaceApiResponse = api
         .get_q("/x/web-interface/wbi/view", &query)
@@ -3027,12 +3040,16 @@ async fn fetch_video_details(
 
     let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
 
+    // Why: generate_wbi_signature already inserts wts into `params`
+    // (src-tauri/src/utils/wbi.rs) and this query is built from `params`, so
+    // pushing wts again would send the pair twice; wbi endpoints return
+    // v_voucher when wts/w_rid are missing or wrong
+    // (references/bilibili-API-collect/docs/misc/sign/wbi.md)
     let mut query: Vec<(&str, String)> = params
         .iter()
         .map(|(k, v)| (k.as_str(), v.clone()))
         .collect();
-    query.push(("w_rid", signature.w_rid.clone()));
-    query.push(("wts", signature.wts.clone()));
+    query.push(("w_rid", signature.w_rid));
 
     let body: XPlayerApiResponse = api
         .get_q("/x/player/wbi/playurl", &query)
@@ -3884,12 +3901,16 @@ pub async fn fetch_subtitles(
     ]);
     let signature = crate::utils::wbi::generate_wbi_signature(&mut params, &mixin_key);
 
+    // Why: generate_wbi_signature already inserts wts into `params`
+    // (src-tauri/src/utils/wbi.rs) and this query is built from `params`, so
+    // pushing wts again would send the pair twice; wbi endpoints return
+    // v_voucher when wts/w_rid are missing or wrong
+    // (references/bilibili-API-collect/docs/misc/sign/wbi.md)
     let mut query: Vec<(&str, String)> = params
         .iter()
         .map(|(k, v)| (k.as_str(), v.clone()))
         .collect();
     query.push(("w_rid", signature.w_rid));
-    query.push(("wts", signature.wts));
 
     // Transport errors (send failure or non-2xx status) both soft-fail here.
     let response = match BiliApi::new(Client::clone(client), API_BASE, cookie_header)


### PR DESCRIPTION
## Summary

`generate_wbi_signature` already inserts `wts` into the params map, and the query vec is built from that map afterwards — so the explicit `query.push(("wts", ...))` in `fetch_wbi_view`, `fetch_video_details` and `fetch_subtitles` sent the pair **twice** on the wire (identical values, tolerated by the server).

Follow-up cleanup to #592. Removes the duplicate pushes in all three sites (the only non-test `generate_wbi_signature` callers) and guards the contract with an "exactly one `wts=` pair" assertion in the wiremock test. WBI endpoints return `v_voucher` when `wts`/`w_rid` are missing or wrong (`references/bilibili-API-collect/docs/misc/sign/wbi.md`), which is why the wire query must match the signed param set exactly.

## Related Issue

None (cleanup noted in review of #592)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring

## Test Plan

- [x] `cargo test` (346+11 pass; the logged-out wiremock test now asserts exactly one `wts` pair)
- [x] `cargo clippy` clean, `cargo fmt` applied
- [x] Manual: verified logged-in and logged-out downloads + merges in app.log after the change (2026-09-08 00:00-00:01, no errors)

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no user-facing text changed