### PR TITLE
test: make githubStarsCache TTL boundary tests deterministic

### DIFF
--- a/src/shared/lib/githubStarsCache.test.ts
+++ b/src/shared/lib/githubStarsCache.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearCachedStars,
@@ -42,7 +42,21 @@ describe('githubStarsCache', () => {
   })
 
   describe('cache expiry', () => {
-    it('returns the count within the 1-hour TTL', () => {
+    // Why: freeze the clock — these tests pin the exact TTL boundary, and
+    // with the real clock a millisecond can elapse between seeding the
+    // cache and the expiry check, flipping "exactly at TTL" to expired
+    // (getCachedStars uses a strict `>` comparison, so TTL+1ms is expired;
+    // CI-only flake on slow runners: failed main-merge run 34171787200,
+    // 2026-09-08).
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns the count at exactly the TTL boundary', () => {
       localStorage.setItem(
         KEY,
         JSON.stringify({ count: 7, timestamp: Date.now() - 60 * 60 * 1000 }),


### PR DESCRIPTION
## Summary

Fixes a CI-only flake introduced with the githubStarsCache tests. The cache-expiry tests seeded a timestamp at **exactly** the 1-hour TTL using the real clock; `getCachedStars` uses a strict `>` comparison, so whenever a millisecond elapsed between seeding and the expiry check, "exactly at TTL" flipped to expired and the test failed (`expected null to be 7`). Fast local machines stayed under 1ms and passed — slow CI runners did not (failed main-merge CI run 34171787200 after #593).

Fix: freeze the clock (`vi.useFakeTimers()` + `vi.setSystemTime`) inside the `cache expiry` describe, restoring real timers in `afterEach`. Both boundary cases are now pinned deterministically:

- exactly TTL → still valid (returns count)
- TTL + 1ms → expired (null + entry removed)

Test renamed from "within the 1-hour TTL" to "at exactly the TTL boundary" to match what is actually asserted.

## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore (test-only change)

## Test Plan

- [x] `npx vitest run src/shared/lib/githubStarsCache.test.ts` — 10/10 pass
- [x] `npm test` — 1203 pass, eslint + prettier clean
- [x] Determinism argument: both `Date.now()` calls (seed + expiry check) return the identical frozen value, so the delta is exactly 3600000 regardless of runner speed

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no user-facing text changed