### PR TITLE
fix(download): move download locks to sidecar files for Windows merges

### DIFF
--- a/src-tauri/src/handlers/bilibili.rs
+++ b/src-tauri/src/handlers/bilibili.rs
@@ -680,10 +680,11 @@ async fn download_video_impl(app: &AppHandle, options: &DownloadOptions) -> Resu
     let host_health = Arc::new(crate::utils::cdn_selector::HostHealth::new());
 
     // 1. Determine output file path + reserve it (multi-process safe,
-    //    issue #560). All bytes are written to the reserved staging name
-    //    (`{stem}.part.{ext}`) and renamed to the final name on success;
-    //    `OutputReservation`'s Drop removes the staging file on every early
-    //    return below.
+    //    issue #560/#595). The name claim + liveness lock live on a sidecar
+    //    `video.mp4.lock`; all bytes are written to the reserved staging name
+    //    (`{stem}.part.{ext}`) — created lazily by the writers — and renamed
+    //    to the final name on success; `OutputReservation`'s Drop removes
+    //    staging + sidecar on every early return below.
     let reservation = reserve_output_path(&build_output_path(app, &options.filename).await?)?;
 
     // 2. Get cookies (WBI signing enables non-logged-in usage)
@@ -974,13 +975,15 @@ async fn download_video_impl(app: &AppHandle, options: &DownloadOptions) -> Resu
     let temp_video_path = lib_path.join(format!("temp_video_{}.m4s", options.download_id));
     let temp_audio_path = lib_path.join(format!("temp_audio_{}.m4s", options.download_id));
 
-    // Hold an exclusive flock on both temp files for the whole download
-    // (issue #560): startup cleanup treats a temp file whose flock is free as
-    // an orphan (owner crashed) and deletes it immediately regardless of age,
-    // so a second app instance must never see an in-flight temp as garbage.
-    // The lock lives on the inode the download writes to (created once by
-    // preallocate/single-stream open, never deleted-and-recreated mid-flight),
-    // and advisory locking never blocks our own writers.
+    // Hold an exclusive flock on both temp files' sidecar locks for the whole
+    // download (issue #560/#595): startup cleanup treats a temp file whose
+    // sidecar flock is free as an orphan (owner crashed) and deletes it
+    // immediately regardless of age, so a second app instance must never see
+    // an in-flight temp as garbage. The lock lives on a sidecar
+    // (`temp_*.m4s.lock`), never on the payload: `download_url`'s
+    // is_override entry unlinks and re-creates the payload, which would
+    // orphan a payload-bound flock, and on Windows a mandatory LockFileEx on
+    // the payload would block our own writers outright.
     // Note: keep the named binding — `let _ = lock_temp_paths(...)` would drop
     // the locks immediately, and startup cleanup would then delete these
     // in-flight temps as orphans.
@@ -1223,6 +1226,15 @@ async fn download_video_impl(app: &AppHandle, options: &DownloadOptions) -> Resu
 
     // Registry cleanup (token removal + pre-cancel flag clear) is handled by
     // the CancelTokenGuard acquired at register() above (issue #561).
+
+    // Release the temp sidecar locks before removing them (required on
+    // Windows: a held LockFileEx must be released before remove_file).
+    drop(_temp_locks);
+    // Remove the temp sidecars eagerly so zero-byte `.m4s.lock` files do not
+    // linger in the lib dir until the next startup sweep (issue #595).
+    for temp_path in [&temp_video_path, &temp_audio_path] {
+        let _ = tokio::fs::remove_file(lock_sidecar_path(temp_path)).await;
+    }
 
     // On error, clean up temp files
     if result.is_err() {
@@ -1667,6 +1679,65 @@ mod tests {
             reservation.reserved_path().file_name().unwrap(),
             "never_written.part.mp4"
         );
+        // The claim + liveness lock live on the sidecar, not the payload
+        // (issue #595): the sidecar exists from the moment of reservation,
+        // while the staging payload is only created by writers.
+        assert!(reservation_exists(dir.path(), "never_written.mp4.lock"));
+        assert!(!reservation_exists(dir.path(), "never_written.part.mp4"));
+    }
+
+    #[test]
+    fn reservation_locks_sidecar_not_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("video.mp4");
+        let reservation = reserve_output_path(&path).unwrap();
+
+        // The sidecar flock is held: a try_lock from a second handle fails.
+        let sidecar = dir.path().join("video.mp4.lock");
+        assert!(
+            flock_is_held(&sidecar),
+            "live reservation must hold the sidecar flock"
+        );
+        drop(reservation);
+    }
+
+    #[test]
+    fn staging_is_writable_while_reservation_held() {
+        // The #595 invariant: nothing the download writes is ever locked.
+        // On Windows the old payload-bound flock made this write fail with
+        // os error 33 (LockFileEx mandatory lock) — the exact failure behind
+        // "Permission denied" in the ffmpeg merge.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("video.mp4");
+        let reservation = reserve_output_path(&path).unwrap();
+
+        use std::io::Write;
+        let mut writer = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(reservation.reserved_path())
+            .unwrap();
+        writer.write_all(b"payload bytes").unwrap();
+
+        drop(reservation);
+    }
+
+    #[test]
+    fn orphan_sidecar_is_reclaimed_on_next_reserve() {
+        // Simulate a crashed process: an unlocked sidecar with no payload.
+        // The next reserve for the same name reclaims it instead of jumping
+        // to " (1)".
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("video.mp4");
+        std::fs::write(lock_sidecar_path(&path), b"").unwrap();
+
+        let reservation = reserve_output_path(&path).unwrap();
+        assert_eq!(
+            reservation.reserved_path().file_name().unwrap(),
+            "video.part.mp4",
+            "dead sidecar is reclaimed, not skipped"
+        );
     }
 
     #[test]
@@ -1691,6 +1762,24 @@ mod tests {
         assert_eq!(final_path, path);
         assert_eq!(std::fs::read(&path).unwrap(), b"payload");
         assert!(!reservation_exists(dir.path(), "done.part.mp4"));
+        assert!(
+            !reservation_exists(dir.path(), "done.mp4.lock"),
+            "completing must release and remove the sidecar claim"
+        );
+    }
+
+    #[test]
+    fn complete_without_staging_fails_and_releases_claim() {
+        // Writers never ran (early failure before any bytes). complete()
+        // fails loudly on the missing rename source and Drop still releases
+        // the claimed name.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never_started.mp4");
+        let reservation = reserve_output_path(&path).unwrap();
+        assert!(reservation.complete().is_err());
+        // complete() consumes the reservation; Drop ran inside it.
+        assert!(!reservation_exists(dir.path(), "never_started.mp4.lock"));
+        assert!(!reservation_exists(dir.path(), "never_started.part.mp4"));
     }
 
     #[test]
@@ -1701,14 +1790,19 @@ mod tests {
         std::fs::write(reservation.reserved_path(), b"partial").unwrap();
         drop(reservation);
         assert!(!reservation_exists(dir.path(), "abandoned.part.mp4"));
+        assert!(
+            !reservation_exists(dir.path(), "abandoned.mp4.lock"),
+            "dropping must release and remove the sidecar claim"
+        );
         assert!(!path.exists(), "final name must stay untouched on failure");
     }
 
     #[test]
     fn dead_reservation_is_reclaimed_on_next_reserve() {
-        // Simulate a crashed process: a staging file exists but nobody holds
-        // its flock. The next reserve for the same name must reclaim it
-        // instead of jumping to " (1)".
+        // Simulate pre-#595 crash debris: a staging file exists with no
+        // sidecar, so the name is claimable. The next reserve reuses the
+        // name (writers overwrite the stale staging bytes) instead of
+        // jumping to " (1)".
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("video.mp4");
         std::fs::write(part_path(&path), b"orphan").unwrap();
@@ -1724,6 +1818,17 @@ mod tests {
     /// Test helper: does `name` exist in `dir`?
     fn reservation_exists(dir: &std::path::Path, name: &str) -> bool {
         dir.join(name).exists()
+    }
+
+    /// Test helper: is an exclusive flock currently held on `path` by
+    /// someone else?
+    fn flock_is_held(path: &std::path::Path) -> bool {
+        let probe = OpenOptions::new()
+            .write(true)
+            .read(true)
+            .open(path)
+            .unwrap();
+        probe.try_lock_exclusive().is_err()
     }
 
     #[test]
@@ -1745,6 +1850,38 @@ mod tests {
             "finished file must not be overwritten"
         );
         assert_eq!(std::fs::read(&final_path).unwrap(), b"ours");
+        // The sidecar is named after the CLAIMED candidate (video.mp4), so
+        // shifting the rename target does not change which claim is removed.
+        assert!(!reservation_exists(dir.path(), "video.mp4.lock"));
+    }
+
+    #[test]
+    fn lock_temp_paths_locks_sidecars_not_payloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp_video_dl-1.m4s");
+        let guards = lock_temp_paths(&[&temp]);
+
+        // Sidecar exists and is locked for the guard's lifetime; the payload
+        // is neither created nor locked (issue #595).
+        let sidecar = dir.path().join("temp_video_dl-1.m4s.lock");
+        assert!(sidecar.exists());
+        assert!(
+            !temp.exists(),
+            "lock_temp_paths must not create the payload"
+        );
+        assert!(
+            flock_is_held(&sidecar),
+            "temp sidecar must be flock-held while the download lives"
+        );
+
+        // Payload writes (download_url's second handle) work unimpeded.
+        std::fs::write(&temp, b"segment bytes").unwrap();
+
+        drop(guards);
+        assert!(
+            !flock_is_held(&sidecar),
+            "dropping the guards releases the sidecar flock"
+        );
     }
 
     // ---- ensure_free_space (fs, tempfile) ----
@@ -3062,7 +3199,7 @@ async fn fetch_video_details(
     Ok(body)
 }
 
-/// Multi-process safe output-file reservation (issue #560).
+/// Multi-process safe output-file reservation (issue #560, issue #595).
 ///
 /// Two app instances downloading to the same output filename used to race:
 /// the old `auto_rename` checked `path.exists()` once at download start
@@ -3070,34 +3207,44 @@ async fn fetch_video_details(
 /// would overwrite each other. This reservation closes that window with two
 /// OS-level primitives:
 ///
-/// - `File::create_new` (O_EXCL) — exactly one process can create the
-///   reservation file; creation is atomic, so there is no check-then-create
-///   gap to slip through.
-/// - an exclusive `flock` held on it for the download's lifetime — if the
-///   owning process dies, the OS releases the lock, so the leftover
+/// - `File::create_new` (O_EXCL) on the sidecar lock file — exactly one
+///   process can create it; creation is atomic, so there is no
+///   check-then-create gap to slip through.
+/// - an exclusive `flock` held on the sidecar for the download's lifetime —
+///   if the owning process dies, the OS releases the lock, so the leftover
 ///   reservation is detectably dead and the next download reclaims it.
+///
+/// The lock lives on a sidecar file named after the FINAL path
+/// (`video.mp4` -> `video.mp4.lock`), never on the payload (issue #595):
+/// on Windows fs2 maps `lock_exclusive` to `LockFileEx`, a mandatory
+/// whole-file byte-range lock, so a flock held on the staging
+/// `video.part.mp4` blocked the ffmpeg child process from writing the merge
+/// output (os error 33 -> "Permission denied" -> `ERR::MERGE_FAILED`).
+/// On Unix it also keeps the liveness signal intact when `download_url`
+/// unlinks and re-creates the payload mid-flight (flock follows the inode).
 ///
 /// All output (direct durl downloads, ffmpeg merges) is written to the
 /// reserved staging name (`{stem}.part.{ext}`) and only renamed to the
 /// final user-visible name on success, so a crashed download can never leave
-/// a half-written `video.mp4` behind — only a `.part` staging file,
-/// which startup cleanup removes.
+/// a half-written `video.mp4` behind — only a `.part` staging file plus the
+/// sidecar, which startup cleanup removes.
 struct OutputReservation {
     /// Final user-visible path (e.g. `video.mp4`).
     final_path: PathBuf,
     /// Staging path all bytes are written to (e.g. `video.part.mp4`).
     reserved_path: PathBuf,
-    /// Holds the exclusive flock for the download's lifetime. Releasing it
-    /// (drop / process death) is what marks this reservation as reclaimable.
+    /// Holds the exclusive flock on the sidecar lock file for the download's
+    /// lifetime. Releasing it (drop / process death) is what marks this
+    /// reservation as reclaimable.
     lock_file: Option<File>,
     completed: bool,
 }
 
 impl OutputReservation {
-    fn new(final_path: PathBuf, reserved_path: PathBuf, lock_file: File) -> Self {
+    fn new(final_path: PathBuf, lock_file: File) -> Self {
         Self {
+            reserved_path: part_path(&final_path),
             final_path,
-            reserved_path,
             lock_file: Some(lock_file),
             completed: false,
         }
@@ -3127,6 +3274,12 @@ impl OutputReservation {
         fs::rename(&self.reserved_path, &target)
             .map_err(|e| format!("Failed to finalize output file: {}", e))?;
         self.completed = true;
+        // Release the flock BEFORE removing the sidecar (required on
+        // Windows; same rule as HistorySession's Drop). The sidecar is named
+        // after the claimed candidate, so shifting the rename target to a
+        // " (N)" variant never changes which lock file to remove.
+        self.lock_file = None;
+        let _ = fs::remove_file(lock_sidecar_path(&self.final_path));
         Ok(target)
     }
 }
@@ -3141,31 +3294,38 @@ impl Drop for OutputReservation {
         if !self.completed {
             let _ = fs::remove_file(&self.reserved_path);
         }
-        self.lock_file = None; // release the flock
+        self.lock_file = None; // release the flock before removing (Windows)
+        let _ = fs::remove_file(lock_sidecar_path(&self.final_path));
     }
 }
 
-/// Opens each temp path (creating it if absent) and holds an exclusive flock
-/// for the caller's lifetime. Best-effort: an unpersistable path logs and is
-/// skipped rather than failing the download (cleanup then falls back to the
-/// age-based rule for that file).
+/// Holds an exclusive flock on each temp file's SIDE CAR lock file
+/// (`temp_video_X.m4s` -> `temp_video_X.m4s.lock`) for the caller's
+/// lifetime. The payload temp itself is never locked (issue #595): on
+/// Windows `LockFileEx` is a mandatory lock that would block our own
+/// writers, and on every platform `download_url(is_override=true)` unlinks
+/// and re-creates the payload, which would orphan a payload-bound flock.
+/// Best-effort: an unpersistable path logs and is skipped rather than
+/// failing the download (cleanup then falls back to probing the payload's
+/// own flock, same as a pre-#595 leftover).
 fn lock_temp_paths(paths: &[&Path]) -> Vec<File> {
     let mut locked = Vec::with_capacity(paths.len());
     for path in paths {
+        let lock_path = lock_sidecar_path(path);
         let file = match OpenOptions::new()
             .create(true)
-            // truncate(false): opening an existing temp must never zero it —
-            // the download continues into the same inode the flock lives on.
+            // truncate(false): a leftover sidecar from a dead run is reused
+            // as-is; it holds no payload bytes, so zeroing never matters.
             .truncate(false)
             .write(true)
             .read(true)
-            .open(path)
+            .open(&lock_path)
         {
             Ok(file) => file,
             Err(e) => {
                 log::warn!(
                     "[BE] lock_temp_paths: open failed for {}: {}",
-                    path.display(),
+                    lock_path.display(),
                     e
                 );
                 continue;
@@ -3174,7 +3334,7 @@ fn lock_temp_paths(paths: &[&Path]) -> Vec<File> {
         if let Err(e) = file.lock_exclusive() {
             log::warn!(
                 "[BE] lock_temp_paths: lock failed for {}: {}",
-                path.display(),
+                lock_path.display(),
                 e
             );
             continue;
@@ -3201,6 +3361,19 @@ fn part_path(candidate: &Path) -> PathBuf {
     candidate.with_file_name(format!("{}.part.{}", stem, ext))
 }
 
+/// Appends `.lock` to the file name (`video.mp4` -> `video.mp4.lock`,
+/// `temp_video_X.m4s` -> `temp_video_X.m4s.lock`).
+///
+/// The download-sidecar is named after the FINAL path (not the staging
+/// `video.part.mp4`), so it survives the staging->final rename semantics
+/// unchanged and mirrors the `{path}.lock` convention of `locked_json.rs`
+/// (issue #595).
+pub(crate) fn lock_sidecar_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    path.with_file_name(name)
+}
+
 /// Yields candidate final paths: the desired name first, then `" (N)"`
 /// variants for N in 1..=10_000 (mirrors the historical auto_rename scheme).
 fn candidate_output_paths(path: &Path) -> Vec<PathBuf> {
@@ -3214,50 +3387,27 @@ fn candidate_output_paths(path: &Path) -> Vec<PathBuf> {
     candidates
 }
 
-/// Tries to claim `candidate` by atomically creating its staging file.
+/// Tries to claim `candidate` by atomically creating its sidecar lock file
+/// (`video.mp4` -> `video.mp4.lock`) and holding an exclusive flock on it
+/// (issue #595). The staging payload itself is NOT created here — every
+/// writer (ffmpeg `-y`, `download_url`'s preallocate/single-stream paths)
+/// creates it on first write, and locking the payload is exactly what broke
+/// the Windows merge.
 ///
-/// Returns `Some((locked_file, staging_path))` on success. On
-/// `AlreadyExists`, checks whether the existing reservation is dead (its
-/// holder crashed: flock gone) and if so reclaims it, so a crashed download
-/// never blocks its filename for 24h. Returns `None` when the name is taken
-/// by a live reservation or cannot be claimed.
-fn try_claim(candidate: &Path) -> Option<(File, PathBuf)> {
-    let reserved = part_path(candidate);
-    match OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .read(true)
-        .open(&reserved)
-    {
-        Ok(file) => match file.lock_exclusive() {
-            Ok(()) => Some((file, reserved)),
-            // Locking a file only we just created should never fail; treat it
-            // as claim failure rather than panicking.
-            Err(_) => {
-                let _ = fs::remove_file(&reserved);
-                None
-            }
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Dead-holder reclamation: an exclusive try_lock on the existing
-            // staging file succeeds only when no live process holds it.
-            if let Ok(existing) = OpenOptions::new().write(true).read(true).open(&reserved) {
-                if existing.try_lock_exclusive().is_ok() {
-                    drop(existing);
-                    let _ = fs::remove_file(&reserved);
-                }
-            }
-            None
-        }
-        Err(_) => None,
-    }
+/// Reuses [`crate::handlers::history_session::acquire_session_lock`], which
+/// also performs dead-holder reclamation: an existing sidecar whose flock
+/// can be taken has no live owner (its process died), so it is removed and
+/// re-created, and a crashed download never blocks its filename. Returns
+/// `None` when the name is taken by a live reservation or cannot be claimed.
+fn try_claim(candidate: &Path) -> Option<File> {
+    crate::handlers::history_session::acquire_session_lock(&lock_sidecar_path(candidate)).ok()
 }
 
 /// Reserves a unique output path for a download (issue #560).
 ///
-/// Walks `desired`, `desired (1)`, ... until a staging file can be claimed
-/// atomically. Falls back to a timestamp-based name if all 10,000 variants
-/// are taken (mirrors the historical auto_rename behavior).
+/// Walks `desired`, `desired (1)`, ... until a sidecar lock file can be
+/// claimed atomically. Falls back to a timestamp-based name if all 10,000
+/// variants are taken (mirrors the historical auto_rename behavior).
 fn reserve_output_path(desired: &Path) -> Result<OutputReservation, String> {
     for candidate in candidate_output_paths(desired) {
         // Preserve the historical auto_rename contract: never target a name
@@ -3265,12 +3415,8 @@ fn reserve_output_path(desired: &Path) -> Result<OutputReservation, String> {
         if candidate.exists() {
             continue;
         }
-        // Two passes per candidate: the first pass may reclaim a dead
-        // reservation, the second can then create_new it ourselves.
-        for _ in 0..2 {
-            if let Some((lock_file, reserved_path)) = try_claim(&candidate) {
-                return Ok(OutputReservation::new(candidate, reserved_path, lock_file));
-            }
+        if let Some(lock_file) = try_claim(&candidate) {
+            return Ok(OutputReservation::new(candidate, lock_file));
         }
     }
 
@@ -3289,10 +3435,10 @@ fn reserve_output_path(desired: &Path) -> Result<OutputReservation, String> {
         .map(|d| d.as_millis())
         .unwrap_or(0);
     let fallback = parent.join(format!("{}_{}.{}", stem, timestamp, ext));
-    let Some((lock_file, reserved_path)) = try_claim(&fallback) else {
+    let Some(lock_file) = try_claim(&fallback) else {
         return Err("ERR::OUTPUT_RESERVE_FAILED".to_string());
     };
-    Ok(OutputReservation::new(fallback, reserved_path, lock_file))
+    Ok(OutputReservation::new(fallback, lock_file))
 }
 
 /// Builds the full output path for a download file.

--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -2,21 +2,25 @@
 //!
 //! Cleans up orphaned temporary files left from interrupted downloads.
 //!
-//! Orphan detection (issue #560): `temp_video_*`/`temp_audio_*` files are
-//! held under an exclusive flock for the lifetime of their download, so a
-//! file whose flock can be taken has no live owner (the process died before
-//! Drop ran) and is deleted immediately regardless of age. `temp_sub_*`
-//! files carry no lock and keep the legacy age rule. The same flock rule
-//! removes abandoned `*.part.*` staging files from the download output
-//! directory.
+//! Orphan detection (issues #560/#595): downloads hold an exclusive flock on
+//! a SIDE CAR lock file (`.lock` sibling) for the download's lifetime —
+//! `temp_video_*.m4s` / `temp_audio_*.m4s` on `temp_*.m4s.lock`, output
+//! staging `*.part.*` on the final-named `video.mp4.lock`. A sidecar whose
+//! flock can be taken has no live owner (the process died before Drop ran),
+//! so payload + sidecar are deleted immediately regardless of age. Payload
+//! files without a sidecar (left by pre-#595 versions, which locked the
+//! payload itself) fall back to probing the payload's own flock.
+//! `temp_sub_*` files carry no lock and keep the legacy age rule. Final
+//! output files (`video.mp4`) are never touched.
 
 use fs2::FileExt;
 use std::fs::{self, OpenOptions};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use tauri::AppHandle;
 
+use crate::handlers::bilibili::lock_sidecar_path;
 use crate::utils::paths::get_lib_path;
 
 /// Default age threshold in hours (24 hours = 1 day)
@@ -41,11 +45,14 @@ pub fn cleanup_temp_files(app: &AppHandle, max_age_hours: Option<u64>) -> Cleanu
 
 /// Cleans up orphaned temp files in `dir`.
 ///
-/// - `temp_video_*.m4s` / `temp_audio_*.m4s`: deleted as soon as their flock
-///   is free (owner died) — age is irrelevant, so a crashed session's files
-///   stop occupying disk at the next launch instead of after 24h. A live
-///   download (another app instance included) holds the lock and is never
-///   touched.
+/// - `temp_video_*.m4s` / `temp_audio_*.m4s`: liveness is signaled by the
+///   exclusive flock on their sidecar `temp_*.m4s.lock` (issue #595); a free
+///   sidecar (or, for pre-#595 leftovers without one, a free payload flock)
+///   means the owner died, and the file is deleted immediately regardless of
+///   age. A live download (another app instance included) holds the sidecar
+///   lock and is never touched.
+/// - `temp_video_*.m4s.lock` / `temp_audio_*.m4s.lock`: unlocked sidecars
+///   (e.g. a crash between payload removal and sidecar removal) are swept.
 /// - `temp_sub_*.srt`: no lock is held on these; they keep the legacy
 ///   "older than max_age" rule.
 pub fn cleanup_temp_files_in_dir(dir: &Path, max_age_hours: Option<u64>) -> CleanupResult {
@@ -62,6 +69,14 @@ pub fn cleanup_temp_files_in_dir(dir: &Path, max_age_hours: Option<u64>) -> Clea
         Ok(entries) => {
             for entry in entries.flatten() {
                 let path = entry.path();
+                if is_media_temp_lock(&path) {
+                    // An unlocked sidecar is provably dead — a live download
+                    // always holds its flock.
+                    if is_unlocked_orphan(&path) {
+                        delete_file(&path, &mut result);
+                    }
+                    continue;
+                }
                 if !is_temp_file(&path) {
                     continue;
                 }
@@ -70,10 +85,10 @@ pub fn cleanup_temp_files_in_dir(dir: &Path, max_age_hours: Option<u64>) -> Clea
                     .and_then(|m| m.modified())
                     .map(|modified| modified < threshold)
                     .unwrap_or(false);
-                // Locked media temps skip the age rule entirely; the flock is
-                // the liveness signal. Subtitle temps fall back to `stale`.
+                // Media temps skip the age rule entirely; the sidecar flock
+                // is the liveness signal. Subtitle temps fall back to `stale`.
                 let removable = if is_media_temp(&path) {
-                    is_unlocked_orphan(&path)
+                    media_temp_is_orphan(&path)
                 } else {
                     stale
                 };
@@ -94,10 +109,11 @@ pub fn cleanup_temp_files_in_dir(dir: &Path, max_age_hours: Option<u64>) -> Clea
     result
 }
 
-/// Removes abandoned `*.part.*` staging files from the download output
-/// directory (issue #560). A staging file whose flock is free has no live
-/// download behind it (the owning process died before cleanup could run) and
-/// is deleted regardless of age.
+/// Removes abandoned `*.part.*` staging files and orphaned sidecar locks
+/// from the download output directory (issues #560/#595). A staging file
+/// whose sidecar flock is free has no live download behind it (the owning
+/// process died before cleanup could run) and is deleted regardless of age.
+/// Final files are never touched.
 pub async fn cleanup_part_files(app: &AppHandle) -> CleanupResult {
     let settings = crate::handlers::settings::get_settings(app).await.ok();
     let Some(dl_dir) = settings.and_then(|s| s.dl_output_path) else {
@@ -118,7 +134,15 @@ fn cleanup_part_in_dir(dir: &Path) -> CleanupResult {
         Ok(entries) => {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if is_part_file(&path) && is_unlocked_orphan(&path) {
+                if is_output_sidecar(&path) {
+                    // Orphaned output sidecar (`video.mp4.lock`): the claim is
+                    // dead. Delete the sidecar only — never the final file,
+                    // which may be a finished download (or a user file that
+                    // happens to share the name shape).
+                    if is_unlocked_orphan(&path) {
+                        delete_file(&path, &mut result);
+                    }
+                } else if is_part_file(&path) && staging_is_orphan(&path) {
                     delete_file(&path, &mut result);
                 }
             }
@@ -159,7 +183,59 @@ fn is_unlocked_orphan(path: &Path) -> bool {
     }
 }
 
-/// `temp_video_*` / `temp_audio_*` files (flock-protected during downloads).
+/// Liveness of a media temp: the sidecar flock is authoritative when the
+/// sidecar exists; a temp without a sidecar is a pre-#595 leftover (its own
+/// flock was the liveness signal) and falls back to probing the payload.
+fn media_temp_is_orphan(temp: &Path) -> bool {
+    let sidecar = lock_sidecar_path(temp);
+    if sidecar.exists() {
+        is_unlocked_orphan(&sidecar)
+    } else {
+        is_unlocked_orphan(temp)
+    }
+}
+
+/// Liveness of an output staging file: the final-named sidecar flock is
+/// authoritative when it exists; staging without a sidecar is a pre-#595
+/// leftover and falls back to probing the staging file itself.
+fn staging_is_orphan(staging: &Path) -> bool {
+    let liveness_lock = final_from_part(staging)
+        .map(|final_path| lock_sidecar_path(&final_path))
+        .filter(|sidecar| sidecar.exists())
+        .unwrap_or_else(|| staging.to_path_buf());
+    is_unlocked_orphan(&liveness_lock)
+}
+
+/// Pre-#595 inverse of [`part_path`]: `video.part.mp4` -> `video.mp4`.
+/// Returns `None` for names not shaped `{stem}.part.{ext}`.
+fn final_from_part(part: &Path) -> Option<PathBuf> {
+    let name = part.file_name()?.to_str()?;
+    let (stem, ext) = name.rsplit_once('.')?;
+    let stem = stem.strip_suffix(".part")?;
+    Some(part.with_file_name(format!("{stem}.{ext}")))
+}
+
+/// `temp_video_*.m4s.lock` / `temp_audio_*.m4s.lock` sidecars.
+fn is_media_temp_lock(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    (name.starts_with("temp_video_") || name.starts_with("temp_audio_"))
+        && name.ends_with(".m4s.lock")
+}
+
+/// Output sidecar locks in the download dir (`video.mp4.lock`). Outputs are
+/// always `.mp4` (see `build_output_path`), so the narrow `.mp4.lock` suffix
+/// keeps unrelated user `.lock` files out of the sweep.
+fn is_output_sidecar(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.ends_with(".mp4.lock") && n.len() > ".mp4.lock".len())
+}
+
+/// `temp_video_*` / `temp_audio_*` files (sidecar-flock-protected during
+/// downloads).
 fn is_media_temp(path: &Path) -> bool {
     let name = match path.file_name().and_then(|n| n.to_str()) {
         Some(n) => n,
@@ -271,7 +347,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("temp_audio_dl-2.m4s");
         fs::write(&path, b"x").unwrap();
-        // Simulate a live download: hold the flock across the cleanup call.
+        // Simulate a pre-#595 live download: payload flock held, no sidecar.
         let holder = OpenOptions::new()
             .write(true)
             .read(true)
@@ -282,9 +358,72 @@ mod tests {
         let result = cleanup_temp_files_in_dir(dir.path(), None);
         assert_eq!(
             result.deleted_count, 0,
-            "locked temp belongs to a live download"
+            "legacy payload-locked temp belongs to a live download"
         );
         assert!(path.exists());
+    }
+
+    /// Test helper: create `path` if absent and hold an exclusive flock on
+    /// it for the returned guard's lifetime.
+    fn hold_flock(path: &Path) -> fs::File {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true)
+            .open(path)
+            .unwrap();
+        file.lock_exclusive().unwrap();
+        file
+    }
+
+    #[test]
+    fn sidecar_locked_media_temp_is_never_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("temp_audio_dl-2.m4s");
+        fs::write(&path, b"x").unwrap();
+        // Simulate a live download (issue #595): flock held on the sidecar.
+        let sidecar = lock_sidecar_path(&path);
+        let _holder = hold_flock(&sidecar);
+
+        let result = cleanup_temp_files_in_dir(dir.path(), None);
+        assert_eq!(
+            result.deleted_count, 0,
+            "sidecar-locked temp belongs to a live download"
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn unlocked_temp_sidecar_sweeps_payload_and_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("temp_video_dl-4.m4s");
+        fs::write(&path, b"x").unwrap();
+        // Unlocked sidecar (crashed download): both files go in one pass.
+        fs::write(lock_sidecar_path(&path), b"").unwrap();
+
+        let result = cleanup_temp_files_in_dir(dir.path(), None);
+        assert_eq!(
+            result.deleted_count, 2,
+            "dead claim sweeps payload + sidecar"
+        );
+        assert!(!path.exists());
+        assert!(!lock_sidecar_path(&path).exists());
+    }
+
+    #[test]
+    fn locked_temp_sidecar_is_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        // Claim held, payload not yet created (download starting).
+        let path = dir.path().join("temp_video_dl-5.m4s");
+        let sidecar = lock_sidecar_path(&path);
+        let _holder = hold_flock(&sidecar);
+
+        let result = cleanup_temp_files_in_dir(dir.path(), None);
+        assert_eq!(
+            result.deleted_count, 0,
+            "locked sidecar means live download"
+        );
+        assert!(sidecar.exists());
     }
 
     #[test]
@@ -303,6 +442,8 @@ mod tests {
     #[test]
     fn unlocked_part_is_deleted() {
         let dir = tempfile::tempdir().unwrap();
+        // Pre-#595 debris: staging without a sidecar; its own (dead) flock
+        // was the liveness signal.
         fs::write(dir.path().join("video.part.mp4"), b"partial").unwrap();
 
         let result = cleanup_part_in_dir(dir.path());
@@ -315,6 +456,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("video.part.mp4");
         fs::write(&path, b"partial").unwrap();
+        // Simulate a pre-#595 live download: payload flock held, no sidecar.
         let holder = OpenOptions::new()
             .write(true)
             .read(true)
@@ -325,5 +467,95 @@ mod tests {
         let result = cleanup_part_in_dir(dir.path());
         assert_eq!(result.deleted_count, 0);
         assert!(path.exists());
+    }
+
+    #[test]
+    fn locked_output_sidecar_keeps_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        let staging = dir.path().join("video.part.mp4");
+        fs::write(&staging, b"partial").unwrap();
+        // Live download (issue #595): flock held on the final-named sidecar.
+        let sidecar = dir.path().join("video.mp4.lock");
+        let _holder = hold_flock(&sidecar);
+
+        let result = cleanup_part_in_dir(dir.path());
+        assert_eq!(result.deleted_count, 0, "sidecar-locked staging is live");
+        assert!(staging.exists());
+        assert!(sidecar.exists());
+    }
+
+    #[test]
+    fn unlocked_output_sidecar_sweeps_staging_and_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let staging = dir.path().join("video.part.mp4");
+        fs::write(&staging, b"partial").unwrap();
+        fs::write(dir.path().join("video.mp4.lock"), b"").unwrap();
+
+        let result = cleanup_part_in_dir(dir.path());
+        assert_eq!(
+            result.deleted_count, 2,
+            "dead claim sweeps staging + sidecar"
+        );
+        assert!(!staging.exists());
+        assert!(!dir.path().join("video.mp4.lock").exists());
+    }
+
+    #[test]
+    fn orphan_output_sidecar_deleted_final_untouched() {
+        // Crash window between complete()'s rename and sidecar removal: the
+        // finished file survives, only the leftover claim goes.
+        let dir = tempfile::tempdir().unwrap();
+        let final_file = dir.path().join("video.mp4");
+        fs::write(&final_file, b"done").unwrap();
+        let sidecar = dir.path().join("video.mp4.lock");
+        fs::write(&sidecar, b"").unwrap();
+
+        let result = cleanup_part_in_dir(dir.path());
+        assert_eq!(result.deleted_count, 1, "only the sidecar is swept");
+        assert!(!sidecar.exists());
+        assert!(final_file.exists(), "final file must never be deleted");
+    }
+
+    #[test]
+    fn unrelated_lock_files_are_not_swept() {
+        // A user's own *.lock file in the download dir that is not shaped
+        // like an output sidecar must survive the sweep.
+        let dir = tempfile::tempdir().unwrap();
+        let notes_lock = dir.path().join("notes.txt.lock");
+        fs::write(&notes_lock, b"").unwrap();
+
+        let result = cleanup_part_in_dir(dir.path());
+        assert_eq!(result.deleted_count, 0);
+        assert!(notes_lock.exists());
+    }
+
+    #[test]
+    fn final_from_part_is_inverse_of_staging_shape() {
+        assert_eq!(
+            final_from_part(Path::new("/d/video.part.mp4")).as_deref(),
+            Some(Path::new("/d/video.mp4"))
+        );
+        assert_eq!(
+            final_from_part(Path::new("/d/a (1).part.mp4")).as_deref(),
+            Some(Path::new("/d/a (1).mp4"))
+        );
+        assert_eq!(
+            final_from_part(Path::new("/d/my.video.part.mp4")).as_deref(),
+            Some(Path::new("/d/my.video.mp4"))
+        );
+        assert_eq!(final_from_part(Path::new("/d/video.mp4")), None);
+        assert_eq!(final_from_part(Path::new("/d/just part")), None);
+    }
+
+    #[test]
+    fn output_sidecar_matcher_is_narrow() {
+        assert!(is_output_sidecar(Path::new("/d/video.mp4.lock")));
+        assert!(is_output_sidecar(Path::new("/d/a (1).mp4.lock")));
+        // Not ours: wrong extension or bare suffix.
+        assert!(!is_output_sidecar(Path::new("/d/notes.txt.lock")));
+        assert!(!is_output_sidecar(Path::new("/d/.mp4.lock")));
+        // Staging files and finals never match the sidecar rule.
+        assert!(!is_output_sidecar(Path::new("/d/video.part.mp4")));
+        assert!(!is_output_sidecar(Path::new("/d/video.mp4")));
     }
 }

--- a/src-tauri/src/handlers/cleanup.rs
+++ b/src-tauri/src/handlers/cleanup.rs
@@ -368,6 +368,9 @@ mod tests {
     fn hold_flock(path: &Path) -> fs::File {
         let file = OpenOptions::new()
             .create(true)
+            // truncate(false): the holder only fakes a live lock owner; it
+            // must not zero an existing file's contents.
+            .truncate(false)
             .write(true)
             .read(true)
             .open(path)

--- a/src-tauri/src/handlers/concurrency.rs
+++ b/src-tauri/src/handlers/concurrency.rs
@@ -101,7 +101,7 @@ pub struct DownloadCancelRegistry {
 /// id return `true` and emit a spurious `download_cancelled` event, and the
 /// map grows without bound in long sessions. The guard deregisters on every
 /// scope exit — early return, panic unwind, or normal completion — exactly
-/// like `OutputReservation` covers the staging file.
+/// like `OutputReservation` covers its claimed output name.
 ///
 /// Hold the guard for the whole download; dropping it performs
 /// `remove` + `clear_cancelled` (both idempotent, so double cleanup with

--- a/src-tauri/src/handlers/history_session.rs
+++ b/src-tauri/src/handlers/history_session.rs
@@ -361,8 +361,12 @@ async fn fetch_thumbnail(app: &AppHandle, bvid: &str) -> Option<String> {
 ///
 /// Reclaims a dead holder first: an existing file whose flock can be taken
 /// has no live owner (its process died; the OS released the lock), so it is
-/// removed and re-created — the same rule as `try_claim` (issue #560).
-fn acquire_session_lock(path: &Path) -> Result<File, String> {
+/// removed and re-created.
+///
+/// Shared with `bilibili::try_claim` (issue #595): the download output
+/// reservation claims its sidecar lock file with this exact rule (the rule
+/// the former `bilibili::try_claim` body duplicated, issue #560).
+pub(crate) fn acquire_session_lock(path: &Path) -> Result<File, String> {
     let try_create = || -> Result<File, std::io::Error> {
         let file = OpenOptions::new()
             .create_new(true)

--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -67,8 +67,9 @@ pub async fn initialize(app: AppHandle) -> Result<(), String> {
     // 1. Clean up orphaned temp files from previous sessions.
     emit_step(&app, "init.cleanup_in_progress");
     let _ = cleanup::cleanup_temp_files(&app, None);
-    // Also sweep abandoned *.part.* staging files from the download
-    // output directory (crashed downloads, issue #560).
+    // Also sweep abandoned *.part.* staging files and orphaned sidecar
+    // locks from the download output directory (crashed downloads,
+    // issues #560/#595).
     let _ = cleanup::cleanup_part_files(&app).await;
     // Mark in_progress history entries whose owning process is gone as
     // failed (crash recovery, issue #511). Live downloads in another app


### PR DESCRIPTION
## Summary

On Windows, fs2's `lock_exclusive` maps to `LockFileEx`, a mandatory whole-file byte-range lock. `OutputReservation` held that lock on the staging payload (`video.part.mp4`) for the whole download, so the ffmpeg child process could not write the merge output (os error 33 → "Permission denied" → `ERR::MERGE_FAILED`).

- Claim the output name via a sidecar lock `video.mp4.lock` (named after the final path), reusing `history_session::acquire_session_lock`
- The staging payload is no longer created at reserve time; writers (ffmpeg `-y`, `download_url` preallocate/single-stream) create it lazily
- `lock_temp_paths` locks `temp_*.m4s.lock` sidecars instead of payloads, which also keeps the liveness signal intact when `download_url` unlinks/recreates the payload mid-flight (all platforms — fixes a latent orphaned-flock cleanup race)
- cleanup: probe sidecar flocks first, fall back to payload flocks for pre-#595 leftovers; sweep orphan sidecars; never touch final files
- Temp sidecars are removed eagerly after the download settles

## Related Issue

closes #595

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `cargo build` / `cargo fmt` / `cargo clippy` clean (pre-existing warnings only)
- [x] `npm run lint` clean
- [x] Unit tests: sidecar lifecycle, legacy payload-flock fallback, `final_from_part` round-trip, `.mp4.lock` matcher narrowness (local `cargo test` binary cannot start on this Windows machine — pre-existing env issue, identical on main; CI runs the suite on Ubuntu)
- [x] Manual verification on Windows: DASH download completes with merge (the #595 repro), no `.part.mp4`/`.mp4.lock` residue, cancel path clean
- [x] Multi-instance: second window killed + relaunched mid-download — startup cleanup deleted nothing in-flight, download completed (1.35 GB)
- [x] Parallel downloads from two windows completed cleanly

## Breaking Changes

None. Leftover staging/temp files from v1.54–v1.56 (no sidecars) are still swept via the payload-flock fallback.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, backend-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)