### PR TITLE
fix(download): suppress console window flash from integrity check on Windows

### DIFF
--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -795,21 +795,37 @@ pub async fn merge_avs(
             //   the async worker would stall other tasks (progress events,
             //   concurrent segment downloads) for the whole check.
             let out = tokio::task::spawn_blocking(move || {
-                std::process::Command::new(&ffmpeg_path_chk)
-                    .args([
-                        "-v",
-                        "error",
-                        "-i",
-                        &video_str_chk,
-                        "-map",
-                        "0:v",
-                        "-c",
-                        "copy",
-                        "-f",
-                        "null",
-                        "-",
-                    ])
-                    .output()
+                let mut cmd = std::process::Command::new(&ffmpeg_path_chk);
+                cmd.args([
+                    "-v",
+                    "error",
+                    "-i",
+                    &video_str_chk,
+                    "-map",
+                    "0:v",
+                    "-c",
+                    "copy",
+                    "-f",
+                    "null",
+                    "-",
+                ]);
+                // Why: without CREATE_NO_WINDOW this fire-and-forget probe
+                // pops a console window on every DASH download's merge start
+                // in release builds (the GUI parent has no console, so
+                // Windows allocates a new conhost for the console-subsystem
+                // ffmpeg.exe).
+                #[cfg(target_os = "windows")]
+                {
+                    use std::os::windows::process::CommandExt;
+                    // Note: 0x0800_0000 is the Win32 CREATE_NO_WINDOW value
+                    // from CreateProcess's dwCreationFlags (Microsoft Learn,
+                    // Process Creation Flags). CommandExt::creation_flags
+                    // takes a raw u32 and std exports no constant for it, so
+                    // the value is defined locally here.
+                    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                    cmd.creation_flags(CREATE_NO_WINDOW);
+                }
+                cmd.output()
             })
             .await;
             if let Ok(Ok(out)) = out {


### PR DESCRIPTION
## Summary

The fire-and-forget video integrity probe in `merge_avs` spawned `ffmpeg.exe` via `std::process::Command` without `CREATE_NO_WINDOW` — the only unflagged spawn site in the codebase (all 10 others set it). In release builds the GUI parent has no console (`windows_subsystem = "windows"`), so Windows allocated a fresh conhost for the console-subsystem ffmpeg.exe at every DASH download's merge start — a terminal window flashing at "download completion".

- Adds the same `#[cfg(target_os = "windows")]` `CREATE_NO_WINDOW` block used by `validate_command`, plus a `Note` on the flag constant's provenance
- Not a v1.57.0 regression: the unflagged probe has existed since ~v1.50.0 (verified via tag raw files); release-build usage made it visible
- Dev builds are unaffected (parent already has a console) — verified on a release build

## Related Issue

None (user report in chat; no issue filed)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `cargo build` / `cargo fmt` / `cargo clippy --all-targets` clean (pre-existing warnings only)
- [x] Manual verification on a Windows release build: DASH download completes with no console window at merge start, download still succeeds

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore) — platform-specific spawn glue, exempt per project rules
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, backend-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)