### PR TITLE
feat(ui): show app version in native window title

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-set-theme",
     "core:window:allow-set-progress-bar",
+    "core:window:allow-set-title",
     "core:window:allow-request-user-attention",
     "core:window:allow-start-dragging",
     "process:default",

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -29,6 +29,16 @@ const MIN_HEIGHT: f64 = 609.0;
 const WINDOW_TITLE: &str = "Bilibili Downloader";
 const GEOMETRY_STORE_KEY: &str = "windowGeometry";
 
+/// Composes the native window title: fixed app name + version (issue #598).
+///
+/// The version is always included so it is visible from the first frame,
+/// before the frontend runs. When an update is available, the frontend
+/// appends an " (update available)" suffix via `setTitle` — see
+/// `useWindowTitle.ts` on the frontend side.
+fn window_title(version: &str) -> String {
+    format!("{WINDOW_TITLE} v{version}")
+}
+
 // Splash window dimensions (logical). Square on all platforms for a consistent
 // Discord-style splash. Tunable; the frontend splash route fills this area.
 const SPLASH_WIDTH: f64 = 480.0;
@@ -83,7 +93,7 @@ pub fn create_splash_window(
         None => "splashscreen".to_string(),
     };
     let _splash = WebviewWindowBuilder::new(app, "splash", WebviewUrl::App(url.into()))
-        .title(WINDOW_TITLE)
+        .title(window_title(&app.package_info().version.to_string()))
         .theme(theme.or(Some(Theme::Light)))
         .inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
         .min_inner_size(SPLASH_WIDTH, SPLASH_HEIGHT)
@@ -126,7 +136,7 @@ pub fn create_main_window(
     let should_maximize = geometry.as_ref().map(|g| g.maximized).unwrap_or(false);
 
     let mut builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-        .title(WINDOW_TITLE)
+        .title(window_title(&app.package_info().version.to_string()))
         .theme(theme.or(Some(Theme::Light)))
         .min_inner_size(MIN_WIDTH, MIN_HEIGHT);
 
@@ -583,6 +593,11 @@ mod tests {
             work_w,
             work_h,
         }
+    }
+
+    #[test]
+    fn window_title_includes_version() {
+        assert_eq!(window_title("1.57.0"), "Bilibili Downloader v1.57.0");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/features/notifications'
 import { useFontSizeShortcuts } from '@/features/settings/hooks/useFontSizeShortcuts'
 import { useThemeEffect } from '@/features/settings/hooks/useThemeEffect'
-import { UpdateNotification } from '@/features/updater'
+import { UpdateNotification, useWindowTitle } from '@/features/updater'
 import IndexPage from '@/pages'
 import ErrorPage from '@/pages/error'
 import InitPage from '@/pages/init'
@@ -22,6 +22,7 @@ function App() {
   useFontSizeShortcuts()
   useTaskbarProgress()
   useDownloadCompletionNotifications()
+  useWindowTitle()
 
   useEffect(() => {
     if (import.meta.env.DEV) return

--- a/src/features/updater/hooks/useWindowTitle.test.tsx
+++ b/src/features/updater/hooks/useWindowTitle.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * useWindowTitle suite.
+ *
+ * The app version comes from '@tauri-apps/api/app' (mocked locally — setup.ts
+ * does not own that module); getCurrentWindow().setTitle is the shared
+ * mockCurrentWindow vi.fn from src/test/setup.ts.
+ */
+
+import { store } from '@/app/store'
+import { useWindowTitle } from '@/features/updater/hooks/useWindowTitle'
+import {
+  resetUpdater,
+  setUpdateAvailable,
+} from '@/features/updater/model/updaterSlice'
+import { renderHookWithStore } from '@/test/test-utils'
+import { getVersion } from '@tauri-apps/api/app'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('1.2.3'),
+}))
+
+const mockGetVersion = getVersion as unknown as Mock
+// setup.ts returns a single shared window instance, so this is the same
+// vi.fn the hook invokes.
+const mockSetTitle = getCurrentWindow().setTitle as unknown as Mock
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetVersion.mockResolvedValue('1.2.3')
+  store.dispatch(resetUpdater())
+})
+
+describe('useWindowTitle', () => {
+  it('never calls setTitle while no update is available', async () => {
+    const { rerender } = renderHookWithStore(() => useWindowTitle())
+
+    await waitFor(() => expect(mockGetVersion).toHaveBeenCalled())
+    // Latest / dev mode / check failure: the backend-composed base title
+    // stands untouched — no IPC call.
+    expect(mockSetTitle).not.toHaveBeenCalled()
+
+    rerender()
+    expect(mockSetTitle).not.toHaveBeenCalled()
+  })
+
+  it('appends the (update available) suffix when an update exists', async () => {
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: '2.0.0',
+        currentVersion: '1.2.3',
+      }),
+    )
+    renderHookWithStore(() => useWindowTitle())
+
+    await waitFor(() => expect(mockSetTitle).toHaveBeenCalled())
+    expect(mockSetTitle).toHaveBeenCalledWith(
+      'Bilibili Downloader v1.2.3 (update available)',
+    )
+  })
+
+  it('reacts to an update becoming available after mount', async () => {
+    renderHookWithStore(() => useWindowTitle())
+
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: '2.0.0',
+        currentVersion: '1.2.3',
+      }),
+    )
+    await waitFor(() => expect(mockSetTitle).toHaveBeenCalled())
+    expect(mockSetTitle).toHaveBeenLastCalledWith(
+      'Bilibili Downloader v1.2.3 (update available)',
+    )
+  })
+
+  it('never calls setTitle when getVersion rejects', async () => {
+    mockGetVersion.mockRejectedValue(new Error('no app'))
+    renderHookWithStore(() => useWindowTitle())
+
+    store.dispatch(
+      setUpdateAvailable({
+        available: true,
+        latestVersion: '2.0.0',
+        currentVersion: '1.2.3',
+      }),
+    )
+    // Give the rejected promise a tick to settle; no title write happens.
+    await waitFor(() => expect(mockGetVersion).toHaveBeenCalledTimes(1))
+    expect(mockSetTitle).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/updater/hooks/useWindowTitle.ts
+++ b/src/features/updater/hooks/useWindowTitle.ts
@@ -1,0 +1,54 @@
+import { useSelector } from '@/app/store'
+import { logger } from '@/shared/lib/logger'
+import { getVersion } from '@tauri-apps/api/app'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { useEffect, useState } from 'react'
+
+// CAUTION: keep in sync with WINDOW_TITLE in src-tauri/src/window.rs, which
+// composes the creation-time title before this hook can run.
+const BASE_TITLE = 'Bilibili Downloader'
+
+// Why hardcoded English (a deliberate exception to the react-i18next rule):
+// native window chrome is already hardcoded English (WINDOW_TITLE in
+// window.rs, macOS menu names in menu.rs). A localized suffix on an English
+// base would produce mixed-language chrome.
+const UPDATE_SUFFIX = ' (update available)'
+
+/**
+ * Reflect the update-available state in the native window title.
+ *
+ * The backend composes "Bilibili Downloader v{version}" at window creation
+ * (window.rs), so the version is visible from the first frame. When an
+ * update is available, this hook appends the suffix via
+ * getCurrentWindow().setTitle. Otherwise (latest, dev mode, check failure,
+ * or version fetch failure) the backend-composed base title stands untouched.
+ *
+ * Must be mounted exactly once at the app root (see App.tsx). The splash
+ * webview never runs this hook (main.tsx renders SplashScreen, not App, on
+ * /splashscreen), so only the main window's title is ever written.
+ */
+export function useWindowTitle(): void {
+  const updateAvailable = useSelector((state) => state.updater.updateAvailable)
+  const [version, setVersion] = useState<string | null>(null)
+
+  // Why: fetched from the Tauri API instead of reading state.updater.currentVersion —
+  // that store field defaults to null and can be the literal "unknown" when the
+  // plugin-updater omits it (see UpdaterProvider.tsx), so it is not a reliable
+  // version source for composing the title.
+  useEffect(() => {
+    getVersion()
+      .then(setVersion)
+      .catch((e) => logger.error('useWindowTitle: getVersion failed', e))
+  }, [])
+
+  // Note: issue #598 also floated a "(latest)" marker when up to date; that
+  // half is not implemented — when no update is available the title stays at
+  // the backend-composed base and no IPC call is made.
+  useEffect(() => {
+    if (!version || !updateAvailable) return
+
+    getCurrentWindow()
+      .setTitle(`${BASE_TITLE} v${version}${UPDATE_SUFFIX}`)
+      .catch((e) => logger.error('useWindowTitle: setTitle failed', e))
+  }, [version, updateAvailable])
+}

--- a/src/features/updater/index.ts
+++ b/src/features/updater/index.ts
@@ -8,6 +8,7 @@
 
 export * from '@/features/updater/api/updaterApi'
 export { useUpdateDownload } from '@/features/updater/hooks/useUpdateDownload'
+export { useWindowTitle } from '@/features/updater/hooks/useWindowTitle'
 export * from '@/features/updater/model/updaterSlice'
 export * from '@/features/updater/types'
 export { UpdateNotification } from '@/features/updater/ui/UpdateNotification'

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -75,13 +75,15 @@ vi.mock('@tauri-apps/plugin-shell', () => ({
 
 // Mock @tauri-apps/api/window. useTaskbarProgress and
 // useDownloadCompletionNotifications call getCurrentWindow().setProgressBar /
-// requestUserAttention. A single hoisted instance is returned so tests can
-// grab the same vi.fn references and assert on them.
+// requestUserAttention; useWindowTitle calls setTitle. A single hoisted
+// instance is returned so tests can grab the same vi.fn references and
+// assert on them.
 const { mockCurrentWindow } = vi.hoisted(() => ({
   mockCurrentWindow: {
     setProgressBar: vi.fn().mockResolvedValue(undefined),
     requestUserAttention: vi.fn().mockResolvedValue(undefined),
     setTheme: vi.fn().mockResolvedValue(undefined),
+    setTitle: vi.fn().mockResolvedValue(undefined),
     isFocused: vi.fn().mockResolvedValue(true),
     onFocusChanged: vi.fn().mockResolvedValue(() => {}),
   },


### PR DESCRIPTION
## Summary

- Compose the native window title as `Bilibili Downloader v{version}` in Rust at window creation (`window_title()` in `window.rs`), so the version is visible from the first frame — previously it was only reachable via Settings or the About dialog
- New `useWindowTitle` hook (mounted at the app root next to `useTaskbarProgress`) appends an " (update available)" suffix via `getCurrentWindow().setTitle()` once the updater flags a new release
- Adds the `core:window:allow-set-title` capability; suffix is hardcoded English by design (native chrome — `WINDOW_TITLE`, macOS menu names — is already hardcoded English)

## Related Issue

Closes #598

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `npm test` (1207 passed, incl. new `useWindowTitle` suite)
- [x] `cargo test window_title` in `src-tauri/`
- [x] `npm run lint`, `cargo fmt --check`, `cargo clippy` clean
- [x] Manual verification in `npm run tauri dev`: title shows `Bilibili Downloader v1.57.1`

## Breaking Changes

None.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (no new keys — title suffix is a documented i18n exception)