### PR TITLE
test: add unit tests for small and untested modules (R2)

### DIFF
--- a/src-tauri/src/handlers/favorites.rs
+++ b/src-tauri/src/handlers/favorites.rs
@@ -75,6 +75,15 @@ pub async fn fetch_favorite_folders(
     // and surface as a parse error instead of an ERR:: code the frontend can map
     // (src/shared/lib/mapBackendError.ts).
     let api = BiliApi::from_cookie_header(cookie_header)?;
+    fetch_favorite_folders_via(&api, mid).await
+}
+
+/// Transport-injectable variant of [`fetch_favorite_folders`] (test seam:
+/// wiremock tests pass a BiliApi whose base URL points at a local server).
+async fn fetch_favorite_folders_via(
+    api: &BiliApi,
+    mid: i64,
+) -> Result<Vec<FavoriteFolder>, String> {
     let raw_text = api
         .get(&format!(
             "/x/v3/fav/folder/created/list-all?up_mid={}&type=2",
@@ -191,6 +200,17 @@ pub async fn fetch_favorite_videos(
     // and surface as a parse error instead of an ERR:: code the frontend can map
     // (src/shared/lib/mapBackendError.ts).
     let api = BiliApi::from_cookie_header(cookie_header)?;
+    fetch_favorite_videos_via(&api, media_id, page_num, page_size).await
+}
+
+/// Transport-injectable variant of [`fetch_favorite_videos`] (test seam:
+/// wiremock tests pass a BiliApi whose base URL points at a local server).
+async fn fetch_favorite_videos_via(
+    api: &BiliApi,
+    media_id: i64,
+    page_num: i32,
+    page_size: i32,
+) -> Result<FavoriteVideoListResponse, String> {
     let response = api
         .get(&format!(
             "/x/v3/fav/resource/list?media_id={}&pn={}&ps={}&order=mtime&type=0&platform=web",
@@ -246,4 +266,181 @@ pub async fn fetch_favorite_videos(
         has_more: data.has_more,
         total_count,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::bilibili::{build_client, BiliApi};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn api_at(base: &str) -> BiliApi {
+        BiliApi::new(build_client().unwrap(), base, "SESSDATA=x")
+    }
+
+    #[tokio::test]
+    async fn folders_maps_api_response_to_dto() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/folder/created/list-all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "message": "0",
+                "data": {
+                    "count": 2,
+                    "list": [
+                        {
+                            "id": 11, "fid": 11, "mid": 1, "attr": 0,
+                            "title": "Default", "media_count": 3,
+                            "upper": {"mid": 1, "name": "u1", "face": "https://face/1"}
+                        },
+                        { "id": 22, "fid": 22, "mid": 1, "attr": 0, "title": "NoUpper", "media_count": 0 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let folders = fetch_favorite_folders_via(&api_at(&server.uri()), 1)
+            .await
+            .unwrap();
+        assert_eq!(folders.len(), 2);
+        assert_eq!(folders[0].id, 11);
+        assert_eq!(folders[0].title, "Default");
+        assert_eq!(folders[0].media_count, 3);
+        let upper = folders[0].upper.as_ref().expect("upper present");
+        assert_eq!(upper.mid, 1);
+        assert_eq!(upper.name, "u1");
+        assert!(folders[1].upper.is_none(), "missing upper maps to None");
+    }
+
+    #[tokio::test]
+    async fn folders_without_data_list_returns_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/folder/created/list-all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0, "message": "0"
+            })))
+            .mount(&server)
+            .await;
+
+        let folders = fetch_favorite_folders_via(&api_at(&server.uri()), 1)
+            .await
+            .unwrap();
+        assert!(
+            folders.is_empty(),
+            "missing data.list must map to empty vec"
+        );
+    }
+
+    #[tokio::test]
+    async fn folders_unauthorized_maps_to_err_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/folder/created/list-all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": -101, "message": "账号未登录"
+            })))
+            .mount(&server)
+            .await;
+
+        let err = fetch_favorite_folders_via(&api_at(&server.uri()), 1)
+            .await
+            .unwrap_err();
+        assert_eq!(err, "ERR::UNAUTHORIZED");
+    }
+
+    #[tokio::test]
+    async fn folders_nonzero_code_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/folder/created/list-all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": -400, "message": "请求错误"
+            })))
+            .mount(&server)
+            .await;
+
+        let err = fetch_favorite_folders_via(&api_at(&server.uri()), 1)
+            .await
+            .unwrap_err();
+        assert!(err.contains("API error (code -400)"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn videos_maps_api_response_to_dto() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/resource/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "message": "0",
+                "data": {
+                    "has_more": true,
+                    "info": {"id": 98765, "fid": 98765, "mid": 1, "attr": 0, "title": "Fav", "cover": "https://c/f", "upper": {"mid": 1, "name": "u1", "face": "https://face/1"}, "cover_type": 0, "cnt_info": {"collect": 0, "play": 0, "thumb_up": 0, "share": 0}, "type": 0, "intro": "", "ctime": 0, "mtime": 0, "state": 0, "fav_state": 0, "media_count": 7},
+                    "medias": [
+                        {
+                            "id": 5, "type": 2, "title": "Video", "cover": "https://c/1",
+                            "intro": "", "page": 1, "duration": 60,
+                            "upper": {"mid": 2, "name": "upper2", "face": "https://face/2"},
+                            "attr": 0,
+                            "cnt_info": {"collect": 10, "play": 100, "danmaku": 5},
+                            "link": "https://b23.tv/x",
+                            "ctime": 0, "pubtime": 0, "fav_time": 0,
+                            "bv_id": "BV1xx", "bvid": "BV1xx"
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let resp = fetch_favorite_videos_via(&api_at(&server.uri()), 98765, 1, 20)
+            .await
+            .unwrap();
+        assert!(resp.has_more);
+        assert_eq!(resp.total_count, 7);
+        assert_eq!(resp.videos.len(), 1);
+        let v = &resp.videos[0];
+        assert_eq!(v.bvid, "BV1xx");
+        assert_eq!(v.play_count, 100);
+        assert_eq!(v.collect_count, 10);
+        assert_eq!(v.upper.name, "upper2");
+    }
+
+    #[tokio::test]
+    async fn videos_missing_data_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/resource/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0, "message": "0"
+            })))
+            .mount(&server)
+            .await;
+
+        let err = fetch_favorite_videos_via(&api_at(&server.uri()), 1, 1, 20)
+            .await
+            .unwrap_err();
+        assert_eq!(err, "No data in response");
+    }
+
+    #[tokio::test]
+    async fn videos_unauthorized_maps_to_err_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/x/v3/fav/resource/list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": -101, "message": "账号未登录"
+            })))
+            .mount(&server)
+            .await;
+
+        let err = fetch_favorite_videos_via(&api_at(&server.uri()), 1, 1, 20)
+            .await
+            .unwrap_err();
+        assert_eq!(err, "ERR::UNAUTHORIZED");
+    }
 }

--- a/src-tauri/src/handlers/github.rs
+++ b/src-tauri/src/handlers/github.rs
@@ -45,6 +45,12 @@ pub async fn fetch_repo_stars(owner: &str, repo: &str) -> Result<usize> {
         repo
     );
     let github = Octocrab::builder().build()?;
+    fetch_repo_stars_with(&github, owner, repo).await
+}
+
+/// Transport-injectable variant of [`fetch_repo_stars`] (test seam: wiremock
+/// tests pass a client whose base URL points at a local server).
+async fn fetch_repo_stars_with(github: &Octocrab, owner: &str, repo: &str) -> Result<usize> {
     let repository = github
         .repos(owner, repo)
         .get()
@@ -59,4 +65,101 @@ pub async fn fetch_repo_stars(owner: &str, repo: &str) -> Result<usize> {
         repo
     );
     Ok(stars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn mock_client(base: &str) -> Octocrab {
+        Octocrab::builder().base_uri(base).unwrap().build().unwrap()
+    }
+
+    #[tokio::test]
+    async fn returns_stargazers_count_on_success() {
+        let server = MockServer::start().await;
+        // Why: this fixture cannot shrink to just stargazers_count — octocrab's
+        // Repository model requires `id`/`name`/`url`, and every URL-typed field
+        // (`url`, `html_url`, and all `owner.*` URLs once `owner` is present) is
+        // `url::Url` and only parses absolute URLs, so a minimal or relative-URL
+        // body fails deserialization before the count is read
+        // (octocrab 0.42 src/models.rs, Repository/Author fields).
+        Mock::given(method("GET"))
+            .and(path("/repos/j4rviscmd/bilibili-downloader-gui"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 123456,
+                "name": "bilibili-downloader-gui",
+                "full_name": "j4rviscmd/bilibili-downloader-gui",
+                "private": false,
+                "stargazers_count": 42,
+                "html_url": "https://github.com/j4rviscmd/bilibili-downloader-gui",
+                "description": "desc",
+                "fork": false,
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "pushed_at": "2024-01-01T00:00:00Z",
+                "size": 1000,
+                "url": "https://api.github.com/repos/j4rviscmd/bilibili-downloader-gui",
+                "node_id": "R_123",
+                "owner": {"login": "j4rviscmd", "id": 1, "node_id": "U_1", "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4", "gravatar_id": "", "url": "https://api.github.com/users/j4rviscmd", "received_events_url": "https://api.github.com/users/j4rviscmd/received_events", "type": "User", "html_url": "https://github.com/j4rviscmd", "followers_url": "https://api.github.com/users/j4rviscmd/followers", "following_url": "https://api.github.com/users/j4rviscmd/following{/other_user}", "gists_url": "https://api.github.com/users/j4rviscmd/gists{/gist_id}", "organizations_url": "https://api.github.com/users/j4rviscmd/orgs", "repos_url": "https://api.github.com/users/j4rviscmd/repos", "starred_url": "https://api.github.com/users/j4rviscmd/starred{/owner}{/repo}", "subscriptions_url": "https://api.github.com/users/j4rviscmd/subscriptions", "events_url": "https://api.github.com/users/j4rviscmd/events{/privacy}", "site_admin": false}
+            })))
+            .mount(&server)
+            .await;
+
+        let stars = fetch_repo_stars_with(
+            &mock_client(&server.uri()),
+            "j4rviscmd",
+            "bilibili-downloader-gui",
+        )
+        .await
+        .unwrap();
+        assert_eq!(stars, 42);
+    }
+
+    #[tokio::test]
+    async fn missing_stargazers_count_counts_as_zero() {
+        let server = MockServer::start().await;
+        // Repository JSON without stargazers_count (serde default -> None)
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 1,
+                "name": "r",
+                "full_name": "o/r",
+                "private": false,
+                "url": "https://api.github.com/repos/o/r",
+                "node_id": "R_1",
+                "forks_count": 0,
+                "watchers_count": 0,
+                "open_issues_count": 0,
+                "default_branch": "main"
+            })))
+            .mount(&server)
+            .await;
+
+        let stars = fetch_repo_stars_with(&mock_client(&server.uri()), "o", "r")
+            .await
+            .unwrap();
+        assert_eq!(stars, 0);
+    }
+
+    #[tokio::test]
+    async fn api_error_is_wrapped_with_context() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let err = fetch_repo_stars_with(&mock_client(&server.uri()), "o", "missing")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to fetch repository"),
+            "error should carry request-failure context, got: {err}"
+        );
+    }
 }

--- a/src-tauri/src/handlers/init.rs
+++ b/src-tauri/src/handlers/init.rs
@@ -176,7 +176,11 @@ pub fn get_init_result(state: State<'_, Mutex<InitResult>>) -> InitResult {
 }
 
 /// Emits a synchronous init step (label only) to the splash window.
-fn emit_step(app: &AppHandle, label_key: &str) {
+// Why: generic over R — production callers pass AppHandle (= AppHandle<Wry>)
+// while tests pass tauri::test::mock_app()'s AppHandle<MockRuntime>
+// (tauri "test" dev-dependency feature, src-tauri/Cargo.toml); Emitter<R> is
+// the minimal bound covering both.
+fn emit_step<R: tauri::Runtime>(app: &impl Emitter<R>, label_key: &str) {
     let _ = app.emit_to(
         "splash",
         "init_step",
@@ -188,7 +192,11 @@ fn emit_step(app: &AppHandle, label_key: &str) {
 
 /// Emits an asynchronous init step (label + percentage) to the splash window.
 #[allow(dead_code)]
-fn emit_progress(app: &AppHandle, label_key: &str, percentage: Option<f64>) {
+fn emit_progress<R: tauri::Runtime>(
+    app: &impl Emitter<R>,
+    label_key: &str,
+    percentage: Option<f64>,
+) {
     let _ = app.emit_to(
         "splash",
         "init_progress",
@@ -197,4 +205,95 @@ fn emit_progress(app: &AppHandle, label_key: &str, percentage: Option<f64>) {
             percentage,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_step_serializes_camel_case() {
+        let json = serde_json::to_value(InitStep {
+            label_key: "init.cleanup_in_progress".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"labelKey": "init.cleanup_in_progress"})
+        );
+    }
+
+    #[test]
+    fn init_progress_serializes_camel_case_with_optional_percentage() {
+        let with_pct = serde_json::to_value(InitProgress {
+            label_key: "init.x".into(),
+            percentage: Some(42.5),
+        })
+        .unwrap();
+        assert_eq!(
+            with_pct,
+            serde_json::json!({"labelKey": "init.x", "percentage": 42.5})
+        );
+
+        let without_pct = serde_json::to_value(InitProgress {
+            label_key: "init.x".into(),
+            percentage: None,
+        })
+        .unwrap();
+        assert_eq!(
+            without_pct,
+            serde_json::json!({"labelKey": "init.x", "percentage": null})
+        );
+    }
+
+    #[test]
+    fn init_result_default_is_empty_and_serializes_camel_case() {
+        let default = InitResult::default();
+        assert!(default.settings.is_none());
+        assert!(default.user.is_none());
+        assert!(default.user_error.is_none());
+        assert!(!default.ffmpeg_success);
+
+        let json = serde_json::to_value(InitResult {
+            user_error: Some("ERR::UNAUTHORIZED".into()),
+            ffmpeg_success: true,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "settings": null,
+                "user": null,
+                "userError": "ERR::UNAUTHORIZED",
+                "ffmpegSuccess": true
+            })
+        );
+    }
+
+    #[test]
+    fn get_init_result_returns_managed_state() {
+        // mock_app lets State<T> resolution run without a real window/app;
+        // initialize() itself is NOT invoked (it would run the full network
+        // init — cleanup/ffmpeg/user fetch — against the mock runtime).
+        let app = tauri::test::mock_app();
+        let stored = InitResult {
+            ffmpeg_success: true,
+            ..Default::default()
+        };
+        app.manage(Mutex::new(stored));
+
+        let state: State<'_, Mutex<InitResult>> = app.state();
+        let result = get_init_result(state);
+        assert!(result.ffmpeg_success);
+        assert!(result.user.is_none());
+    }
+
+    #[test]
+    fn emit_step_to_missing_splash_window_is_swallowed() {
+        // The mock app has no "splash" window, so emit_to errors; emit_step
+        // must swallow it instead of panicking.
+        let app = tauri::test::mock_app();
+        emit_step(app.handle(), "init.cleanup_in_progress");
+    }
 }

--- a/src-tauri/src/utils/error_handler.rs
+++ b/src-tauri/src/utils/error_handler.rs
@@ -5,6 +5,20 @@
 
 use std::panic;
 
+/// Extracts a human-readable message from a panic payload.
+///
+/// Pure seam split out of the panic hook so payload handling is testable
+/// without triggering a real panic through the global hook.
+fn payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic payload".to_string()
+    }
+}
+
 /// Sets up a custom panic hook that logs panic information.
 ///
 /// This hook captures panic information (location and message) and
@@ -25,21 +39,30 @@ pub fn setup_panic_hook() {
             .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
             .unwrap_or_else(|| "unknown location".to_string());
 
-        let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic payload".to_string()
-        };
-
-        log::error!("[BE] APPLICATION PANIC at {}: {}", location, message);
+        log::error!(
+            "[BE] APPLICATION PANIC at {}: {}",
+            location,
+            payload_message(panic_info.payload())
+        );
     }));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Runs `f` with panic output silenced and returns the caught payload.
+    // Note: the panic hook is process-global while cargo test runs tests in
+    // parallel threads of one process, so restoring the saved hook is
+    // load-bearing — a test that leaves the silencer installed would swallow
+    // panic reporting for every other test (std::panic::set_hook).
+    fn catch_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> Box<dyn std::any::Any + Send> {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let payload = std::panic::catch_unwind(f).unwrap_err();
+        std::panic::set_hook(previous);
+        payload
+    }
 
     #[test]
     fn setup_panic_hook_installs_without_panicking() {
@@ -49,5 +72,28 @@ mod tests {
         let previous = std::panic::take_hook();
         setup_panic_hook();
         std::panic::set_hook(previous);
+    }
+
+    #[test]
+    fn payload_message_extracts_str_payload() {
+        // catch_unwind preserves the panic!(&str) payload boxed; downcast
+        // inside payload_message must recover the literal message.
+        let payload = catch_payload(|| panic!("boom-str"));
+        assert_eq!(payload_message(payload.as_ref()), "boom-str");
+    }
+
+    #[test]
+    fn payload_message_extracts_string_payload() {
+        let msg = String::from("boom-string");
+        let payload = catch_payload(|| panic!("{}", msg));
+        assert_eq!(payload_message(payload.as_ref()), "boom-string");
+    }
+
+    #[test]
+    fn payload_message_falls_back_for_non_string_payload() {
+        // panic_any with a non-string type exercises the fallback branch,
+        // which normal `panic!` cannot reach.
+        let payload = catch_payload(|| std::panic::panic_any(42usize));
+        assert_eq!(payload_message(payload.as_ref()), "Unknown panic payload");
     }
 }

--- a/src-tauri/src/utils/paths.rs
+++ b/src-tauri/src/utils/paths.rs
@@ -78,9 +78,13 @@ pub fn get_default_lib_path(app: &AppHandle) -> PathBuf {
 ///
 /// Returns the configured library path or the default path.
 pub fn get_lib_path(app: &AppHandle) -> PathBuf {
-    let settings_path = get_settings_path(app);
+    resolve_lib_path(&get_settings_path(app), &get_default_lib_path(app))
+}
 
-    if let Ok(settings_str) = fs::read_to_string(&settings_path) {
+/// Pure variant of [`get_lib_path`] over explicit paths (test seam:
+/// runs against a tempfile-backed settings file without an AppHandle).
+fn resolve_lib_path(settings_path: &Path, default_path: &Path) -> PathBuf {
+    if let Ok(settings_str) = fs::read_to_string(settings_path) {
         if let Ok(settings) = serde_json::from_str::<Settings>(&settings_str) {
             if let Some(custom_path) = settings.lib_path {
                 let path = PathBuf::from(custom_path);
@@ -90,9 +94,8 @@ pub fn get_lib_path(app: &AppHandle) -> PathBuf {
         }
     }
 
-    let default_path = get_default_lib_path(app);
-    ensure_dir_exists(&default_path);
-    default_path
+    ensure_dir_exists(default_path);
+    default_path.to_path_buf()
 }
 
 /// Returns the platform-specific path to the ffmpeg binary.
@@ -109,7 +112,11 @@ pub fn get_lib_path(app: &AppHandle) -> PathBuf {
 ///
 /// Returns the absolute path to the ffmpeg executable.
 pub fn get_ffmpeg_path(app: &AppHandle) -> PathBuf {
-    let lib = get_lib_path(app);
+    ffmpeg_path_in_lib(&get_lib_path(app))
+}
+
+/// Pure variant of [`get_ffmpeg_path`] over an explicit lib dir (test seam).
+fn ffmpeg_path_in_lib(lib: &Path) -> PathBuf {
     let subdir = ffmpeg_subdir();
 
     if cfg!(target_os = "windows") {
@@ -165,9 +172,112 @@ pub fn get_settings_path(app: &AppHandle) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// Writes a settings file with the given `libPath` into `dir` and
+    /// returns its path.
+    fn write_settings(dir: &Path, lib_path: Option<&str>) -> PathBuf {
+        let settings = crate::models::settings::Settings {
+            lib_path: lib_path.map(String::from),
+            ..Default::default()
+        };
+        let path = dir.join("settings.json");
+        std::fs::write(&path, serde_json::to_string(&settings).unwrap()).unwrap();
+        path
+    }
+
     #[test]
-    fn test_get_settings_path_returns_app_data_dir() {
-        // This test verifies that settings are stored in app_data_dir
-        // Actual implementation requires Tauri test context
+    fn ffmpeg_subdir_matches_platform() {
+        let subdir = ffmpeg_subdir();
+        if cfg!(target_os = "windows") {
+            assert_eq!(subdir, "ffmpeg-master-latest-win64-gpl");
+        } else if cfg!(target_os = "linux") {
+            assert_eq!(subdir, "ffmpeg-master-latest-linux64-gpl");
+        } else {
+            assert_eq!(subdir, "ffmpeg");
+        }
+    }
+
+    #[test]
+    fn resolve_lib_path_uses_custom_path_when_configured() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom-lib");
+        // The custom dir does not exist yet; resolve must create it
+        let settings = write_settings(tmp.path(), custom.to_str());
+        let default = tmp.path().join("lib");
+
+        let resolved = resolve_lib_path(&settings, &default);
+
+        assert_eq!(resolved, custom);
+        assert!(custom.is_dir(), "custom lib dir must be created on use");
+        assert!(
+            !default.exists(),
+            "default dir must not be created when unused"
+        );
+    }
+
+    #[test]
+    fn resolve_lib_path_falls_back_when_lib_path_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = write_settings(tmp.path(), None);
+        let default = tmp.path().join("lib");
+
+        let resolved = resolve_lib_path(&settings, &default);
+
+        assert_eq!(resolved, default);
+        assert!(default.is_dir(), "default lib dir must be created on use");
+    }
+
+    #[test]
+    fn resolve_lib_path_falls_back_when_settings_missing_or_invalid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nonexistent-settings.json");
+        let default = tmp.path().join("lib");
+        assert_eq!(
+            resolve_lib_path(&missing, &default),
+            default,
+            "missing settings file must fall back to default"
+        );
+
+        let invalid = tmp.path().join("invalid.json");
+        std::fs::write(&invalid, "not json{").unwrap();
+        assert_eq!(
+            resolve_lib_path(&invalid, &default),
+            default,
+            "unparseable settings file must fall back to default"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_paths_under_lib_match_platform_layout() {
+        let lib = Path::new("/fake/lib");
+        let bin = ffmpeg_path_in_lib(lib);
+
+        // Why: the doubled join(ffmpeg_subdir()) is not a bug — BtbN win64/linux
+        // archives contain a top-level folder named after the archive and are
+        // extracted into {lib}/{subdir} (get_ffmpeg_root_path), so the binary
+        // lands at {lib}/{subdir}/{subdir}/bin/ffmpeg; only the macOS archive is
+        // flat (commit 17e0db3 "Fix FFmpeg path double-nesting").
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                bin,
+                lib.join(ffmpeg_subdir())
+                    .join(ffmpeg_subdir())
+                    .join("bin")
+                    .join("ffmpeg")
+                    .with_extension("exe")
+            );
+        } else if cfg!(target_os = "linux") {
+            assert_eq!(
+                bin,
+                lib.join(ffmpeg_subdir())
+                    .join(ffmpeg_subdir())
+                    .join("bin")
+                    .join("ffmpeg")
+            );
+        } else {
+            // macOS: flat layout {lib}/ffmpeg/ffmpeg
+            assert_eq!(bin, lib.join(ffmpeg_subdir()).join("ffmpeg"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

R2 of the Rust test-coverage plan: 24 new unit tests across the five zero/low-coverage files, plus behavior-preserving seams where tests needed injection. Production code paths are unchanged — every seam is a delegate of the original logic.

| File | Lines coverage (local) | Tests | Approach |
|---|---|---|---|
| `handlers/favorites.rs` | 0% → 89% | 7 | `fetch_favorite_*_via` (`BiliApi` injectable) + wiremock: DTO mapping, empty list fallback, `ERR::UNAUTHORIZED` (-101), API error codes, missing data |
| `handlers/github.rs` | 0% → 91% | 3 | `fetch_repo_stars_with` (Octocrab injectable) + wiremock: star count, missing count → 0, error wrapping |
| `handlers/init.rs` | 0% → 48% | 5 | Runtime-generic `emit_step`/`emit_progress` (mock_app compatible, follows emits.rs pattern): camelCase serde, `get_init_result` state, emit-to-missing-window |
| `utils/error_handler.rs` | 36% → 80% | 4 | `payload_message` extraction; \&str / String / non-string payloads via `catch_unwind` |
| `utils/paths.rs` | 3% → 66% | 5 | `resolve_lib_path` + `ffmpeg_path_in_lib` pure variants: custom libPath, missing/invalid settings fallback, dir-creation side effects, platform layouts |

## Related Issue

Closes #610
Refs #609

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] `cargo test`: 385 unit + 11 doctests green (24 added)
- [x] `cargo clippy --all-targets -- -D warnings` green
- [x] `cargo fmt` applied
- [ ] CI Rust Coverage job green; record the CI-measured total in #609's ratchet history

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None — seams delegate to the original functions with identical behavior.

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated
- [x] i18n files synced (N/A — Rust only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)