### PR TITLE
test: cover ffmpeg merge-args and concat validation (R6), ratchet to 61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,8 +372,8 @@ jobs:
         # silently masking a threshold breach as a green, half-empty report
         # Why `report` (not a fresh run): reuses the profdata written by the
         # generate step above — tests run once per job
-        # Why 60: ratchet measured at 61.10% lines on this Ubuntu runner
-        # (issues #606/#609, after R4 PR #620), floor minus one following the
+        # Why 61: ratchet measured at 62.02% lines on this Ubuntu runner
+        # (issues #606/#609, after R5 PR #621), floor minus one following the
         # vitest.config.ts convention; bump per PR as coverage grows, never
         # lower it.
         # CAUTION: baseline must be measured on CI, not locally — macOS/nightly
@@ -389,7 +389,7 @@ jobs:
           rc=0
           cargo llvm-cov report --summary-only --show-missing-lines \
             --ignore-filename-regex 'src/(main|lib|menu)\.rs' \
-            --fail-under-lines 60 \
+            --fail-under-lines 61 \
             | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit $rc

--- a/src-tauri/src/handlers/concat.rs
+++ b/src-tauri/src/handlers/concat.rs
@@ -422,4 +422,134 @@ mod tests {
 
         cleanup_list(&list);
     }
+    // ---- R6: validation and path helpers ----
+
+    fn touch_mp4(dir: &std::path::Path, name: &str) -> String {
+        let p = dir.join(name);
+        std::fs::write(&p, b"x").unwrap();
+        p.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn validate_inputs_requires_at_least_two_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let one = touch_mp4(tmp.path(), "a.mp4");
+        let out = tmp.path().join("out.mp4");
+        assert_eq!(
+            validate_inputs(&[one], &out).unwrap_err(),
+            "ERR::CONCAT_TOO_FEW_FILES"
+        );
+        assert_eq!(
+            validate_inputs(&[], &out).unwrap_err(),
+            "ERR::CONCAT_TOO_FEW_FILES"
+        );
+    }
+
+    #[test]
+    fn validate_inputs_rejects_missing_and_non_mp4_inputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = touch_mp4(tmp.path(), "a.mp4");
+        let out = tmp.path().join("out.mp4");
+
+        let missing = tmp.path().join("ghost.mp4").to_str().unwrap().to_string();
+        assert_eq!(
+            validate_inputs(&[good.clone(), missing], &out).unwrap_err(),
+            "ERR::CONCAT_FILE_NOT_FOUND"
+        );
+
+        let bad = tmp.path().join("b.mkv");
+        std::fs::write(&bad, b"x").unwrap();
+        assert_eq!(
+            validate_inputs(&[good, bad.to_str().unwrap().to_string()], &out).unwrap_err(),
+            "ERR::CONCAT_UNSUPPORTED_FORMAT"
+        );
+    }
+
+    #[test]
+    fn validate_inputs_rejects_output_collision_and_bad_output_ext() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = touch_mp4(tmp.path(), "a.mp4");
+        let b = touch_mp4(tmp.path(), "b.mp4");
+
+        // An input that IS the output collides
+        let out_as_input = tmp.path().join("out.mp4");
+        std::fs::write(&out_as_input, b"x").unwrap();
+        assert_eq!(
+            validate_inputs(
+                &[a.clone(), out_as_input.to_str().unwrap().to_string()],
+                &out_as_input
+            )
+            .unwrap_err(),
+            "ERR::CONCAT_OUTPUT_COLLISION"
+        );
+
+        // Output must be .mp4
+        let bad_out = tmp.path().join("out.mkv");
+        assert_eq!(
+            validate_inputs(&[a, b], &bad_out).unwrap_err(),
+            "ERR::CONCAT_UNSUPPORTED_OUTPUT_FORMAT"
+        );
+    }
+
+    #[test]
+    fn validate_inputs_accepts_two_distinct_mp4s() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = touch_mp4(tmp.path(), "a.mp4");
+        let b = touch_mp4(tmp.path(), "b.mp4");
+        let out = tmp.path().join("out.mp4");
+        assert!(validate_inputs(&[a, b], &out).is_ok());
+    }
+
+    #[test]
+    fn is_same_file_prefers_canonical_and_falls_back_lexical() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("a.mp4");
+        std::fs::write(&a, b"x").unwrap();
+
+        assert!(is_same_file(&a, &a));
+        // Note: the parent-canonicalization fallback's positive direction
+        // (existing input vs. lexically-different nonexistent output that
+        // resolves equal) is NOT exercised here — a plain re-spelling of the
+        // same existing path canonicalizes directly, so it duplicates the
+        // assert above. Covered indirectly via validate_inputs collision.
+        assert!(!is_same_file(&a, &tmp.path().join("b.mp4")));
+
+        // Two nonexistent paths fall back to lexical equality
+        let ghost1 = tmp.path().join("ghost.mp4");
+        assert!(is_same_file(&ghost1, &tmp.path().join("ghost.mp4")));
+    }
+
+    #[test]
+    fn canonicalize_with_parent_rejoins_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("not-yet.mp4");
+        let canon = canonicalize_with_parent(&p).unwrap();
+        assert_eq!(canon.file_name().unwrap(), "not-yet.mp4");
+        // Parent must resolve to the real (canonicalized) temp dir
+        assert_eq!(
+            canon.parent().unwrap(),
+            std::fs::canonicalize(tmp.path()).unwrap().as_path()
+        );
+    }
+
+    #[test]
+    fn cleanup_list_removes_file_and_owned_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bilibili-dl-concat");
+        std::fs::create_dir_all(&dir).unwrap();
+        let list = dir.join("filelist_1.txt");
+        std::fs::write(&list, b"x").unwrap();
+
+        cleanup_list(&list);
+        assert!(!list.exists());
+        assert!(!dir.exists(), "owned empty dir removed");
+
+        // A list outside bilibili-dl-concat must not nuke its parent
+        let other_dir = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&other_dir).unwrap();
+        let other = other_dir.join("filelist.txt");
+        std::fs::write(&other, b"x").unwrap();
+        cleanup_list(&other);
+        assert!(other_dir.exists(), "foreign parent kept");
+    }
 }

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -1153,4 +1153,158 @@ mod tests {
         .unwrap();
         assert_audio_codec_pair(&args, "aac");
     }
+    // ---- R6: merge args builder, install path helpers ----
+
+    fn sub(path: &str, lang: &str, title: &str) -> SubtitleMergeOptions {
+        SubtitleMergeOptions {
+            path: std::path::PathBuf::from(path),
+            language: lang.to_string(),
+            title: title.to_string(),
+        }
+    }
+
+    #[test]
+    fn merge_args_none_mode_is_stream_copy() {
+        let args = build_merge_args(
+            "v.m4s",
+            "a.m4s",
+            "out.mp4",
+            &MergeMode::None,
+            AudioCodec::Copy,
+        )
+        .unwrap();
+        let joined = args.join(" ");
+        assert!(joined.contains("-c:v copy"));
+        assert!(joined.contains("-c:a copy"));
+        assert!(!joined.contains("-vf"));
+        assert!(joined.contains("-progress pipe:1"));
+        assert_eq!(args.last().unwrap(), "out.mp4");
+    }
+
+    #[test]
+    fn merge_args_aac_fallback_only_changes_audio_codec() {
+        let copy = build_merge_args("v", "a", "o", &MergeMode::None, AudioCodec::Copy).unwrap();
+        let aac = build_merge_args("v", "a", "o", &MergeMode::None, AudioCodec::Aac).unwrap();
+        assert!(copy.contains(&"-c:a".to_string()) && copy.contains(&"copy".to_string()));
+        assert!(aac.contains(&"-c:a".to_string()) && aac.contains(&"aac".to_string()));
+        // Only the codec token differs: identical arg count and layout
+        assert_eq!(copy.len(), aac.len());
+    }
+
+    #[test]
+    fn merge_args_softsub_maps_and_tags_each_track() {
+        let mode = MergeMode::SoftSub(vec![
+            sub("/s/eng.ass", "eng", "English"),
+            sub("/s/chi.ass", "chi", "Chinese"),
+        ]);
+        let args = build_merge_args("v", "a", "out.mp4", &mode, AudioCodec::Copy).unwrap();
+        let joined = args.join(" ");
+
+        // two extra inputs after video+audio
+        assert!(joined.contains("-i /s/eng.ass"));
+        assert!(joined.contains("-i /s/chi.ass"));
+        // maps: 0:v, 1:a, then one per subtitle starting at stream 2
+        assert!(joined.contains("-map 0:v"));
+        assert!(joined.contains("-map 1:a"));
+        assert!(joined.contains("-map 2:0"));
+        assert!(joined.contains("-map 3:0"));
+        // per-track mov_text metadata
+        assert!(joined.contains("-metadata:s:s:0 language=eng"));
+        assert!(joined.contains("-metadata:s:s:0 title=English"));
+        assert!(joined.contains("-metadata:s:s:1 language=chi"));
+        assert!(joined.contains("-metadata:s:s:1 title=Chinese"));
+        assert!(joined.contains("-c:s mov_text"));
+    }
+
+    #[test]
+    fn merge_args_hardsub_escapes_filter_specials() {
+        let mode = MergeMode::HardSub(sub(r"/tmp/C:\subs'x.ass", "eng", "English"));
+        let args = build_merge_args("v", "a", "o", &mode, AudioCodec::Aac).unwrap();
+
+        // Exact filter assertion: loose contains-checks pass even when the
+        // escape ORDER regresses (colon-before-backslash still contains
+        // "\:"), so pin the full expected filter grammar instead:
+        // backslash doubled first, then ':' escaped, then single quotes.
+        let vf_index = args.iter().position(|a| a == "-vf").unwrap();
+        assert_eq!(
+            args[vf_index + 1],
+            "subtitles='/tmp/C\\:\\\\subs'\\''x.ass'"
+        );
+        assert!(args.contains(&"libx264".to_string()));
+        assert!(args.contains(&"-preset".to_string()) && args.contains(&"fast".to_string()));
+    }
+
+    #[test]
+    fn build_ffmpeg_bin_path_matches_platform_layout() {
+        let base = std::path::Path::new("/lib");
+        let bin = build_ffmpeg_bin_path(base);
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                bin,
+                base.join("ffmpeg-master-latest-win64-gpl")
+                    .join("bin")
+                    .join("ffmpeg.exe")
+            );
+        } else if cfg!(target_os = "linux") {
+            assert_eq!(
+                bin,
+                base.join("ffmpeg-master-latest-linux64-gpl")
+                    .join("bin")
+                    .join("ffmpeg")
+            );
+        } else {
+            assert_eq!(bin, base.join("ffmpeg"));
+        }
+    }
+
+    #[test]
+    fn cleanup_ffmpeg_dir_removes_dir_file_or_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let dir = tmp.path().join("dir-root");
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested").join("x.bin"), b"x").unwrap();
+        cleanup_ffmpeg_dir(&dir);
+        assert!(!dir.exists(), "directory tree removed");
+
+        let file = tmp.path().join("file-root");
+        std::fs::write(&file, b"x").unwrap();
+        cleanup_ffmpeg_dir(&file);
+        assert!(!file.exists(), "single file removed");
+
+        // Missing path must not panic
+        cleanup_ffmpeg_dir(&tmp.path().join("absent"));
+    }
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("src");
+        std::fs::create_dir_all(from.join("a").join("b")).unwrap();
+        std::fs::write(from.join("top.txt"), b"top").unwrap();
+        std::fs::write(from.join("a").join("mid.txt"), b"mid").unwrap();
+        std::fs::write(from.join("a").join("b").join("leaf.txt"), b"leaf").unwrap();
+
+        let to = tmp.path().join("dst");
+        copy_dir_recursive(&from, &to).unwrap();
+
+        assert_eq!(std::fs::read(to.join("top.txt")).unwrap(), b"top");
+        assert_eq!(std::fs::read(to.join("a").join("mid.txt")).unwrap(), b"mid");
+        assert_eq!(
+            std::fs::read(to.join("a").join("b").join("leaf.txt")).unwrap(),
+            b"leaf"
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_empty_source_is_ok_without_creating_dest() {
+        // Pins actual behavior: dest directories are created lazily per
+        // entry, so an empty source copies nothing and creates no dest.
+        let tmp = tempfile::tempdir().unwrap();
+        let empty_src = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty_src).unwrap();
+        let to = tmp.path().join("dst");
+        copy_dir_recursive(&empty_src, &to).unwrap();
+        assert!(!to.exists(), "empty source must not create the dest");
+    }
 }


### PR DESCRIPTION
## Summary

R6 of the Rust test-coverage plan: 15 test-only additions across the media handlers, plus the ratchet bump.

- `ffmpeg.rs` (6→15): `build_merge_args` for all three subtitle modes — None (stream-copy), SoftSub (multi-track `-map`/metadata/`mov_text`), HardSub (**exact** subtitles-filter escape grammar, pinned via `assert_eq!` after review showed loose `contains` cannot catch escape-order regressions); `build_ffmpeg_bin_path` platform layouts; `cleanup_ffmpeg_dir`; `copy_dir_recursive` (incl. empty-source behavior pin)
- `concat.rs` (4→11): `validate_inputs` all five `ERR::CONCAT_*` branches + happy path; `is_same_file` canonical/lexical fallbacks; `canonicalize_with_parent`; `cleanup_list` owned-dir vs foreign-parent

`ci.yml`: `--fail-under-lines` 60 → 61 (CI measured 62.02% after R5, floor-1).

**Result vs target**: ffmpeg.rs 29.96% → **42.18%**, concat.rs 46.18% → **67.65%** (local). Both under their 60/75% goals — the remainder is `install_ffmpeg`/`validate_command`/`merge_avs`/`concat_videos` orchestration (process spawn + AppHandle emit); noted in #614.

## Related Issue

Closes #614
Refs #609

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] `cargo test`: 452 unit + 11 doctests green (15 added)
- [x] `cargo clippy --all-targets -- -D warnings` green
- [x] `cargo fmt` applied
- [ ] CI Rust Coverage green at ratchet 61; record CI total in #609

## Checklist

- [x] `/review-all` executed (code-reviewer pass; 2 assertion-strength/comment fixes applied)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated
- [x] i18n files synced (N/A — Rust only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)