### PR TITLE
chore: remove stray src-tauri/.language marker

### DIFF
--- a/src-tauri/.language
+++ b/src-tauri/.language
@@ -1,1 +1,0 @@
-japanese


### PR DESCRIPTION
## Summary

Deletes `src-tauri/.language` (contained `japanese`, tracked since 262f494). The repo language is `english` (root `.language`); the nested marker made detect-language misjudge any run whose cwd is `src-tauri`, risking Japanese PR/commit messages in an English repo. No tooling reads the nested file — the root marker is authoritative.

## Related Issue

None (housekeeping; surfaced during the coverage loop on 2026-09-09)

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] No code change — single file deletion
- [ ] CI green

## Checklist

- [x] Conventional Commits format followed
- [x] Tests (N/A)
- [x] i18n files synced (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)