### PR TITLE
refactor: make Emits Runtime-generic, e2e-test download_url (PR1 of #626)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,10 @@ jobs:
         # silently masking a threshold breach as a green, half-empty report
         # Why `report` (not a fresh run): reuses the profdata written by the
         # generate step above — tests run once per job
-        # Why 62: ratchet measured at 63.04% lines on this Ubuntu runner
-        # (issues #606/#609, after R6 PR #622), floor minus one following the
-        # vitest.config.ts convention; bump per PR as coverage grows, never
-        # lower it.
+        # Why 65: ratchet measured at 66.46% lines locally after the PR①
+        # orchestration e2e batch (issue #626); CI tracks local within ~0.3pt
+        # at this size (63.43 CI vs 63.16 local at R7), floor minus one per
+        # the vitest.config.ts convention; bump as coverage grows, never lower.
         # CAUTION: baseline must be measured on CI, not locally — macOS/nightly
         # measured 56.62% over 20174 lines while CI counts 12056 lines
         # (nightly rustc coverage mapping differs per platform)
@@ -389,7 +389,7 @@ jobs:
           rc=0
           cargo llvm-cov report --summary-only --show-missing-lines \
             --ignore-filename-regex 'src/(main|lib|menu)\.rs' \
-            --fail-under-lines 62 \
+            --fail-under-lines 65 \
             | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit $rc

--- a/src-tauri/src/emits.rs
+++ b/src-tauri/src/emits.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Runtime};
 // Why: tokio's Instant, not std, so the paused-clock tests below work:
 // with the test-util feature (dev-dependency only, src-tauri/Cargo.toml)
 // Instant::now() follows tokio::time::advance(); without it tokio
@@ -119,13 +119,17 @@ impl Default for EmitsInner {
 ///
 /// Uses watch::Sender for lock-free progress updates from download thread,
 /// avoiding contention with the background emission task.
-pub struct Emits {
-    app: AppHandle,
+// Why generic over R: production constructs Emits<Wry> from AppHandle<Wry>,
+// while tests construct Emits<MockRuntime> from tauri::test::mock_app()
+// (tauri "test" dev-dependency feature, src-tauri/Cargo.toml) — the same
+// seam as handlers/cookie.rs read_cookie and handlers/init.rs emits.
+pub struct Emits<R: Runtime> {
+    app: AppHandle<R>,
     inner: Arc<Mutex<EmitsInner>>,
     progress_tx: watch::Sender<u64>,
 }
 
-impl Emits {
+impl<R: Runtime> Emits<R> {
     /// Creates a new progress emitter and starts automatic updates.
     ///
     /// This function initializes the progress tracker, emits an initial progress
@@ -141,7 +145,7 @@ impl Emits {
     /// # Returns
     ///
     /// Returns a new `Emits` instance with an active background update task.
-    pub fn new(app: AppHandle, download_id: String, filesize_bytes: Option<u64>) -> Self {
+    pub fn new(app: AppHandle<R>, download_id: String, filesize_bytes: Option<u64>) -> Self {
         fn bytes_to_mb(bytes: u64) -> f64 {
             bytes as f64 / (1024.0 * 1024.0)
         }
@@ -323,15 +327,9 @@ impl Emits {
     ///
     /// * `app` - Tauri application handle for event emission
     /// * `inner` - Mutable reference to the locked inner state
-    // Why: generic over R — production callers pass AppHandle
-    // (= AppHandle<Wry>) while the tests pass tauri::test::mock_app()'s
-    // AppHandle<MockRuntime> (tauri "test" dev-dependency feature,
-    // src-tauri/Cargo.toml); Emitter<R> is the minimal bound covering both.
-    fn send_progress_locked<R: tauri::Runtime>(
-        app: &impl Emitter<R>,
-        inner: &mut EmitsInner,
-        current_bytes: u64,
-    ) {
+    // Rationale for the generic parameter: see the struct definition.
+    // Emitter<R> is the minimal bound covering both production and tests.
+    fn send_progress_locked(app: &impl Emitter<R>, inner: &mut EmitsInner, current_bytes: u64) {
         let now = Instant::now();
         let delta_time = now.duration_since(inner.last_instant).as_secs_f64();
         let elapsed_time = now.duration_since(inner.start_instant).as_secs_f64();
@@ -439,18 +437,24 @@ mod tests {
     fn calculate_percentage_uses_raw_byte_denominator() {
         // 5 MiB downloaded against 10 MiB total -> 50%
         assert_eq!(
-            Emits::calculate_percentage(5 * 1024 * 1024, Some(10 * 1024 * 1024)),
+            Emits::<tauri::Wry>::calculate_percentage(5 * 1024 * 1024, Some(10 * 1024 * 1024)),
             50.0
         );
         // Zero progress stays 0
-        assert_eq!(Emits::calculate_percentage(0, Some(10 * 1024 * 1024)), 0.0);
+        assert_eq!(
+            Emits::<tauri::Wry>::calculate_percentage(0, Some(10 * 1024 * 1024)),
+            0.0
+        );
     }
 
     #[test]
     fn calculate_percentage_unknown_size_is_zero() {
         // Unknown total (None) or zero total must not divide by zero.
-        assert_eq!(Emits::calculate_percentage(12345, None), 0.0);
-        assert_eq!(Emits::calculate_percentage(12345, Some(0)), 0.0);
+        assert_eq!(Emits::<tauri::Wry>::calculate_percentage(12345, None), 0.0);
+        assert_eq!(
+            Emits::<tauri::Wry>::calculate_percentage(12345, Some(0)),
+            0.0
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src-tauri/src/handlers/ffmpeg.rs
+++ b/src-tauri/src/handlers/ffmpeg.rs
@@ -16,7 +16,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use tauri::AppHandle;
+use tauri::{AppHandle, Runtime};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
 use tokio::time::timeout;
@@ -924,12 +924,12 @@ pub async fn merge_avs(
 /// Runs ffmpeg with the given args for merge operations.
 ///
 /// Handles progress parsing, cancellation, and stderr collection.
-async fn run_merge_ffmpeg(
+async fn run_merge_ffmpeg<R: Runtime>(
     ffmpeg_path: &Path,
     args: &[String],
     output_path: &Path,
     duration_ms: Option<u64>,
-    emits: &Emits,
+    emits: &Emits<R>,
     cancel_token: &Option<CancellationToken>,
 ) -> Result<(), String> {
     let mut cmd = AsyncCommand::new(ffmpeg_path);

--- a/src-tauri/src/models/frontend_dto.rs
+++ b/src-tauri/src/models/frontend_dto.rs
@@ -241,8 +241,10 @@ pub struct SubtitleDto {
 /// frontend. This avoids side effects where re-sending a full `Progress`
 /// payload would reset `filesize`/`downloaded` to `None`.
 ///
-/// CDN rotation inside `download_url` does NOT use this event; it sets
-/// `is_retrying` directly on the `Progress` payload via `Emits::set_retrying`.
+/// CDN rotation inside `download_url` does NOT use this event; the
+/// `is_retrying` field of the `Progress` payload stays `None` there (the
+/// `Emits::set_retrying` helper was removed along with the EMA speed
+/// smoothing in #491).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DownloadRetrying {

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -2625,4 +2625,57 @@ mod tests {
         assert!(err.to_string().contains("ERR::CANCELLED"), "got: {err}");
         assert!(!path.exists());
     }
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn download_url_fallback_open_failure_stops_emitter() {
+        // Drives the error funnel's Err arm (open failure inside the async
+        // block): the emitter must be stopped and nothing written.
+        let app = tauri::test::mock_app();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("range"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "text/html")
+                    .set_body_string("x"),
+            )
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "application/octet-stream")
+                    .set_body_bytes(e2e_body()),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Read-only parent: OpenOptions create fails with EACCES
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+        let path = dir.path().join("out.bin");
+
+        let result = download_url(
+            app.handle(),
+            server.uri(),
+            None,
+            path.clone(),
+            None,
+            false,
+            None,
+            None,
+            false,
+            1,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await;
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let err = result.unwrap_err();
+        assert!(!path.exists());
+        // The error is the raw io error (EACCES), not a cancel — and the
+        // emitter's ticker was stopped by the funnel before returning.
+        assert!(!err.to_string().contains("CANCELLED"), "got: {err}");
+    }
 }

--- a/src-tauri/src/utils/downloads.rs
+++ b/src-tauri/src/utils/downloads.rs
@@ -82,7 +82,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, Runtime};
 use tokio::sync::Semaphore;
 use tokio::{fs, io::AsyncSeekExt, io::AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
@@ -334,7 +334,7 @@ pub fn build_download_client() -> reqwest::Client {
 /// Files starting with "temp_audio" are marked as "audio" stage,
 /// and files starting with "temp_video" are marked as "video" stage.
 /// This allows the frontend to display which part of the download process is active.
-async fn set_stage_from_filename(emits: &Emits, filename: &str) {
+async fn set_stage_from_filename<R: Runtime>(emits: &Emits<R>, filename: &str) {
     let stage = if filename.starts_with("temp_audio") {
         Some("audio")
     } else if filename.starts_with("temp_video") {
@@ -605,8 +605,8 @@ fn content_range_start(value: &header::HeaderValue) -> Option<u64> {
 /// - Segment or final size mismatch after exhausting retries
 /// - Disk I/O failure (mapped to `ERR::DISK_FULL` for ENOSPC)
 #[allow(clippy::too_many_arguments)]
-pub async fn download_url(
-    app: &AppHandle,
+pub async fn download_url<R: Runtime>(
+    app: &AppHandle<R>,
     url: String,
     backup_urls: Option<Vec<String>>,
     output_path: PathBuf,
@@ -1664,11 +1664,13 @@ async fn download_segment_stream(
 /// Returns an anyhow error in the following cases:
 /// - `ERR::FILE_EXISTS` - File already exists and `is_override` is `false`
 /// - `ERR::CANCELLED` - Download was cancelled via the registry
+/// - `ERR::INVALID_MEDIA_RESPONSE` - Non-success HTTP status or non-media
+///   content type (so playurl-refetch retry can engage)
 /// - Disk I/O failure (mapped to `ERR::DISK_FULL` for ENOSPC)
 /// - HTTP/streaming failure from the underlying reqwest response
 #[allow(clippy::too_many_arguments)]
-async fn single_stream_fallback(
-    app: &AppHandle,
+async fn single_stream_fallback<R: Runtime>(
+    app: &AppHandle<R>,
     url: String,
     _backup_urls: Option<Vec<String>>, // Unused in fallback mode
     output_path: PathBuf,
@@ -1697,6 +1699,17 @@ async fn single_stream_fallback(
     // Build and send request using the shared client
     let req = apply_cookie(client.get(&url).header(header::REFERER, REFERER), &cookie);
     let mut resp = req.send().await?;
+    // Reject non-success statuses before streaming to disk. CAUTION: the
+    // media guard below cannot catch bare 4xx/5xx — is_media_content_type
+    // treats a MISSING Content-Type header as media, so a 404 with no
+    // content-type was persisted as a 0-byte "download".
+    if !resp.status().is_success() {
+        log::error!(
+            "[BE] download_url: single-stream invalid status {}, not streaming to disk",
+            resp.status()
+        );
+        return Err(anyhow::anyhow!("ERR::INVALID_MEDIA_RESPONSE"));
+    }
     // Reject non-media error responses before streaming to disk (see
     // is_media_content_type). Mirrors the segmented path's guard so the
     // fallback path cannot silently persist a JSON/text error payload.
@@ -1721,38 +1734,47 @@ async fn single_stream_fallback(
         let _ = emits.set_stage(stage).await;
     }
 
-    // Open file and download
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&output_path)
-        .await
-        .map_err(map_io_error)?;
-
     let mut downloaded: u64 = 0;
-    let emits_for_callback = emits.clone();
-    while let Some(chunk) = resp.chunk().await? {
-        // Check cancellation on each chunk
-        if let Err(e) = check_cancelled(&cancel_token) {
-            let _ = emits.stop().await;
-            return Err(e);
+    // Stream to disk; on ANY failure (open, stream error, cancel, disk
+    // error) stop the emitter first — its ticker task only exits once
+    // is_complete is set, so returning without stop()/complete() leaks a
+    // 500ms progress loop.
+    let result: Result<()> = async {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&output_path)
+            .await
+            .map_err(map_io_error)?;
+
+        while let Some(chunk) = resp.chunk().await? {
+            check_cancelled(&cancel_token)?;
+            file.write_all(&chunk).await.map_err(map_io_error)?;
+            downloaded += chunk.len() as u64;
+            // Emit progress update via watch channel (non-blocking)
+            emits.update_progress(downloaded);
         }
-
-        file.write_all(&chunk).await.map_err(map_io_error)?;
-        downloaded += chunk.len() as u64;
-        // Emit progress update via watch channel (non-blocking)
-        emits_for_callback.update_progress(downloaded);
+        file.flush().await.map_err(map_io_error)?;
+        Ok(())
     }
+    .await;
 
-    file.flush().await.map_err(map_io_error)?;
-    if emit_complete {
-        emits.complete().await;
-    } else {
-        // Stop background task without emitting complete event
-        emits.stop().await;
+    match result {
+        Ok(()) => {
+            if emit_complete {
+                emits.complete().await;
+            } else {
+                // Stop background task without emitting complete event
+                emits.stop().await;
+            }
+            Ok(())
+        }
+        Err(e) => {
+            emits.stop().await;
+            Err(e)
+        }
     }
-    Ok(())
 }
 
 /// Implements capped exponential backoff sleep for retry logic.
@@ -2354,5 +2376,253 @@ mod tests {
     fn build_download_client_constructs() {
         // Smoke: the shared client must build with the tuned pool options.
         let _client = build_download_client();
+    }
+    // ---- PR① e2e: download_url / single_stream_fallback via mock_app ----
+
+    /// 4096 bytes (251-value cycle): > MIN_MEDIA_BYTES (1 KiB) so the final
+    /// size floor passes, < 32 MiB segment size so one segment covers it.
+    fn e2e_body() -> Vec<u8> {
+        (0..4096u32).map(|i| (i % 251) as u8).collect()
+    }
+
+    /// Mounts the 206 mock that satisfies BOTH the CDN probe and the segment
+    /// GET (both carry a Range header).
+    async fn segmented_206_mock(server: &wiremock::MockServer, body: &[u8]) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(206)
+                    .insert_header(
+                        "Content-Range",
+                        format!("bytes 0-{}/{}", body.len() - 1, body.len()),
+                    )
+                    .insert_header("Content-Type", "application/octet-stream")
+                    .set_body_bytes(body.to_vec()),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn download_url_segmented_path_writes_exact_bytes() {
+        // Proves the Emits<R> generic refactor end-to-end: the whole
+        // download pipeline runs against AppHandle<MockRuntime>.
+        let app = tauri::test::mock_app();
+        let server = wiremock::MockServer::start().await;
+        let body = e2e_body();
+        segmented_206_mock(&server, &body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+
+        download_url(
+            app.handle(),
+            server.uri(),
+            None,
+            path.clone(),
+            None,
+            false,
+            None,
+            None,
+            false,
+            2,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), body, "byte-exact output");
+    }
+
+    #[tokio::test]
+    async fn download_url_falls_back_when_probe_serves_html() {
+        let app = tauri::test::mock_app();
+        let server = wiremock::MockServer::start().await;
+        // Mount order is load-bearing: equal-priority mocks match in
+        // registration order, so the Range-header mock must come first to
+        // answer the probe; the Range-less mock answers the fallback GET.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("range"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "text/html")
+                    .set_body_string("<html>error</html>"),
+            )
+            .mount(&server)
+            .await;
+        let body = e2e_body();
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "application/octet-stream")
+                    .set_body_bytes(body.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        download_url(
+            app.handle(),
+            server.uri(),
+            None,
+            path.clone(),
+            None,
+            false,
+            None,
+            None,
+            false,
+            2,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), body);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests[0].headers.contains_key("range"),
+            "probe request carries Range"
+        );
+        assert!(
+            !requests[1].headers.contains_key("range"),
+            "fallback GET has no Range"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_url_fallback_rejects_404_with_media_content_type() {
+        // Regression for the status guard: a 404 with a media-looking (or
+        // absent) Content-Type used to be streamed to disk as a 0-byte
+        // "successful" download.
+        let app = tauri::test::mock_app();
+        let server = wiremock::MockServer::start().await;
+        // Probe mock: Range-bearing GET gets a media-typed 404, so the probe
+        // fails the size lookup and download_url routes to the fallback.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("range"))
+            .respond_with(wiremock::ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        // Fallback mock: Range-less GET gets the same 404 (with a media
+        // content-type so only the status guard can reject it).
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(404)
+                    .insert_header("Content-Type", "application/octet-stream"),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        let err = download_url(
+            app.handle(),
+            server.uri(),
+            None,
+            path.clone(),
+            None,
+            false,
+            None,
+            None,
+            false,
+            2,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("ERR::INVALID_MEDIA_RESPONSE"),
+            "got: {err}"
+        );
+        assert!(!path.exists(), "nothing written to disk");
+    }
+
+    #[tokio::test]
+    async fn download_url_errors_when_file_exists() {
+        let app = tauri::test::mock_app();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        std::fs::write(&path, b"existing").unwrap();
+
+        let err = download_url(
+            app.handle(),
+            // Unroutable: the existence check precedes any HTTP call.
+            "http://127.0.0.1:9/x".to_string(),
+            None,
+            path.clone(),
+            None,
+            false,
+            None,
+            None,
+            false,
+            1,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("ERR::FILE_EXISTS"), "got: {err}");
+        assert_eq!(std::fs::read(&path).unwrap(), b"existing");
+    }
+
+    #[tokio::test]
+    async fn download_url_override_replaces_existing_file() {
+        let app = tauri::test::mock_app();
+        let server = wiremock::MockServer::start().await;
+        let body = e2e_body();
+        segmented_206_mock(&server, &body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        std::fs::write(&path, b"stale junk").unwrap();
+
+        download_url(
+            app.handle(),
+            server.uri(),
+            None,
+            path.clone(),
+            None,
+            true,
+            None,
+            None,
+            false,
+            2,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn download_url_pre_cancelled_id_errors_immediately() {
+        // register -> cancel drops the token but flags the id, so
+        // resolve_cancel_token's is_cancelled fallback fires before any HTTP.
+        let id = "e2e-precancel";
+        let (_token, _guard) = DOWNLOAD_CANCEL_REGISTRY.register(id);
+        DOWNLOAD_CANCEL_REGISTRY.cancel(id);
+
+        let app = tauri::test::mock_app();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin");
+        let err = download_url(
+            app.handle(),
+            "http://127.0.0.1:9/x".to_string(),
+            None,
+            path.clone(),
+            None,
+            false,
+            Some(id.to_string()),
+            None,
+            false,
+            1,
+            Arc::new(cdn_selector::HostHealth::new()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("ERR::CANCELLED"), "got: {err}");
+        assert!(!path.exists());
     }
 }


### PR DESCRIPTION
## Summary

First orchestration-layer batch of #626:  becomes -generic (extending the seam only `send_progress_locked` had), unlocking end-to-end tests of the download pipeline via `mock_app` + wiremock. Plus two fixes in `single_stream_fallback` surfaced during design/exploration.

| Change | Behavior |
|---|---|
| `Emits<R: Runtime>` + 4 signatures carry `<R>` (`merge_avs` stays concrete) | **None** — monomorphizes to `Emits<Wry>`; acceptance criterion: no diffs outside the touched files |
| Status guard: non-2xx → `ERR::INVALID_MEDIA_RESPONSE` before streaming | **Intended fix** — a bare 404 (no Content-Type counts as media) used to persist as a 0-byte "successful" download; now fails into the existing playurl-refetch retry path |
| Single error funnel (open/stream/cancel/disk) always `emits.stop()` | Internal — stops the 500ms progress-ticker leak on every failure path (reviewer also caught the file-open gap) |
| `frontend_dto.rs` stale doc (`set_retrying`, removed in #491) | Doc only |

**6 new e2e tests** (wiremock + mock_app + tmpdir): segmented happy path (byte-exact), probe-serves-HTML → fallback (request order + Range-presence asserted), 404-with-media-type rejection (regression), `ERR::FILE_EXISTS`, override replacement, pre-cancelled id.

**Coverage**:  52.33% → **77.00%** lines (+373); crate 63.16% → **66.46%** local. `ci.yml` ratchet 62 → 65.

## Related Issue

Refs #626
Refs #609

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [x] 🐛 Bug fix (single_stream status guard)

## Test Plan

- [x] `cargo test`: 469 unit + 11 doctests green (6 e2e added)
- [x] `cargo clippy --all-targets -- -D warnings` green; `cargo fmt` applied
- [x] Reviewer drift-check: old-vs-new `single_stream_fallback` line-by-line — only the two intended divergences
- [ ] CI green at ratchet 65

## Checklist

- [x] `/review-all` executed (2 reviewers; open-failure leak + doc structure fixed on review)
- [x] Conventional Commits format followed
- [x] Tests added/updated
- [x] i18n files synced (N/A — error code pre-existing and already mapped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)