### PR TITLE
chore: add Renovate configuration for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 6am on Monday"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Group @tauri-apps npm packages (api, cli, plugins) so JS-side versions stay in sync",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@tauri-apps/"],
+      "groupName": "tauri-npm"
+    },
+    {
+      "description": "Group tauri crates (tauri, tauri-build, tauri-plugin-*) so Rust-side versions stay in sync",
+      "matchManagers": ["cargo"],
+      "matchPackagePatterns": ["^tauri"],
+      "groupName": "tauri-cargo"
+    },
+    {
+      "description": "Automerge non-major updates once CI passes; majors stay manual",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` at the repository root to enable Renovate version updates (npm / cargo / github-actions managers via `config:recommended`)
- Weekly schedule: Monday before 6am JST (`Asia/Tokyo`)
- Group tauri packages separately for npm (`@tauri-apps/*`) and cargo (`tauri`, `tauri-plugin-*`) so both sides stay in version sync
- Automerge minor/patch updates once the required `ci-status` check passes; majors stay manual
- Enable `lockFileMaintenance` to refresh lockfiles weekly without manifest churn (keeps transitive deps like rustls current)

Note: version updates start once the Mend Renovate App is installed (repo owner action, "Only select repositories"). Dependabot vulnerability alerts + automated security fixes have already been enabled at the repo level, and `allow_auto_merge` was enabled for platform-native automerge.

## Related Issue

None (no existing issue covers this)

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] `renovate-config-validator`: Config validated successfully
- [x] `prettier --check`: passes
- [ ] After merge + App install: Dependency Dashboard issue is created and update PRs arrive (minor/patch grouped, automerged on green CI)

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
- [x] Conventional Commits format followed in commit messages
- [x] Tests added/updated (N/A — config file only)
- [x] i18n files synced (N/A — no user-facing text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)