### PR TITLE
chore: update PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,7 +49,7 @@ Examples:
 
 ## Checklist
 
-- [ ] `/review-all` executed (format → code-reviewer → code-simplifier → doc-generator)
 - [ ] Conventional Commits format followed in commit messages
+- [ ] PR title/body written in English
 - [ ] Tests added/updated (or N/A for docs/chore)
 - [ ] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)


### PR DESCRIPTION
## Summary

- Remove the `/review-all` checklist item from the PR template — it references internal Claude Code tooling that outside contributors do not have
- Add a "PR title/body written in English" checkbox next to the Conventional Commits item, enforcing the language convention already documented in CONTRIBUTING.md

## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] Verify `prettier --check .github/PULL_REQUEST_TEMPLATE.md` passes (CI enforces `prettier --check .`)
- [x] Verify the rendered checklist on this PR shows the updated items

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no user-facing app text changed