### PR TITLE
ci: add auto-merge workflow for Dependabot security PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,46 @@
+# Auto-merge Dependabot security update PRs once CI passes.
+#
+# Dependabot-triggered pull_request workflows receive a read-only
+# GITHUB_TOKEN, so this workflow uses workflow_run (which runs on the
+# default branch with normal permissions) to enable GitHub auto-merge.
+# The PR ruleset lists Dependabot (integration 29110) as a bypass actor,
+# so no review is required; GitHub merges once all required checks
+# (ci-status) pass.
+name: Dependabot auto-merge
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Why: workflow_run fires for every CI completion regardless of who opened the PR; the
+    # actor check is what confines auto-merge to Dependabot branches (without it, any PR
+    # whose CI passed would get auto-merge enabled here)
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge on the Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Note: an empty result is expected, not an error — workflow_run fires on every CI
+          # completion, including re-runs and runs whose PR was already merged or closed
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR for branch $HEAD_BRANCH; skipping"
+            exit 0
+          fi
+          # Why: --auto requires an explicit merge strategy outside a merge queue (gh pr merge --help);
+          # --merge matches the repo's merge-commit history (main consists of "Merge pull request" commits)
+          gh pr merge --auto --merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+          echo "Auto-merge enabled for PR #$PR_NUMBER"


### PR DESCRIPTION
## Summary

Add a `workflow_run`-based workflow that enables GitHub auto-merge on Dependabot security update PRs once CI passes, so security fixes land without manual merging.

## Background

Dependency management is split between Renovate (scheduled version updates, automerged) and Dependabot security updates (instant PRs on advisory detection). Dependabot PRs were the only ones still requiring manual review + merge.

## How it works

1. The ruleset `Main Branch Protection` now lists Dependabot (integration 29110) as a `pull_request` bypass actor (same treatment as Renovate), so its PRs need no review
2. This workflow triggers on CI completion, gated on: `pull_request` event + CI success + actor `dependabot[bot]`
3. It runs `gh pr merge --auto --merge` — GitHub merges once all required checks (`CI status check`) pass

## Why `workflow_run` instead of `pull_request`

Dependabot-triggered `pull_request` workflows receive a read-only `GITHUB_TOKEN` (per GitHub docs), so they cannot enable auto-merge. `workflow_run` runs on the default branch with normal permissions; no PAT needed.

## Notes

- `--merge` (merge commit) matches this repo's merge policy
- Empty PR lookup results (`// empty` jq fallback) skip gracefully — re-runs or already-merged PRs exit 0
- Only CI conclusion gates this workflow; E2E remains informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)