### PR TITLE
test(tools): seam tool executors, e2e-test trim/rotate/concat/audio

### DIFF
--- a/src-tauri/src/handlers/audio.rs
+++ b/src-tauri/src/handlers/audio.rs
@@ -181,6 +181,21 @@ fn compute_progress(line: &str, total_duration_sec: f64) -> Option<AudioProgress
 /// - `ERR::AUDIO_INVALID_BITRATE`
 /// - `ERR::AUDIO_FFMPEG_FAILED`
 pub async fn extract_audio(app: &AppHandle, options: &AudioOptions) -> Result<AudioResult, String> {
+    extract_audio_with_ffmpeg(&get_ffmpeg_path(app), app, options).await
+}
+
+/// Path-injected split of [`extract_audio`] (test seam, issue #646): runs the
+/// same validation→args→spawn→progress flow against an explicit ffmpeg
+/// binary so tests drive it with a fake script in a tempdir.
+// Why: generic over R, not the default-Wry `&AppHandle`, because the E2E tests
+// below pass `tauri::test::mock_app().handle()` (`AppHandle<MockRuntime>`,
+// tauri "test" feature in src-tauri/Cargo.toml), which only type-checks
+// against a generic Runtime param (issue #646).
+pub(crate) async fn extract_audio_with_ffmpeg<R: tauri::Runtime>(
+    ffmpeg_path: &Path,
+    app: &tauri::AppHandle<R>,
+    options: &AudioOptions,
+) -> Result<AudioResult, String> {
     let input_path = Path::new(&options.input_path);
     let output_path = Path::new(&options.output_path);
 
@@ -193,12 +208,11 @@ pub async fn extract_audio(app: &AppHandle, options: &AudioOptions) -> Result<Au
     }
     validate_value(options)?;
 
-    let ffmpeg_path = get_ffmpeg_path(app);
     let args = build_ffmpeg_args(options);
 
-    let total_duration_sec = probe_duration_sec(&ffmpeg_path, &options.input_path).await;
+    let total_duration_sec = probe_duration_sec(ffmpeg_path, &options.input_path).await;
 
-    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
     cmd.args(&args);
 
     #[cfg(target_os = "windows")]
@@ -398,5 +412,64 @@ mod tests {
             json,
             serde_json::json!({"progress": 10.0, "currentTimeSec": 6.0, "totalDurationSec": 60.0})
         );
+    }
+
+    // ---- PR⑧: executor E2E (issue #646) ----
+    //
+    // The fake ffmpeg writes a sentinel to the output path on success, so
+    // assertions target the file, never stderr (PR #619/#624 flake lesson).
+
+    #[cfg(unix)]
+    use crate::utils::ffmpeg_probe::write_fake_ffmpeg_executor;
+
+    fn audio_options(input: &str, output: &str) -> AudioOptions {
+        AudioOptions {
+            input_path: input.to_string(),
+            output_path: output.to_string(),
+            format: AudioFormat::Mp3,
+            bitrate_kbps: 192,
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn extract_audio_with_ffmpeg_writes_output_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, false);
+        let input = dir.path().join("in.mp4");
+        std::fs::write(&input, b"input").unwrap();
+        let output = dir.path().join("out.mp3");
+
+        let app = tauri::test::mock_app();
+        let result = extract_audio_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &audio_options(&input.to_string_lossy(), &output.to_string_lossy()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.output_path, output.to_string_lossy());
+        assert_eq!(std::fs::read(&output).unwrap(), b"fake-ffmpeg-output\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn extract_audio_with_ffmpeg_maps_failure_to_err_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 1, false);
+        let input = dir.path().join("in.mp4");
+        std::fs::write(&input, b"input").unwrap();
+        let output = dir.path().join("out.mp3");
+
+        let app = tauri::test::mock_app();
+        let err = extract_audio_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &audio_options(&input.to_string_lossy(), &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::AUDIO_FFMPEG_FAILED"), "got: {err}");
     }
 }

--- a/src-tauri/src/handlers/concat.rs
+++ b/src-tauri/src/handlers/concat.rs
@@ -183,8 +183,8 @@ fn cleanup_list(path: &std::path::Path) {
 
 /// Runs ffmpeg with the given args, emitting progress events.
 /// Returns the full stderr output on success, or an error string on failure.
-async fn run_ffmpeg_with_progress(
-    app: &AppHandle,
+async fn run_ffmpeg_with_progress<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     ffmpeg_path: &Path,
     args: &[String],
     total_duration_sec: Option<f64>,
@@ -305,16 +305,29 @@ pub async fn concat_videos(
     app: &AppHandle,
     options: &ConcatOptions,
 ) -> Result<ConcatResult, String> {
+    concat_videos_with_ffmpeg(&get_ffmpeg_path(app), app, options).await
+}
+
+/// Path-injected split of [`concat_videos`] (test seam, issue #646): runs
+/// the same probe→list→copy→fallback-reencode flow against an explicit
+/// ffmpeg binary so tests drive it with a fake script in a tempdir.
+// Why: generic over R, not the default-Wry `&AppHandle`, because the E2E tests
+// below pass `tauri::test::mock_app().handle()` (`AppHandle<MockRuntime>`,
+// tauri "test" feature in src-tauri/Cargo.toml), which only type-checks
+// against a generic Runtime param (issue #646).
+pub(crate) async fn concat_videos_with_ffmpeg<R: tauri::Runtime>(
+    ffmpeg_path: &Path,
+    app: &tauri::AppHandle<R>,
+    options: &ConcatOptions,
+) -> Result<ConcatResult, String> {
     let output_path = Path::new(&options.output_path);
 
     validate_inputs(&options.input_paths, output_path)?;
 
-    let ffmpeg_path = get_ffmpeg_path(app);
-
     // Probe total duration across all input files
     let mut total_duration: f64 = 0.0;
     for p in &options.input_paths {
-        if let Some(d) = probe_duration_sec(&ffmpeg_path, p).await {
+        if let Some(d) = probe_duration_sec(ffmpeg_path, p).await {
             total_duration += d;
         }
     }
@@ -328,7 +341,7 @@ pub async fn concat_videos(
     let copy_args = build_concat_copy_args(&list_str, &output_str);
     let copy_result = run_ffmpeg_with_progress(
         app,
-        &ffmpeg_path,
+        ffmpeg_path,
         &copy_args,
         total_duration,
         "ERR::CONCAT_FFMPEG_FAILED",
@@ -356,7 +369,7 @@ pub async fn concat_videos(
     let reencode_args = build_concat_reencode_args(&list_str, &output_str);
     let reencode_result = run_ffmpeg_with_progress(
         app,
-        &ffmpeg_path,
+        ffmpeg_path,
         &reencode_args,
         total_duration,
         "ERR::CONCAT_REENCODE_FAILED",
@@ -551,5 +564,96 @@ mod tests {
         std::fs::write(&other, b"x").unwrap();
         cleanup_list(&other);
         assert!(other_dir.exists(), "foreign parent kept");
+    }
+
+    // ---- PR⑧: executor E2E (issue #646) ----
+    //
+    // The fake ffmpeg writes a sentinel to the output path on success and
+    // `fail_on_copy` makes stream-copy invocations exit 1, driving the
+    // re-encode fallback. Assertions target the output file, never stderr
+    // (PR #619/#624 flake lesson).
+
+    #[cfg(unix)]
+    use crate::utils::ffmpeg_probe::write_fake_ffmpeg_executor;
+
+    fn concat_fixture(dir: &std::path::Path, count: usize) -> Vec<String> {
+        (0..count)
+            .map(|i| {
+                let p = dir.join(format!("in{i}.mp4"));
+                std::fs::write(&p, b"input").unwrap();
+                p.to_string_lossy().into_owned()
+            })
+            .collect()
+    }
+
+    fn concat_options(inputs: &[String], output: &str) -> ConcatOptions {
+        ConcatOptions {
+            input_paths: inputs.to_vec(),
+            output_path: output.to_string(),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concat_videos_with_ffmpeg_copy_success_writes_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, false);
+        let inputs = concat_fixture(dir.path(), 2);
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let result = concat_videos_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &concat_options(&inputs, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.output_path, output.to_string_lossy());
+        assert_eq!(std::fs::read(&output).unwrap(), b"fake-ffmpeg-output\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concat_videos_with_ffmpeg_falls_back_to_reencode() {
+        // copy fails -> fallback event + re-encode attempt (which succeeds
+        // because its args carry -c:v, not " copy ").
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, true);
+        let inputs = concat_fixture(dir.path(), 2);
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let result = concat_videos_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &concat_options(&inputs, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.output_path, output.to_string_lossy());
+        assert!(output.exists(), "re-encode wrote the output");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concat_videos_with_ffmpeg_both_attempts_failing_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        // copy fails (fail_on_copy) and re-encode fails (exit 1).
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 1, true);
+        let inputs = concat_fixture(dir.path(), 2);
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let err = concat_videos_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &concat_options(&inputs, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::CONCAT_REENCODE_FAILED"), "got: {err}");
     }
 }

--- a/src-tauri/src/handlers/rotation.rs
+++ b/src-tauri/src/handlers/rotation.rs
@@ -253,6 +253,21 @@ pub async fn rotate_video(
     app: &AppHandle,
     options: &RotationOptions,
 ) -> Result<RotationResult, String> {
+    rotate_video_with_ffmpeg(&get_ffmpeg_path(app), app, options).await
+}
+
+/// Path-injected split of [`rotate_video`] (test seam, issue #646): runs the
+/// same validation→args→spawn→progress flow against an explicit ffmpeg
+/// binary so tests drive it with a fake script in a tempdir.
+// Why: generic over R, not the default-Wry `&AppHandle`, because the E2E tests
+// below pass `tauri::test::mock_app().handle()` (`AppHandle<MockRuntime>`,
+// tauri "test" feature in src-tauri/Cargo.toml), which only type-checks
+// against a generic Runtime param (issue #646).
+pub(crate) async fn rotate_video_with_ffmpeg<R: tauri::Runtime>(
+    ffmpeg_path: &Path,
+    app: &tauri::AppHandle<R>,
+    options: &RotationOptions,
+) -> Result<RotationResult, String> {
     let input_path = Path::new(&options.input_path);
     let output_path = Path::new(&options.output_path);
 
@@ -270,7 +285,6 @@ pub async fn rotate_video(
     }
     let angle = resolve_angle(options.angle)?;
 
-    let ffmpeg_path = get_ffmpeg_path(app);
     let input_str = options.input_path.clone();
     let output_str = options.output_path.clone();
     let args = build_ffmpeg_args(&input_str, angle, &output_str, options.mode);
@@ -278,9 +292,9 @@ pub async fn rotate_video(
     // Probe input duration for progress tracking. In copy mode this is unused
     // (ffmpeg finishes near-instantly), but probing is cheap and keeps the
     // progress loop below uniform with the other tool handlers.
-    let total_duration_sec = probe_duration_sec(&ffmpeg_path, &input_str).await;
+    let total_duration_sec = probe_duration_sec(ffmpeg_path, &input_str).await;
 
-    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
     cmd.args(&args);
 
     #[cfg(target_os = "windows")]
@@ -544,5 +558,84 @@ mod tests {
         assert!(args.contains(&"-stats_period".to_string()));
         assert!(args.contains(&"-progress".to_string()));
         assert!(args.contains(&"pipe:2".to_string()));
+    }
+
+    // ---- PR⑧: executor E2E (issue #646) ----
+    //
+    // The fake ffmpeg writes a sentinel to the output path on success, so
+    // assertions target the file, never stderr (PR #619/#624 flake lesson).
+
+    #[cfg(unix)]
+    use crate::utils::ffmpeg_probe::write_fake_ffmpeg_executor;
+
+    fn rotation_options(input: &str, output: &str) -> RotationOptions {
+        RotationOptions {
+            input_path: input.to_string(),
+            output_path: output.to_string(),
+            angle: 90,
+            mode: RotationMode::Copy,
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rotate_video_with_ffmpeg_writes_output_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, false);
+        let input = dir.path().join("in.mp4");
+        std::fs::write(&input, b"input").unwrap();
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let result = rotate_video_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &rotation_options(&input.to_string_lossy(), &output.to_string_lossy()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.output_path, output.to_string_lossy());
+        assert_eq!(std::fs::read(&output).unwrap(), b"fake-ffmpeg-output\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rotate_video_with_ffmpeg_maps_failure_to_err_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 1, false);
+        let input = dir.path().join("in.mp4");
+        std::fs::write(&input, b"input").unwrap();
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let err = rotate_video_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &rotation_options(&input.to_string_lossy(), &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::ROTATION_FFMPEG_FAILED"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rotate_video_with_ffmpeg_spawn_failure_maps_to_err_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.mp4");
+        std::fs::write(&input, b"input").unwrap();
+        let output = dir.path().join("out.mp4");
+        let app = tauri::test::mock_app();
+        let err = rotate_video_with_ffmpeg(
+            &dir.path().join("nonexistent-ffmpeg"),
+            app.handle(),
+            &rotation_options(&input.to_string_lossy(), &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.starts_with("ERR::ROTATION_FFMPEG_FAILED: spawn"),
+            "got: {err}"
+        );
     }
 }

--- a/src-tauri/src/handlers/trim.rs
+++ b/src-tauri/src/handlers/trim.rs
@@ -236,6 +236,21 @@ fn compute_total_duration(start: Option<f64>, end: Option<f64>) -> Option<f64> {
 /// - `ERR::TRIM_NO_RANGE` (both start and end are `None`)
 /// - `ERR::TRIM_FFMPEG_FAILED`
 pub async fn trim_video(app: &AppHandle, options: &TrimOptions) -> Result<TrimResult, String> {
+    trim_video_with_ffmpeg(&get_ffmpeg_path(app), app, options).await
+}
+
+/// Path-injected split of [`trim_video`] (test seam, issue #646): runs the
+/// same validation→args→spawn→progress flow against an explicit ffmpeg
+/// binary so tests drive it with a fake script in a tempdir.
+// Why: generic over R, not the default-Wry `&AppHandle`, because the E2E tests
+// below pass `tauri::test::mock_app().handle()` (`AppHandle<MockRuntime>`,
+// tauri "test" feature in src-tauri/Cargo.toml), which only type-checks
+// against a generic Runtime param (issue #646).
+pub(crate) async fn trim_video_with_ffmpeg<R: tauri::Runtime>(
+    ffmpeg_path: &Path,
+    app: &tauri::AppHandle<R>,
+    options: &TrimOptions,
+) -> Result<TrimResult, String> {
     let input_path = Path::new(&options.input_path);
     let output_path = Path::new(&options.output_path);
 
@@ -263,7 +278,6 @@ pub async fn trim_video(app: &AppHandle, options: &TrimOptions) -> Result<TrimRe
         }
     }
 
-    let ffmpeg_path = get_ffmpeg_path(app);
     let input_str = options.input_path.clone();
     let output_str = options.output_path.clone();
     let args = build_ffmpeg_args(
@@ -280,7 +294,7 @@ pub async fn trim_video(app: &AppHandle, options: &TrimOptions) -> Result<TrimRe
             // start-only case: probe input duration, then subtract start
             // so the bar reflects the actual trim length.
             if let Some(start) = options.start_time {
-                probe_duration_sec(&ffmpeg_path, &input_str)
+                probe_duration_sec(ffmpeg_path, &input_str)
                     .await
                     .map(|d| (d - start).max(0.0))
             } else {
@@ -289,7 +303,7 @@ pub async fn trim_video(app: &AppHandle, options: &TrimOptions) -> Result<TrimRe
         }
     };
 
-    let mut cmd = AsyncCommand::new(&ffmpeg_path);
+    let mut cmd = AsyncCommand::new(ffmpeg_path);
     cmd.args(&args);
 
     #[cfg(target_os = "windows")]
@@ -510,5 +524,111 @@ mod tests {
     #[test]
     fn compute_total_duration_clamps_negative() {
         assert_eq!(compute_total_duration(Some(100.0), Some(50.0)), Some(0.0));
+    }
+
+    // ---- PR⑧: executor E2E (issue #646) ----
+    //
+    // The fake ffmpeg writes a sentinel to the output path on success, so
+    // assertions target the file, never stderr (PR #619/#624 flake lesson).
+
+    #[cfg(unix)]
+    use crate::utils::ffmpeg_probe::write_fake_ffmpeg_executor;
+
+    fn trim_fixture(dir: &std::path::Path, name: &str) -> String {
+        let input = dir.join(name);
+        std::fs::write(&input, b"input").unwrap();
+        input.to_string_lossy().into_owned()
+    }
+
+    fn trim_options(input: &str, output: &str) -> TrimOptions {
+        TrimOptions {
+            input_path: input.to_string(),
+            start_time: Some(1.0),
+            end_time: Some(10.0),
+            output_path: output.to_string(),
+            mode: TrimMode::Copy,
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn trim_video_with_ffmpeg_writes_output_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, false);
+        let input = trim_fixture(dir.path(), "in.mp4");
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let result = trim_video_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &trim_options(&input, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.output_path, output.to_string_lossy());
+        assert_eq!(
+            std::fs::read(&output).unwrap(),
+            b"fake-ffmpeg-output\n",
+            "fake wrote the sentinel"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn trim_video_with_ffmpeg_start_only_probes_duration() {
+        // start-only range: the flow probes input duration for the progress
+        // bar before spawning the encode.
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 0, false);
+        let input = trim_fixture(dir.path(), "in.mp4");
+        let output = dir.path().join("out.mp4");
+        let mut options = trim_options(&input, &output.to_string_lossy());
+        options.end_time = None;
+
+        let app = tauri::test::mock_app();
+        trim_video_with_ffmpeg(&ffmpeg, app.handle(), &options)
+            .await
+            .unwrap();
+        assert!(output.exists(), "probe branch still encodes");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn trim_video_with_ffmpeg_maps_failure_to_err_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let ffmpeg = write_fake_ffmpeg_executor(dir.path(), 1, false);
+        let input = trim_fixture(dir.path(), "in.mp4");
+        let output = dir.path().join("out.mp4");
+
+        let app = tauri::test::mock_app();
+        let err = trim_video_with_ffmpeg(
+            &ffmpeg,
+            app.handle(),
+            &trim_options(&input, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::TRIM_FFMPEG_FAILED"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn trim_video_with_ffmpeg_spawn_failure_maps_to_err_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = trim_fixture(dir.path(), "in.mp4");
+        let output = dir.path().join("out.mp4");
+        let app = tauri::test::mock_app();
+        let err = trim_video_with_ffmpeg(
+            &dir.path().join("nonexistent-ffmpeg"),
+            app.handle(),
+            &trim_options(&input, &output.to_string_lossy()),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.starts_with("ERR::TRIM_FFMPEG_FAILED: spawn"),
+            "got: {err}"
+        );
     }
 }

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -148,6 +148,51 @@ fn parse_trailing_kbps(line: &str) -> Option<u32> {
     token.parse::<u32>().ok()
 }
 
+/// Fake "ffmpeg" executable for the tool-handler E2E tests (issue #646).
+///
+/// Behavior contract, mirroring the parts of real ffmpeg the handlers rely
+/// on (asserts target the output FILE, never stderr text — PR #619/#624
+/// flake lesson):
+/// - Probe invocations (`ffmpeg -i <file>`): print a `Duration:` line to
+///   stderr and exit 1, like real ffmpeg without an output target.
+/// - Encode invocations: write a sentinel to the LAST argument (the output
+///   path) and exit `exit_code`.
+/// - `fail_on_copy`: any invocation whose args contain `copy` exits 1,
+///   which drives concat's copy→re-encode fallback.
+#[cfg(all(test, unix))]
+pub(crate) fn write_fake_ffmpeg_executor(
+    dir: &std::path::Path,
+    exit_code: i32,
+    fail_on_copy: bool,
+) -> std::path::PathBuf {
+    let copy_guard = if fail_on_copy {
+        "case \" $* \" in *\" copy \"*) exit 1;; esac\n"
+    } else {
+        ""
+    };
+    // Note: `for last do :; done` (below) is the POSIX-sh way to grab the last
+    // positional arg — bash's `${@: -1}` is a "Bad substitution" under dash
+    // (/bin/sh on the ubuntu-latest CI job running `cargo test`,
+    // .github/workflows/ci.yml), so the portable loop keeps the fake
+    // executable interpreter-agnostic.
+    let script = format!(
+        "#!/bin/sh
+if [ \"$1\" = \"-i\" ]; then
+    echo \"  Duration: 00:01:00.00, start: 0.000000\" 1>&2
+    exit 1
+fi
+{copy_guard}for last do :; done
+echo fake-ffmpeg-output > \"$last\"
+exit {exit_code}
+"
+    );
+    let path = dir.join("fake-ffmpeg");
+    std::fs::write(&path, script).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Split each local-tool executor into a public wrapper (resolves `get_ffmpeg_path(app)`) plus a path-injected `*_with_ffmpeg` core generic over `R: Runtime`, so the spawn/progress/fallback machinery runs end-to-end against a fake ffmpeg script in a tempdir (issue #646 PR⑧).

- `trim_video_with_ffmpeg` / `rotate_video_with_ffmpeg` / `concat_videos_with_ffmpeg` / `extract_audio_with_ffmpeg`; concat's `run_ffmpeg_with_progress` also genericized
- Shared test-only `write_fake_ffmpeg_executor` (`cfg(all(test, unix))` in `utils/ffmpeg_probe.rs`): probe mode (`-i` first arg) prints a Duration line to stderr and exits 1 like real ffmpeg; encode mode writes a sentinel to the LAST arg; `fail_on_copy` exits 1 on `-c copy` args to drive concat's re-encode fallback
- 12 E2E tests: trim ×4 (success, start-only probe branch, exit-1 mapping, spawn failure), rotation ×3, audio ×2, concat ×3 (copy success, fallback-to-reencode, both-fail → `ERR::CONCAT_REENCODE_FAILED`)
- Assertions target the output FILE, never stderr text (PR #619/#624 flake lesson)

## Related Issue

Refs #646 (PR⑧ of the coverage push; does not close it — updater/init and OS glue batches remain)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `cargo test` — 543 passed (531 → 543, 12 new green)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — applied

## Breaking Changes

None — wrapper behavior byte-identical (same validation order, error strings, emit flow).

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages) — N/A, no user-facing strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)