### PR TITLE
ci(coverage): make the Rust ratchet a required gate, bump to 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,9 +294,11 @@ jobs:
         working-directory: src-tauri
         run: cargo fmt --check
 
-  # Why report-only (not in ci-status needs): coverage visibility disciplines
-  # the test-coverage push without failing PRs on flaky nightly/toolchain
-  # drift; rust-test remains the required green gate.
+  # Why in ci-status needs (required): a coverage regression must fail the
+  # PR, not just report — early detection beats post-hoc triage (user
+  # decision 2026-09-11, issue #646 maintenance phase). The codecov upload
+  # step inside stays fail_ci_if_error: false so codecov outages don't gate
+  # PRs; only the local llvm-cov threshold may fail this job.
   coverage:
     name: Rust Coverage
     runs-on: ubuntu-latest
@@ -372,10 +374,10 @@ jobs:
         # silently masking a threshold breach as a green, half-empty report
         # Why `report` (not a fresh run): reuses the profdata written by the
         # generate step above — tests run once per job
-        # Why 79: ratchet measured at 81.12% lines on CI after the PR⑧
-        # trim-executor batch (issue #646) — floor keeps ~2pt
-        # headroom per the vitest.config.ts convention; bump as coverage
-        # grows, never lower.
+        # Why 81: ratchet measured at 82.44% lines on CI after the PR⑩
+        # coverage(off) batch (issue #646 closed at that line) — floor
+        # keeps ~1.4pt headroom per the vitest.config.ts convention; bump
+        # as coverage grows, never lower.
         # CAUTION: baseline must be measured on CI, not locally — macOS/nightly
         # measured 56.62% over 20174 lines while CI counts 12056 lines
         # (nightly rustc coverage mapping differs per platform)
@@ -389,7 +391,7 @@ jobs:
           rc=0
           cargo llvm-cov report --summary-only --show-missing-lines \
             --ignore-filename-regex 'src/(main|lib|menu)\.rs' \
-            --fail-under-lines 79 \
+            --fail-under-lines 81 \
             | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit $rc
@@ -436,6 +438,7 @@ jobs:
         rust-clippy,
         rust-test,
         rust-format,
+        coverage,
         docs-format,
       ]
     if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,10 @@ comments.
 ## CI & E2E Workflows
 
 - **CI** (`.github/workflows/ci.yml`) runs on Ubuntu and is aggregated
-  into the **required** `ci-status` status check. The report-only
-  `coverage` job (nightly cargo-llvm-cov) is NOT part of ci-status.
+  into the **required** `ci-status` status check. The `coverage` job
+  (nightly cargo-llvm-cov) IS part of ci-status: its
+  `--fail-under-lines` ratchet fails the PR on a coverage regression
+  (only the codecov upload inside is report-only).
 - **E2E Tests** (`.github/workflows/e2e.yml`) runs separately on macOS
   and is **NOT a required** status check.
 - When monitoring CI (e.g. during `worktree-finish`), do **not** wait


### PR DESCRIPTION
## Summary

- **coverage job joins the ci-status needs**: a coverage regression now **fails the PR** instead of only reporting (early detection; maintenance phase of issue #646). The codecov upload step inside stays `fail_ci_if_error: false` so codecov outages don't gate PRs — only the local llvm-cov threshold can fail the job
- **Ratchet 79 → 81**, measured at 82.44% after the PR⑩ coverage(off) batch (issue #646 closed at that line); ~1.4pt headroom per convention, bump-only
- CLAUDE.md CI section updated to match

FE note: the frontend line is already enforced as a required gate — `vitest.config.ts` `thresholds: { lines: 95 }` fails the `Test` job (in ci-status), so no ci.yml duplication is needed.

## Related Issue

Refs #646

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] Workflow YAML structure verified (needs list + threshold step)
- [ ] CI on this PR runs the coverage job as part of ci-status with the new floor

## Breaking Changes

None for passing code; PRs that drop Rust line coverage below 81% will now fail ci-status (intended).

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated — N/A (CI config)
- [x] i18n files synced — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)