### PR TITLE
chore: disable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "timezone": "Asia/Tokyo",
+  "dependencyDashboard": false,
   "schedule": ["before 6am on Monday"],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
## Summary

Add `"dependencyDashboard": false` to `renovate.json`.

Minor/patch updates already automerge on the weekly Monday schedule and
major updates still open reviewable PRs, so the Renovate Dependency
Dashboard issue adds no value — it is just a large auto-generated list
that gets rewritten every run. Disabling it closes the dashboard and
stops the weekly recreate cycle.

## Related Issue

Closes #643

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] JSON valid and Prettier-formatted (`npx prettier --check renovate.json`)
- [x] No dashboard-gated settings (`dependencyDashboardApproval`, `prCreation: approval`) in config, so nothing breaks when the dashboard disappears
- [ ] After merge: confirm Renovate run no longer recreates the dashboard issue

## Breaking Changes

None. Update behavior (schedule, grouping, automerge of minor/patch) is unchanged.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (N/A — config-only change)
- [x] i18n files synced (N/A — config-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)