### PR TITLE
chore: add gitleaks secret scanning CI

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,43 @@
+# Secret scanning for leaked tokens/keys (issue #629)
+name: gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  # Why schedule + workflow_dispatch: gitleaks-action only scans the event
+  # range (PR/push commits) on those triggers — the full-history scan that
+  # issue #629 requires runs exclusively on schedule/dispatch events
+  schedule:
+    - cron: '13 15 * * *' # daily at 00:13 JST
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Why pull-requests write: lets the action comment on the PR when a leak
+  # is found (job failure alone would gate the merge either way).
+  # GITLEAKS_LICENSE is not needed for personal accounts (orgs only)
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (full history)
+        # Why fetch-depth 0: the scheduled scan walks every commit, so
+        # secrets that were removed in past commits are still detected
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,18 @@
+# Note: the fingerprint ignore mechanism is experimental upstream and its
+# format may change across gitleaks/gitleaks-action upgrades, which would
+# void every entry here at once (gitleaks README, .gitleaksignore section)
+# Baseline of gitleaks false positives reviewed on 2026-09-11 (issue #629).
+# All findings below are dummy test fixtures or i18n key lists, not real
+# secrets. Remove a fingerprint only when the underlying code disappears.
+# qr_login.rs: dummy qrcode_key test fixture (abcdef0123456789...)
+6a23fbc8e0e493f5f1bf61216d9af6e10e5b94d1:src-tauri/src/models/qr_login.rs:generic-api-key:332
+# RotationForm.tsx: i18n labelKey/hintKey arrays misread as key-value pairs
+1f39a90cf8b8fa473f7fc5f0885c601f44465f83:src/features/rotation/ui/RotationForm.tsx:generic-api-key:49
+1f39a90cf8b8fa473f7fc5f0885c601f44465f83:src/features/rotation/ui/RotationForm.tsx:generic-api-key:50
+1f39a90cf8b8fa473f7fc5f0885c601f44465f83:src/features/rotation/ui/RotationForm.tsx:generic-api-key:54
+1f39a90cf8b8fa473f7fc5f0885c601f44465f83:src/features/rotation/ui/RotationForm.tsx:generic-api-key:55
+# wbi.rs: dummy mixin_key fixtures in doctest/unit tests (the real mixin
+# key is fetched from the bilibili API at runtime)
+1edb8a52d1336ae6995a23ad2c54cbf8a9b08658:src-tauri/src/utils/wbi.rs:generic-api-key:72
+1edb8a52d1336ae6995a23ad2c54cbf8a9b08658:src-tauri/src/utils/wbi.rs:generic-api-key:206
+1edb8a52d1336ae6995a23ad2c54cbf8a9b08658:src-tauri/src/utils/wbi.rs:generic-api-key:223

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,12 +103,19 @@ comments.
   (nightly cargo-llvm-cov) IS part of ci-status: its
   `--fail-under-lines` ratchet fails the PR on a coverage regression
   (only the codecov upload inside is report-only).
+- **gitleaks** (`.github/workflows/gitleaks.yml`) scans for leaked
+  secrets: PR/push events scan the event's commits, and a daily
+  scheduled run scans the full git history. Its `Secret Scan` check is
+  separate from `ci-status` and must be kept **required** in the main
+  branch ruleset. Reviewed false-positive baselines live in
+  `.gitleaksignore` — extend it only after confirming a finding is a
+  dummy/test value, never for a real secret.
 - **E2E Tests** (`.github/workflows/e2e.yml`) runs separately on macOS
   and is **NOT a required** status check.
 - When monitoring CI (e.g. during `worktree-finish`), do **not** wait
-  for the E2E workflow to finish — `ci-status` passing is sufficient to
-  treat CI as green. Treat E2E as informational (screenshots are still
-  useful for visual review).
+  for the E2E workflow to finish — `ci-status` and `Secret Scan`
+  passing is sufficient to treat CI as green. Treat E2E as
+  informational (screenshots are still useful for visual review).
 
 ## Pre-verification Checklist
 


### PR DESCRIPTION
## Summary

Add `.github/workflows/gitleaks.yml` running `gitleaks/gitleaks-action@v3`:

- **PR / push(main) triggers** scan the event's commit range
- **Daily scheduled run (00:13 JST) + `workflow_dispatch`** scan the full git history — gitleaks-action only scans the event range on PR/push triggers, so the full-history coverage issue #629 requires lives in the scheduled run
- `fetch-depth: 0`, `contents: read` + `pull-requests: write` (PR comments on leak findings), no `GITLEAKS_LICENSE` needed (personal account)

Baseline the 8 pre-existing false positives in `.gitleaksignore` (dummy test fixtures in `qr_login.rs` / `wbi.rs`, i18n key arrays in `RotationForm.tsx`) — verified locally with gitleaks 8.30.1: **1136 commits scanned, no leaks found**.

Update CLAUDE.md's CI section for the new `Secret Scan` check.

## Related Issue

Closes #629

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Chore

## Test Plan

- [x] Local full-history scan with gitleaks 8.30.1: no leaks found (with baseline)
- [x] Baseline entries spot-checked against the flagged commits (all dummy fixtures)
- [x] actionlint validates the workflow
- [ ] CI `Secret Scan` job passes on this PR

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

## Post-merge step (manual)

Add `Secret Scan` to the required status checks of the main branch ruleset (Settings → Branches → ruleset "Main Branch Protection"). This can only be done after the workflow's first run reports the check name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
