### PR TITLE
fix(ci): declare least-privilege permissions in add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -2,6 +2,9 @@ name: Add to Project
 on:
   issues:
     types: [opened]
+# Least privilege: the job authenticates with PROJECT_TOKEN, not GITHUB_TOKEN
+permissions:
+  contents: read
 jobs:
   add-to-project:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a top-level `permissions: contents: read` block to `.github/workflows/add-to-project.yml`
- Resolves the CodeQL `actions/missing-workflow-permissions` alert (medium) raised by code scanning on the repo
- The job authenticates with `secrets.PROJECT_TOKEN`, so GITHUB_TOKEN only needs `contents: read` (least privilege)

## Related Issue

Refs #628 (CodeQL adoption; this PR fixes the one alert its initial scan found — the workflow setup itself lands separately)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [x] 🔧 Chore

## Test Plan

- [x] `actionlint .github/workflows/add-to-project.yml` passes
- [x] Existing issues continue to be added to the project board (workflow logic untouched; only permissions declared)
- [ ] After merge, the CodeQL alert auto-closes on the Security tab

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore) — N/A
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A