### PR TITLE
chore: ignore *.local.md local state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.local.md
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

Add `*.local.md` to `.gitignore`. The Ralph Loop plugin writes session
state to `.claude/ralph-loop.local.md`, and the existing `*.local`
pattern does not match the `.local.md` suffix, so the file showed up
as untracked noise in `git status`.

## Related Issue

None

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] `git check-ignore -v .claude/ralph-loop.local.md` matches the new pattern
- [x] `npx prettier --check .` passes (gitignore is not a prettier target)

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file handling to exclude local Markdown files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->