### PR TITLE
chore: add CodeRabbit AI code review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,59 @@
+# CodeRabbit AI code review configuration (issue #631).
+# Requires the CodeRabbit GitHub App installed on this repository:
+# https://github.com/apps/coderabbitai
+#
+# Policy: CodeRabbit is advisory only — its checks must NOT be added to the
+# required branch protection checks (ci-status / Secret Scan stay the gates).
+language: 'en-US'
+
+reviews:
+  profile: 'chill'
+  # Why: complements the advisory-only policy (see header, issue #631) — bot
+  # reviews must never submit a blocking "Request Changes" verdict
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    # Lockfiles are machine-managed (Renovate/Dependabot churn) — no review value
+    - '!**/package-lock.json'
+    - '!**/Cargo.lock'
+    # tsc incremental build artifact
+    - '!**/*.tsbuildinfo'
+    # UI components installed via shadcn CLI / animate-ui registry, never hand-edited
+    - '!src/components/ui/**'
+    - '!src/shared/animate-ui/**'
+    # Binary assets
+    - '!**/*.{png,jpg,jpeg,webp,gif,ico,icns,mp4,m4s}'
+    # Gitignored dirs — defense in depth, never expected in PR diffs
+    - '!references/**'
+    - '!coverage/**'
+    - '!dist/**'
+    - '!node_modules/**'
+    - '!src-tauri/target/**'
+    - '!src-tauri/gen/schemas/**'
+  path_instructions:
+    # TODO(issue #631): all translation files are currently in review scope.
+    # If per-PR review noise turns out too high, narrow the scope to README
+    # translations only by adding path_filters excludes for
+    # src/i18n/locales/{ja,zh,ko,es,fr}.json and
+    # docs/src/content/faq/{ja,zh,ko,es,fr}.yaml.
+    - path: 'README.{ja,zh,ko,es,fr}.md'
+      instructions: |
+        - These are translations of README.md, the English source of truth.
+        - Compare against README.md changes in the same PR and flag
+          mistranslations, unnatural phrasing, and terminology inconsistent
+          with the English source.
+    - path: 'src/i18n/locales/{ja,zh,ko,es,fr}.json'
+      instructions: |
+        - Focus on translation values, NOT key structure — key parity across
+          all 6 locales is machine-enforced by src/i18n/locales.test.ts.
+        - en.json is the source of truth. Flag mistranslations, broken
+          interpolation placeholders ({{...}}), and inconsistent terminology.
+    - path: 'docs/src/content/faq/{ja,zh,ko,es,fr}.yaml'
+      instructions: |
+        - en.yaml is the source of truth. Flag mistranslations and terminology
+          drift, and missing/untranslated entries.


### PR DESCRIPTION
## Summary

Add `.coderabbit.yaml` so the CodeRabbit GitHub App (installed on this repository) reviews PRs with a bounded, project-aware scope:

- **Advisory only**: chill profile, `request_changes_workflow: false`, and its checks must never join the required branch-protection checks (`ci-status` / `Secret Scan` stay the gates)
- **Excluded from review** (machine-managed / no review value): lockfiles (`package-lock.json` ×3, `Cargo.lock`), `*.tsbuildinfo`, shadcn (`src/components/ui/`) and animate-ui (`src/shared/animate-ui/`) installed components, binary assets, and gitignored dirs (defense in depth)
- **Translation-quality instructions** for README translations, `src/i18n/locales/{ja,zh,ko,es,fr}.json` (en.json is the source of truth; key parity is already machine-enforced by `src/i18n/locales.test.ts`), and docs FAQ yaml — CodeRabbit flags mistranslations, broken `{{...}}` placeholders, and terminology drift
- TODO comment documents the fallback: if per-PR review noise is too high, narrow translation scope to README only

Codecov coexistence confirmed: codecov comments are change-gated (`require_changes: true`, `after_n_builds: 2`) and use distinct markers — no interference.

## Related Issue

Closes #631

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] YAML parses (js-yaml) and keys match the CodeRabbit config schema
- [x] `npx prettier --check .coderabbit.yaml` passes (CI format gate)
- [ ] After merge: open any follow-up PR and confirm CodeRabbit posts the walkthrough + review (first live validation; the App is already installed)

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore) — N/A, config only
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)