### PR TITLE
ci: add reviewdog PR inline comments and local format hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Format staged files before commit and re-stage them so commits are
+# always formatted. rustfmt runs on the whole src-tauri workspace, so
+# unstaged .rs files may also get formatted (left unstaged). CI
+# (ci.yml format jobs + reviewdog suggester) stays the fail-safe gate
+# when this hook is bypassed (e.g. --no-verify).
+
+# CAUTION: re-staging is whole-file. If you partially staged a file
+# (git add -p), unstaged edits in formatted files get committed too.
+# ponytail: no stash dance for partial staging; this repo's flow stages
+# whole files via worktree-finish.
+
+set -e
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+RS_FILES=$(printf '%s\n' "$STAGED" | grep '\.rs$' || true)
+
+# rustfmt when any staged .rs file
+if [ -n "$RS_FILES" ]; then
+  if command -v cargo >/dev/null 2>&1; then
+    cargo fmt --manifest-path src-tauri/Cargo.toml
+    printf '%s\n' "$RS_FILES" | xargs git add --
+  else
+    echo "warning: cargo not found; skipping rustfmt (CI will catch it)" >&2
+  fi
+fi
+
+# prettier for the rest; --ignore-unknown lets prettier itself decide
+# which staged files it supports (honors .prettierignore)
+PRETTIER_FILES=$(printf '%s\n' "$STAGED" | grep -v '\.rs$' || true)
+if [ -n "$PRETTIER_FILES" ]; then
+  if command -v npx >/dev/null 2>&1; then
+    printf '%s\n' "$PRETTIER_FILES" | xargs npx prettier --write --ignore-unknown
+    printf '%s\n' "$PRETTIER_FILES" | xargs git add --
+  else
+    echo "warning: npx not found; skipping prettier (CI will catch it)" >&2
+  fi
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,30 @@ jobs:
       # Why pipefail: eslint's exit code must survive the pipe so the
       # gate semantics match `npm run lint` (fail on any error anywhere,
       # not just errors on added lines that reviewdog reports)
+      # Why --format=json + jq: ESLint 9 dropped the built-in checkstyle
+      # formatter, so JSON is converted to RDFormat here instead (same
+      # shape as the clippy job). env.PWD strips the absolute filePath
+      # prefix reviewdog cannot match against the repo-relative diff
       - name: Run ESLint
         if: github.event_name == 'pull_request'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
-          npx eslint . --format=checkstyle \
-            | reviewdog -f=checkstyle -name=eslint \
+          npx eslint . --format=json \
+            | jq -c '.[] | .filePath as $f | .messages[] | {
+                code: (if .ruleId then { value: .ruleId } else null end),
+                message: .message,
+                severity: (if .severity == 2 then "ERROR" else "WARNING" end),
+                location: {
+                  path: ($f | sub("^" + env.PWD + "/"; "")),
+                  range: {
+                    start: { line: .line, column: .column },
+                    end: { line: (.endLine // .line), column: (.endColumn // .column) }
+                  }
+                }
+              }' \
+            | reviewdog -f=rdjsonl -name=eslint \
                 -reporter=github-pr-review -filter-mode=added \
                 -fail-level=error -tee
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Why checks/issues write: reviewdog github-pr-review needs them for
+# review comments and its Check-annotation fallback for findings outside
+# the PR diff (per reviewdog/action-suggester upstream requirements)
 permissions:
   contents: write
+  checks: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -40,7 +45,30 @@ jobs:
         if: steps.cache-nm-format.outputs.cache-hit != 'true'
         run: npm ci
 
+      # Why the PR/push split: reviewdog reporters only work on
+      # pull_request events; push to main keeps the plain check
+      - name: Apply Prettier
+        if: github.event_name == 'pull_request'
+        run: npx prettier --write .
+
+      - name: Suggest formatting changes
+        # Why cleanup:false: keeps the formatted state so the gate step
+        # below sees the full diff (filter-mode only limits which hunks
+        # get suggestion cards, not which violations fail the job)
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: prettier
+          level: error
+          filter_mode: added
+          cleanup: false
+
+      - name: Fail on unformatted files
+        if: github.event_name == 'pull_request'
+        run: git diff --exit-code
+
       - name: Check formatting
+        if: github.event_name != 'pull_request'
         run: npm run format:check
 
   lint:
@@ -67,7 +95,28 @@ jobs:
         if: steps.cache-nm-lint.outputs.cache-hit != 'true'
         run: npm ci
 
+      # Why the PR/push split: reviewdog reporters only work on
+      # pull_request events; push to main keeps the plain lint
+      - name: Setup reviewdog
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-setup@v1
+
+      # Why pipefail: eslint's exit code must survive the pipe so the
+      # gate semantics match `npm run lint` (fail on any error anywhere,
+      # not just errors on added lines that reviewdog reports)
       - name: Run ESLint
+        if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          npx eslint . --format=checkstyle \
+            | reviewdog -f=checkstyle -name=eslint \
+                -reporter=github-pr-review -filter-mode=added \
+                -fail-level=error -tee
+
+      - name: Run ESLint
+        if: github.event_name != 'pull_request'
         run: npm run lint
 
   frontend-build:
@@ -213,7 +262,53 @@ jobs:
           sudo apt-get update || echo "::warning::apt-get update partially failed; relying on whichever indexes resolved"
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev libglib2.0-dev
 
+      # Why the PR/push split: reviewdog reporters only work on
+      # pull_request events; push to main keeps the plain clippy
+      - name: Setup reviewdog
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-setup@v1
+
+      # Why pipefail: cargo's exit code must survive the pipes so the
+      # gate matches plain `cargo clippy -- -D warnings` (any denied lint
+      # fails the job even when outside the PR's added lines)
+      # Why 2>/dev/null: cargo writes progress to stderr; diagnostics
+      # arrive as JSON on stdout. -tee echoes parsed findings back to
+      # the log so hard compile errors stay debuggable
       - name: Run Clippy
+        if: github.event_name == 'pull_request'
+        working-directory: src-tauri
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          cargo clippy --all-targets --message-format=json -- -D warnings 2>/dev/null \
+            | jq -c 'select(.reason == "compiler-message")
+                | .message.spans as $sp
+                | (($sp | map(select(.is_primary)) | first) // $sp[0]) as $s
+                | select($s != null and .message.code != null)
+                # Why RDFormat field names (code/message/severity/range):
+                # reviewdog -f=rdjsonl silently discards unknown fields, so
+                # Code Climate-style keys (check_name/description/lines) or
+                # lowercase severity would post nothing (verified against
+                # reviewdog v0.21.0)
+                | {
+                    code: { value: .message.code.code },
+                    message: .message.message,
+                    severity: (if .message.level == "error" then "ERROR" else "WARNING" end),
+                    location: {
+                      path: ("src-tauri/" + $s.file_name),
+                      range: {
+                        start: { line: $s.line_start, column: $s.column_start },
+                        end: { line: $s.line_end, column: $s.column_end }
+                      }
+                    }
+                  }' \
+            | reviewdog -f=rdjsonl -name=clippy \
+                -reporter=github-pr-review -filter-mode=added \
+                -fail-level=error -tee
+
+      - name: Run Clippy
+        if: github.event_name != 'pull_request'
         working-directory: src-tauri
         # Why: --all-targets also lints test targets; plain clippy covers lib/bins only, and
         # the test-coverage plan (see dev-dependencies note in src-tauri/Cargo.toml) adds
@@ -290,7 +385,31 @@ jobs:
           sudo apt-get update || echo "::warning::apt-get update partially failed; relying on whichever indexes resolved"
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev libglib2.0-dev
 
+      # Why the PR/push split: action-suggester only supports
+      # pull_request events; push to main keeps the plain check
+      - name: Apply rustfmt
+        if: github.event_name == 'pull_request'
+        working-directory: src-tauri
+        run: cargo fmt
+
+      - name: Suggest formatting changes
+        # Why cleanup:false: keeps the formatted state so the gate step
+        # below sees the full diff (filter-mode only limits which hunks
+        # get suggestion cards, not which violations fail the job)
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: rustfmt
+          level: error
+          filter_mode: added
+          cleanup: false
+
+      - name: Fail on unformatted files
+        if: github.event_name == 'pull_request'
+        run: git diff --exit-code
+
       - name: Check Rust formatting
+        if: github.event_name != 'pull_request'
         working-directory: src-tauri
         run: cargo fmt --check
 
@@ -421,7 +540,31 @@ jobs:
         working-directory: docs
         run: npm ci
 
+      # Why the PR/push split: action-suggester only supports
+      # pull_request events; push to main keeps the plain check
+      - name: Apply Prettier
+        if: github.event_name == 'pull_request'
+        working-directory: docs
+        run: npx prettier --write .
+
+      - name: Suggest formatting changes
+        # Why cleanup:false: keeps the formatted state so the gate step
+        # below sees the full diff (filter-mode only limits which hunks
+        # get suggestion cards, not which violations fail the job)
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: prettier-docs
+          level: error
+          filter_mode: added
+          cleanup: false
+
+      - name: Fail on unformatted files
+        if: github.event_name == 'pull_request'
+        run: git diff --exit-code
+
       - name: Check formatting
+        if: github.event_name != 'pull_request'
         working-directory: docs
         run: npm run format:check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,10 @@ comments.
   (nightly cargo-llvm-cov) IS part of ci-status: its
   `--fail-under-lines` ratchet fails the PR on a coverage regression
   (only the codecov upload inside is report-only).
+- **reviewdog** posts eslint/clippy findings as PR inline comments and
+  formatter fixes as suggested changes (one-click apply) — PR events
+  only; push to main keeps the plain checks. Local format-on-commit
+  hook lives in `.githooks/` (activated by the `prepare` npm script).
 - **gitleaks** (`.github/workflows/gitleaks.yml`) scans for leaked
   secrets: PR/push events scan the event's commits, and a daily
   scheduled run scans the full git history. Its `Secret Scan` check is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ on macOS, MSVC Build Tools + WebView2 on Windows).
 npm install && npm run tauri dev
 ```
 
+`npm install` also activates the format-on-commit hook (`.githooks/`
+via `core.hooksPath`, see the `prepare` script). It runs `cargo fmt`
+and `prettier --write` on staged files and re-stages them; CI remains
+the fail-safe gate if the hook is bypassed (e.g. `--no-verify`).
+
 See `package.json` scripts for all available commands.
 
 ## Development Workflow

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -b --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "prepare": "git config core.hooksPath .githooks || true",
     "format:check": "prettier --check .",
     "test": "vitest",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

- Add reviewdog to CI (`reviewdog/action-setup` + `reviewdog/action-suggester`), closing #630:
  - `lint` job: eslint findings posted as PR inline comments (checkstyle → `github-pr-review`)
  - `rust-clippy` job: clippy JSON converted to RDFormat via jq and posted as inline comments (primary-span aware, `severity`/`range` verified against reviewdog v0.21.0 round-trip)
  - `rust-format` / `format` / `docs-format` jobs: formatter runs, then the diff is posted as suggested changes (one-click apply)
- Gate semantics unchanged: `set -o pipefail` preserves eslint/cargo exit codes; format jobs fail on any formatter-produced diff via `git diff --exit-code` (suggester runs with `cleanup: false` so the gate sees the full diff). `ci-status` remains the required aggregate
- reviewdog paths are PR-event-only (`if: github.event_name == 'pull_request'`); push to main keeps the plain checks
- Add a zero-dependency format-on-commit hook (`.githooks/pre-commit`): cargo fmt on the src-tauri workspace when `.rs` files are staged, `prettier --write --ignore-unknown` for the rest, then re-stage. Activated automatically by the `prepare` npm script (`core.hooksPath .githooks`); CI stays the fail-safe when bypassed
- Permissions gain `checks: write` / `issues: write` per action-suggester upstream requirements
- Docs: CLAUDE.md CI section + CONTRIBUTING.md Getting Started note

## Test plan

- [x] Hook verified end-to-end in a scratch commit: unformatted staged file comes out formatted and re-staged
- [x] jq clippy filter validated against sample cargo JSON (primary span selection, span-less/code-less exclusion) and round-tripped through reviewdog v0.21.0 (`-f=rdjsonl -reporter=rdjson`)
- [x] actionlint, `prettier --check`, `npm run lint` all clean
- [ ] CI on this PR exercises the new steps for real

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic formatting of staged Rust and frontend files before commits.
  * Added pull request checks that provide inline lint, formatting, and code-quality feedback with suggested fixes.
  * Added automatic Git hook setup during project installation.

* **Documentation**
  * Documented format-on-commit behavior, CI checks, and setup requirements in contributor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->