### PR TITLE
chore(ci): run CI workflow on pull_request only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 # CI workflow for PRs to main branch
 name: CI
 
+# Why: pull_request-only — post-merge push runs re-ran the same jobs at
+# ~60min of runner time per merge and never caught a failure the PR run
+# had missed, so merges are validated at PR time instead (user decision
+# 2026-09-11)
+# Note: reviewdog's github-pr-review reporter and action-suggester only
+# work on pull_request events, so re-adding a push trigger requires
+# restoring the event-name guards these steps lost when the trigger was
+# removed
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 concurrency:
@@ -45,17 +51,13 @@ jobs:
         if: steps.cache-nm-format.outputs.cache-hit != 'true'
         run: npm ci
 
-      # Why the PR/push split: reviewdog reporters only work on
-      # pull_request events; push to main keeps the plain check
       - name: Apply Prettier
-        if: github.event_name == 'pull_request'
         run: npx prettier --write .
 
       - name: Suggest formatting changes
         # Why cleanup:false: keeps the formatted state so the gate step
         # below sees the full diff (filter-mode only limits which hunks
         # get suggestion cards, not which violations fail the job)
-        if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: prettier
@@ -64,12 +66,7 @@ jobs:
           cleanup: false
 
       - name: Fail on unformatted files
-        if: github.event_name == 'pull_request'
         run: git diff --exit-code
-
-      - name: Check formatting
-        if: github.event_name != 'pull_request'
-        run: npm run format:check
 
   lint:
     name: Lint
@@ -95,10 +92,7 @@ jobs:
         if: steps.cache-nm-lint.outputs.cache-hit != 'true'
         run: npm ci
 
-      # Why the PR/push split: reviewdog reporters only work on
-      # pull_request events; push to main keeps the plain lint
       - name: Setup reviewdog
-        if: github.event_name == 'pull_request'
         uses: reviewdog/action-setup@v1
 
       # Why pipefail: eslint's exit code must survive the pipe so the
@@ -109,7 +103,6 @@ jobs:
       # shape as the clippy job). env.PWD strips the absolute filePath
       # prefix reviewdog cannot match against the repo-relative diff
       - name: Run ESLint
-        if: github.event_name == 'pull_request'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -130,10 +123,6 @@ jobs:
             | reviewdog -f=rdjsonl -name=eslint \
                 -reporter=github-pr-review -filter-mode=added \
                 -fail-level=error -tee
-
-      - name: Run ESLint
-        if: github.event_name != 'pull_request'
-        run: npm run lint
 
   frontend-build:
     name: Frontend Build
@@ -278,10 +267,7 @@ jobs:
           sudo apt-get update || echo "::warning::apt-get update partially failed; relying on whichever indexes resolved"
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev libglib2.0-dev
 
-      # Why the PR/push split: reviewdog reporters only work on
-      # pull_request events; push to main keeps the plain clippy
       - name: Setup reviewdog
-        if: github.event_name == 'pull_request'
         uses: reviewdog/action-setup@v1
 
       # Why pipefail: cargo's exit code must survive the pipes so the
@@ -290,8 +276,9 @@ jobs:
       # Why 2>/dev/null: cargo writes progress to stderr; diagnostics
       # arrive as JSON on stdout. -tee echoes parsed findings back to
       # the log so hard compile errors stay debuggable
+      # Why --all-targets: also lints test targets; plain clippy covers
+      # lib/bins only, and the unit tests must stay warning-free
       - name: Run Clippy
-        if: github.event_name == 'pull_request'
         working-directory: src-tauri
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -322,14 +309,6 @@ jobs:
             | reviewdog -f=rdjsonl -name=clippy \
                 -reporter=github-pr-review -filter-mode=added \
                 -fail-level=error -tee
-
-      - name: Run Clippy
-        if: github.event_name != 'pull_request'
-        working-directory: src-tauri
-        # Why: --all-targets also lints test targets; plain clippy covers lib/bins only, and
-        # the test-coverage plan (see dev-dependencies note in src-tauri/Cargo.toml) adds
-        # unit tests that must stay warning-free
-        run: cargo clippy --all-targets -- -D warnings
 
   # Why: cargo test also compiles and runs doctests — this job enforces them and is what
   # surfaced the 19 failing doc examples fixed in this PR
@@ -401,10 +380,7 @@ jobs:
           sudo apt-get update || echo "::warning::apt-get update partially failed; relying on whichever indexes resolved"
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libdbus-1-dev libglib2.0-dev
 
-      # Why the PR/push split: action-suggester only supports
-      # pull_request events; push to main keeps the plain check
       - name: Apply rustfmt
-        if: github.event_name == 'pull_request'
         working-directory: src-tauri
         run: cargo fmt
 
@@ -412,7 +388,6 @@ jobs:
         # Why cleanup:false: keeps the formatted state so the gate step
         # below sees the full diff (filter-mode only limits which hunks
         # get suggestion cards, not which violations fail the job)
-        if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: rustfmt
@@ -421,13 +396,7 @@ jobs:
           cleanup: false
 
       - name: Fail on unformatted files
-        if: github.event_name == 'pull_request'
         run: git diff --exit-code
-
-      - name: Check Rust formatting
-        if: github.event_name != 'pull_request'
-        working-directory: src-tauri
-        run: cargo fmt --check
 
   # Why in ci-status needs (required): a coverage regression must fail the
   # PR, not just report — early detection beats post-hoc triage (user
@@ -556,10 +525,7 @@ jobs:
         working-directory: docs
         run: npm ci
 
-      # Why the PR/push split: action-suggester only supports
-      # pull_request events; push to main keeps the plain check
       - name: Apply Prettier
-        if: github.event_name == 'pull_request'
         working-directory: docs
         run: npx prettier --write .
 
@@ -567,7 +533,6 @@ jobs:
         # Why cleanup:false: keeps the formatted state so the gate step
         # below sees the full diff (filter-mode only limits which hunks
         # get suggestion cards, not which violations fail the job)
-        if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: prettier-docs
@@ -576,13 +541,7 @@ jobs:
           cleanup: false
 
       - name: Fail on unformatted files
-        if: github.event_name == 'pull_request'
         run: git diff --exit-code
-
-      - name: Check formatting
-        if: github.event_name != 'pull_request'
-        working-directory: docs
-        run: npm run format:check
 
   ci-status:
     name: CI status check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,17 @@ comments.
 ## CI & E2E Workflows
 
 - **CI** (`.github/workflows/ci.yml`) runs on Ubuntu and is aggregated
-  into the **required** `ci-status` status check. The `coverage` job
-  (nightly cargo-llvm-cov) IS part of ci-status: its
-  `--fail-under-lines` ratchet fails the PR on a coverage regression
-  (only the codecov upload inside is report-only).
+into the **required** `ci-status` status check. The `coverage` job
+(nightly cargo-llvm-cov) IS part of ci-status: its
+`--fail-under-lines` ratchet fails the PR on a coverage regression
+(only the codecov upload inside is report-only).
+<!-- Why: pull_request-only trigger because post-merge push runs cost
+     ~60min of runner time per merge and never caught a failure the PR
+     run had missed (user decision 2026-09-11) — merged commits on main
+     are not re-validated by this workflow -->
 - **reviewdog** posts eslint/clippy findings as PR inline comments and
-  formatter fixes as suggested changes (one-click apply) — PR events
-  only; push to main keeps the plain checks. Local format-on-commit
+  formatter fixes as suggested changes (one-click apply). ci.yml runs
+  on pull_request only (no push-to-main trigger). Local format-on-commit
   hook lives in `.githooks/` (activated by the `prepare` npm script).
 - **gitleaks** (`.github/workflows/gitleaks.yml`) scans for leaked
   secrets: PR/push events scan the event's commits, and a daily


### PR DESCRIPTION
## Summary

Remove the `push: branches: [main]` trigger from `ci.yml` so CI runs only on pull requests to main. Post-merge push runs re-ran the same jobs (~60min of runner time per merge) and never caught a failure the PR run had missed, so merges are validated at PR time instead.

Cleanup that follows from the trigger removal:

- Delete the dead `github.event_name != 'pull_request'` step variants (plain `npm run lint`, `cargo clippy --all-targets`, `format:check`, `cargo fmt --check`)
- Drop the now always-true `if: github.event_name == 'pull_request'` guards
- Relocate the `--all-targets` rationale comment onto the surviving clippy step
- Update CLAUDE.md's reviewdog bullet ("push to main keeps the plain checks" no longer applies)

## Related Issue

None (maintenance change)

## Type of Change

- [x] 🔧 Chore

## Test Plan

- [x] `ruby -ryaml` parse of ci.yml passes
- [x] `grep event_name ci.yml` returns zero hits (no orphaned guards)
- [x] `npx prettier --check` passes for both changed files
- [x] This PR itself proves the pull_request trigger still fires; after merge, confirm no CI run appears on the merge push

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None. The Dependabot automerge workflow (`workflow_run`-based) already filters on `workflow_run.event == 'pull_request'`, so it is unaffected.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI checks now run exclusively for pull requests targeting the main branch.
  * Pull request review checks now include Rust test targets.
  * Removed push-only fallback checks and simplified workflow conditions.

* **Documentation**
  * Clarified the pull-request-only CI behavior and review-check limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->