### PR TITLE
refactor: rename crypto-sounding param names in cdn_selector

### DIFF
--- a/src-tauri/src/utils/cdn_selector.rs
+++ b/src-tauri/src/utils/cdn_selector.rs
@@ -173,10 +173,13 @@ fn substitute_host(url: &str, new_host: &str) -> Option<String> {
     Some(parsed.to_string())
 }
 
-/// Picks a substitution target: mirrors minus unhealthy, spread by `salt`
+/// Picks a substitution target: mirrors minus unhealthy, indexed by `spread`
 /// so repeated substitutions distribute load across the pool.
 /// Deterministic. `None` when no eligible mirror exists.
-fn pick_mirror(snap: &HealthSnapshot, salt: usize) -> Option<String> {
+// CAUTION: keep this parameter name free of crypto vocabulary ("salt",
+// "key", "seed") — CodeQL's hard-coded-cryptographic-value query flags
+// literals passed to such names, causing false-positive critical alerts.
+fn pick_mirror(snap: &HealthSnapshot, spread: usize) -> Option<String> {
     let eligible: Vec<&String> = snap
         .mirrors
         .iter()
@@ -185,7 +188,7 @@ fn pick_mirror(snap: &HealthSnapshot, salt: usize) -> Option<String> {
     if eligible.is_empty() {
         return None;
     }
-    Some(eligible[salt % eligible.len()].clone())
+    Some(eligible[spread % eligible.len()].clone())
 }
 
 /// Pre-selection layer: rewrites every URL whose host is unhealthy (and is
@@ -229,15 +232,21 @@ pub(crate) fn substitute_in_list(urls: &[String], snap: &HealthSnapshot) -> Vec<
 
 /// Rotation-time layer: the URL to actually request. URLs on healthy or
 /// ineligible hosts pass through byte-identical; URLs on unhealthy
-/// `bilivideo.com` hosts are rewritten to a pool mirror chosen by `salt`.
-pub(crate) fn resolve_effective_url(url: &str, snap: &HealthSnapshot, salt: usize) -> String {
+/// `bilivideo.com` hosts are rewritten to a pool mirror chosen by `rotations`
+/// (combined CDN + slow-rotation count, so each rotation advances the mirror).
+// Note: this parameter's name must stay free of crypto vocabulary ("salt",
+// "seed") — CodeQL alerts #4-#6 (rust/hard-coded-cryptographic-value, open
+// as of 2026-09-11) were raised on the old `salt` name, triggered by the
+// literal args at the test call sites below; same rule as the CAUTION on
+// pick_mirror. Renaming is the fix — do not reword back.
+pub(crate) fn resolve_effective_url(url: &str, snap: &HealthSnapshot, rotations: usize) -> String {
     let Some(host) = extract_host(url) else {
         return url.to_string();
     };
     if !snap.unhealthy.contains(&host) || !is_bilivideo_com_host(&host) {
         return url.to_string();
     }
-    match pick_mirror(snap, salt) {
+    match pick_mirror(snap, rotations) {
         Some(target) => substitute_host(url, &target).unwrap_or_else(|| url.to_string()),
         None => url.to_string(),
     }
@@ -771,7 +780,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_effective_url_rotates_mirrors_by_salt() {
+    fn test_resolve_effective_url_rotates_mirrors_by_rotation_count() {
         let s = snap(
             &[
                 "upos-sz-mirrorhw.bilivideo.com",


### PR DESCRIPTION
## Summary

Renames the misleading `salt` parameter in `cdn_selector.rs` to match its actual semantics, resolving CodeQL false-positive critical alerts (#4–#6).

- `pick_mirror(snap, salt)` → `pick_mirror(snap, spread)` — plain pool-distribution index
- `resolve_effective_url(url, snap, salt)` → `resolve_effective_url(url, snap, rotations)` — matches the caller's `rotations_used` (CDN + slow-rotation count, `downloads.rs:841`)
- Doc comments and the test name updated to follow; a CAUTION/Note records why the parameter name must stay free of crypto vocabulary

## Background

CodeQL's `rust/hard-coded-cryptographic-value` query flagged literals (`0`/`1`) passed at test call sites because the parameter was named `salt` (crypto vocabulary). The value is not a KDF salt — it is a plain rotation index — so these are false positives. Renaming is the cleanest fix.

The remaining critical alert of the same rule (#7, `secure_storage.rs`) was a real design trade-off and was dismissed as won't fix on the Security tab (keyring was removed in 2a97902 to avoid repeated macOS password prompts on unsigned builds).

## Verification

- `cargo build` ✓
- `cargo clippy --all-targets` ✓
- `cargo test --lib cdn_selector` — 22 passed ✓
- `cargo fmt --check` ✓

Behavior-neutral rename; the sole external caller passes arguments positionally, so no caller changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed internal CDN selection parameters and updated related documentation and tests.
  - No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->