### PR TITLE
test: cover gif generator gaps flagged by codecov

### DIFF
--- a/src-tauri/src/handlers/gif.rs
+++ b/src-tauri/src/handlers/gif.rs
@@ -512,6 +512,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn generate_animation_with_ffmpeg_rejects_missing_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("out.gif");
+        // Input path does not exist on disk — validation must reject before
+        // any spawn attempt.
+        let options = gif_e2e_options(
+            &dir.path().join("missing.mp4").to_string_lossy(),
+            &output.to_string_lossy(),
+        );
+
+        let app = tauri::test::mock_app();
+        let err = generate_animation_with_ffmpeg(
+            &dir.path().join("nonexistent-ffmpeg"),
+            app.handle(),
+            &options,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::GIF_INPUT_NOT_FOUND"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn generate_animation_with_ffmpeg_rejects_non_mp4_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = gif_fixture(dir.path(), "in.txt");
+        let output = dir.path().join("out.gif");
+        let options = gif_e2e_options(&input, &output.to_string_lossy());
+
+        let app = tauri::test::mock_app();
+        let err = generate_animation_with_ffmpeg(
+            &dir.path().join("nonexistent-ffmpeg"),
+            app.handle(),
+            &options,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::GIF_UNSUPPORTED_FORMAT"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn generate_animation_with_ffmpeg_rejects_same_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = gif_fixture(dir.path(), "in.mp4");
+        // The extension check runs before the same-file guard, so reaching
+        // the same-file rejection needs a .gif-suffixed path that resolves
+        // to the input: a symlink does exactly that.
+        let link = dir.path().join("link.gif");
+        std::os::unix::fs::symlink(&input, &link).unwrap();
+        let options = gif_e2e_options(&input, &link.to_string_lossy());
+
+        let app = tauri::test::mock_app();
+        let err = generate_animation_with_ffmpeg(
+            &dir.path().join("nonexistent-ffmpeg"),
+            app.handle(),
+            &options,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.starts_with("ERR::GIF_SAME_PATH"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn generate_animation_with_ffmpeg_rejects_extension_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let input = gif_fixture(dir.path(), "in.mp4");

--- a/src-tauri/src/utils/ffmpeg_probe.rs
+++ b/src-tauri/src/utils/ffmpeg_probe.rs
@@ -155,8 +155,9 @@ fn parse_trailing_kbps(line: &str) -> Option<u32> {
 /// flake lesson):
 /// - Probe invocations (`ffmpeg -i <file>`): print a `Duration:` line to
 ///   stderr and exit 1, like real ffmpeg without an output target.
-/// - Encode invocations: write a sentinel to the LAST argument (the output
-///   path) and exit `exit_code`.
+/// - Encode invocations: emit one `-progress` line (`out_time=`) to stderr
+///   so the handlers' stderr parsers and progress emits execute, then write
+///   a sentinel to the LAST argument (the output path) and exit `exit_code`.
 /// - `fail_on_copy`: any invocation whose args contain `copy` exits 1,
 ///   which drives concat's copy→re-encode fallback.
 #[cfg(all(test, unix))]
@@ -181,6 +182,7 @@ if [ \"$1\" = \"-i\" ]; then
     echo \"  Duration: 00:01:00.00, start: 0.000000\" 1>&2
     exit 1
 fi
+printf 'frame=15\\nout_time_us=1000000\\nout_time=00:00:01.000000\\nprogress=continue\\n' 1>&2
 {copy_guard}for last do :; done
 echo fake-ffmpeg-output > \"$last\"
 exit {exit_code}

--- a/src/features/gif/hooks/useGif.test.tsx
+++ b/src/features/gif/hooks/useGif.test.tsx
@@ -310,4 +310,56 @@ describe('useGif', () => {
     expect(result.current.status).toBe('idle')
     expect(result.current.progress).toBeNull()
   })
+
+  it('offers a *_clip.gif default name for an extension-less input', async () => {
+    const { result } = renderHook(() => useGif(), { wrapper })
+    mockOpen.mockResolvedValueOnce('/x/movie')
+    await act(async () => {
+      await result.current.handleBrowse()
+    })
+
+    mockSave.mockResolvedValueOnce('/o/out.gif')
+    await act(async () => {
+      await result.current.handleChooseOutput()
+    })
+
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: 'movie_clip.gif' }),
+    )
+  })
+
+  it('setFormat appends the extension when the picked output has none', async () => {
+    const { result } = renderHook(() => useGif(), { wrapper })
+    await pickPaths(result, '/x/movie.mp4', '/o/out-noext')
+
+    act(() => {
+      result.current.setFormat('webm')
+    })
+
+    expect(result.current.outputPath).toBe('/o/out-noext.webm')
+  })
+
+  it('reveal swallows a backend error instead of rejecting', async () => {
+    mockCommands({ reveal_in_folder: new Error('opener failed') })
+    const { result } = renderHook(() => useGif(), { wrapper })
+    await pickPaths(result)
+
+    // Must resolve (error is logged, not thrown)
+    await act(async () => {
+      await result.current.handleReveal()
+    })
+  })
+
+  it('setFormat still updates locally when patch_settings fails', async () => {
+    mockCommands({ patch_settings: new Error('disk full') })
+    const { result } = renderHook(() => useGif(), { wrapper })
+    await pickPaths(result)
+
+    act(() => {
+      result.current.setFormat('webm')
+    })
+
+    expect(result.current.format).toBe('webm')
+    expect(store.getState().settings.gifFormat).toBe('webm')
+  })
 })

--- a/src/features/settings/ui/sections/ToolDefaultsSection.test.tsx
+++ b/src/features/settings/ui/sections/ToolDefaultsSection.test.tsx
@@ -54,6 +54,11 @@ describe('ToolDefaultsSection', () => {
       { audioFormat: 'm4a' },
     ],
     [
+      'settings.gif_format_label',
+      'settings.gif_format_webm',
+      { gifFormat: 'webm' },
+    ],
+    [
       'settings.rotation_mode_label',
       'settings.rotation_mode_reencode',
       { rotationMode: 'reencode' },

--- a/src/pages/gif/index.test.tsx
+++ b/src/pages/gif/index.test.tsx
@@ -162,6 +162,33 @@ describe('GifContent (page + GifForm wiring)', () => {
     expect(screen.getByText(/gif\.remaining/)).toHaveTextContent('2:05')
     expect(screen.getByText('gif.generating')).toBeInTheDocument()
   })
+
+  it('renders progress without a remaining estimate when unavailable', () => {
+    vi.mocked(useGif).mockReturnValue(
+      createMockUseGif({
+        status: 'generating',
+        progress: { progress: 1, currentTimeSec: 0, totalDurationSec: 0 },
+        elapsedSec: 3,
+        remainingSec: null,
+      }),
+    )
+
+    renderWithProviders(<GifContent />, { route: '/gif' })
+
+    expect(screen.getByText('1%')).toBeInTheDocument()
+    expect(screen.getByText(/gif\.elapsed/)).toHaveTextContent('0:03')
+    expect(screen.queryByText(/gif\.remaining/)).not.toBeInTheDocument()
+  })
+
+  it('renders the empty-start range error key from the hook', () => {
+    vi.mocked(useGif).mockReturnValue(
+      createMockUseGif({ rangeError: 'empty_start' }),
+    )
+
+    renderWithProviders(<GifContent />, { route: '/gif' })
+
+    expect(screen.getByText('gif.error.empty_start')).toBeInTheDocument()
+  })
 })
 
 describe('formatDuration (gif)', () => {


### PR DESCRIPTION
## Summary

Coverage follow-up to #695: the codecov PR report flagged 53 uncovered lines in the gif generator (patch 89.65%). This PR covers them — no product code changes.

- **Rust** (handlers/gif.rs tests): three validation-error paths — ERR::GIF_INPUT_NOT_FOUND, ERR::GIF_UNSUPPORTED_FORMAT (non-mp4 input), and ERR::GIF_SAME_PATH (a symlink reaches the same-file guard behind the extension check)
- **Rust** (ffmpeg_probe.rs): the fake ffmpeg executor now emits a real per-line -progress block (out_time=...) instead of nothing, so every tool handler's stderr parser and progress-emit path executes under tests (gif.rs lines: 91.35% → 96.51%; same lift applies to trim/audio/concat/rotation)
- **Frontend**: useGif — extension-less default name, extension swap on format change, reveal/patch error swallowing; GifForm — no-remaining-estimate progress state and empty_start error rendering; ToolDefaultsSection — gifFormat segmented-control row

## Testing

- Rust: 587 tests pass, clippy clean
- Frontend: 1321 tests pass (+18), eslint + prettier clean
- Verified with local nightly cargo-llvm-cov: handlers/gif.rs 96.51% lines

Refs #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded GIF conversion coverage for invalid inputs, same-file selections, and expected validation errors.
  - Added coverage for ffmpeg progress reporting during encoding.
  - Verified default GIF filenames and format changes, including extension handling.
  - Added coverage for graceful handling of reveal and settings-update errors.
  - Verified GIF format preferences persist correctly.
  - Added coverage for elapsed-time display without an estimate and clear messaging for empty start ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->