### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately via GitHub's vulnerability reporting:
+
+1. Open the
+   [Security tab](https://github.com/j4rviscmd/bilibili-downloader-gui/security)
+2. Click **Report a vulnerability** and fill in the report form
+
+The report is visible only to the maintainers. Please do **not** open a
+public issue for security problems.
+
+## Supported Versions
+
+Only the latest release receives security updates. Older versions are not
+backported; upgrade to the latest release instead.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| latest release | :white_check_mark: |
+| older          | :x:                |


### PR DESCRIPTION
## Summary

Add `SECURITY.md` to the repository root to satisfy the OpenSSF Scorecard
Security-Policy check (currently 0/10).

- Directs vulnerability reports to GitHub private vulnerability reporting
  (Security tab → "Report a vulnerability"). The feature has been enabled
  in the repository settings.
- Discourages opening public issues for security problems.
- Documents the support policy: only the latest release receives security
  updates, no backports.

## Related Issue

Refs #677 (Security-Policy item only; Token-Permissions and
Pinned-Dependencies remain open)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🔧 Chore

## Test Plan

- [x] `npx prettier --check SECURITY.md` passes (CI format gate)
- [x] Reviewed rendered content on GitHub
- [x] Verified "Report a vulnerability" button appears on the Security tab
  (private vulnerability reporting enabled via repo settings)

## Screenshots / Videos (Optional)

N/A (docs-only change)

## Breaking Changes

None.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (N/A for docs)
- [x] i18n files synced (N/A for docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)