### PR TITLE
feat(settings): add group dividers between setting groups

### DIFF
--- a/src/features/settings/ui/DevOptions.test.tsx
+++ b/src/features/settings/ui/DevOptions.test.tsx
@@ -142,4 +142,12 @@ describe('DevOptions', () => {
       patch: { enableDevUpdater: true },
     })
   })
+
+  it('renders one divider between each of the three options', () => {
+    const { container } = renderWithProviders(<DevOptions />)
+
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      2,
+    )
+  })
 })

--- a/src/features/settings/ui/DevOptions.tsx
+++ b/src/features/settings/ui/DevOptions.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '@/features/settings/useSettings'
 import { useUser } from '@/features/user'
 import { logger } from '@/shared/lib/logger'
 
+import { Separator } from '@/shared/ui/separator'
 import { Switch } from '@/shared/ui/switch'
 import { invoke } from '@tauri-apps/api/core'
 import { useTranslation } from 'react-i18next'
@@ -89,6 +90,7 @@ export function DevOptions() {
           onCheckedChange={handleToggleDevtools}
         />
       </SettingRow>
+      <Separator />
       <SettingRow
         label={t('settings.dev_options.enable_dev_updater')}
         htmlFor="enable-dev-updater"
@@ -100,6 +102,7 @@ export function DevOptions() {
           onCheckedChange={handleToggleDevUpdater}
         />
       </SettingRow>
+      <Separator />
       <SettingRow
         label={t('settings.dev_options.simulate_logout')}
         htmlFor="simulate-logout"

--- a/src/features/settings/ui/sections/DownloadSection.test.tsx
+++ b/src/features/settings/ui/sections/DownloadSection.test.tsx
@@ -326,6 +326,15 @@ describe('DownloadSection', () => {
       }),
     )
   })
+
+  it('renders one divider per group boundary', () => {
+    seedSettings()
+    const { container } = renderWithProviders(<DownloadSection />)
+
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      5,
+    )
+  })
 })
 
 /** Mirrors DEFAULT_RULES in TitleReplacementSettings (backend defaults). */

--- a/src/features/settings/ui/sections/DownloadSection.tsx
+++ b/src/features/settings/ui/sections/DownloadSection.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/shared/animate-ui/radix/tooltip'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
+import { Separator } from '@/shared/ui/separator'
 import { Switch } from '@/shared/ui/switch'
 import { Info } from 'lucide-react'
 import { useState } from 'react'
@@ -114,6 +115,9 @@ export function DownloadSection() {
           {t('settings.output_dir_description')}
         </p>
       </SettingField>
+      {/* Why: one separator per group boundary, not per item — issue #693 allows
+          adjacent settings in the same group to go undivided */}
+      <Separator />
       <SettingField
         label={
           <span className="flex items-center gap-2">
@@ -144,6 +148,7 @@ export function DownloadSection() {
           }))}
         />
       </SettingField>
+      <Separator />
       <SettingRow
         label={t('settings.auto_rename_duplicates_label')}
         description={t('settings.auto_rename_duplicates_description')}
@@ -174,6 +179,7 @@ export function DownloadSection() {
           }}
         />
       </SettingRow>
+      <Separator />
       {/* id is the deep-link anchor for /settings?category=download&anchor=
           speed-limit (the download status bar's limit link, issue #421). */}
       <div id="setting-speed-limit">
@@ -217,7 +223,11 @@ export function DownloadSection() {
           )}
         </SettingField>
       )}
+      {/* The speed-limit pair (anchor row + conditional value field) stays
+          together between the surrounding separators. */}
+      <Separator />
       <TitleReplacementSettings />
+      <Separator />
       <SettingField
         label={t('settings.video_codec_priority_label')}
         description={t('settings.video_codec_priority_description')}

--- a/src/features/settings/ui/sections/GeneralSection.test.tsx
+++ b/src/features/settings/ui/sections/GeneralSection.test.tsx
@@ -112,4 +112,13 @@ describe('GeneralSection', () => {
 
     await waitFor(() => expect(lastSetSettings()).toMatchObject(expected))
   })
+
+  it('renders one divider per group boundary', () => {
+    seedSettings()
+    const { container } = renderWithProviders(<GeneralSection />)
+
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      1,
+    )
+  })
 })

--- a/src/features/settings/ui/sections/GeneralSection.tsx
+++ b/src/features/settings/ui/sections/GeneralSection.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/shared/ui/select'
+import { Separator } from '@/shared/ui/separator'
 import { Switch } from '@/shared/ui/switch'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -115,6 +116,7 @@ export function GeneralSection() {
           </span>
         </div>
       </div>
+      <Separator />
       <SettingRow
         label={t('settings.show_github_stars_label')}
         description={t('settings.show_github_stars_description')}

--- a/src/features/settings/ui/sections/ToolDefaultsSection.test.tsx
+++ b/src/features/settings/ui/sections/ToolDefaultsSection.test.tsx
@@ -109,4 +109,12 @@ describe('ToolDefaultsSection', () => {
     // All info buttons render and swallow clicks without throwing
     expect(screen.getByText('settings.trim_mode_label')).toBeInTheDocument()
   })
+
+  it('renders one divider per tool group', () => {
+    const { container } = renderWithProviders(<ToolDefaultsSection />)
+
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      3,
+    )
+  })
 })

--- a/src/features/settings/ui/sections/ToolDefaultsSection.tsx
+++ b/src/features/settings/ui/sections/ToolDefaultsSection.tsx
@@ -1,6 +1,7 @@
 import { SettingField } from '@/features/settings/ui/SettingRow'
 import { SettingToggleGroup } from '@/features/settings/ui/SettingToggleGroup'
 import { useSettings } from '@/features/settings/useSettings'
+import { Separator } from '@/shared/ui/separator'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -43,6 +44,7 @@ export function ToolDefaultsSection() {
           options={copyReencodeChoices('trim_mode', 'trim')}
         />
       </SettingField>
+      <Separator />
       <SettingField
         label={t('settings.audio_format_label')}
         description={t('settings.audio_format_description')}
@@ -58,6 +60,7 @@ export function ToolDefaultsSection() {
           ]}
         />
       </SettingField>
+      <Separator />
       <SettingField
         label={t('settings.gif_format_label')}
         description={t('settings.gif_format_description')}
@@ -73,6 +76,7 @@ export function ToolDefaultsSection() {
           ]}
         />
       </SettingField>
+      <Separator />
       <SettingField
         label={t('settings.rotation_mode_label')}
         description={t('settings.rotation_mode_description')}


### PR DESCRIPTION
## Summary

Add `<Separator />` dividers between setting groups across the settings page (issue #693). Items in the same group stay undivided (e.g. the speed-limit toggle and its value input), per the issue's grouping guidance.

Grouping applied:

| Section | Dividers | Groups |
| --- | --- | --- |
| General | 1 | appearance (language/theme/font) \| app toggles (stars/splash) |
| Download | 5 | output dir \| parallelism \| rename pair \| speed-limit pair \| title replacement \| codec |
| Tool Defaults | 3 | trim \| audio \| gif \| rotation pair |
| Dev Options | 2 | one between each of the 3 options |

Storage / Notifications / Account / About are intentionally unchanged (single-group sections).

Uses the existing shadcn `Separator` (`src/shared/ui/separator.tsx`) as plain siblings in each section's `space-y-6` stack — no className tuning needed; the hairline sits centered in the 3rem inter-group gap vs 1.5rem intra-group. The speed-limit value field is conditionally rendered, but `space-y` only applies to rendered pairs, so spacing stays symmetric in both toggle states.

## Related Issue

Closes #693

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] `npm run lint` / `npm test` (1318 passed) / `npm run typecheck` all green
- [x] Added a divider-count assertion per touched section (`[data-slot="separator"]`)
- [x] Verified in `npm run tauri dev`: General / Download / Tool Defaults / Dev Options — dividers at group boundaries only, speed-limit ON/OFF keeps symmetric spacing

## Screenshots / Videos (Optional)

N/A (visual grouping only; verified live)

## Breaking Changes

None.

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore)
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — N/A, no user-facing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)