### PR TITLE
docs: require CREATE_NO_WINDOW on child process spawns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,14 @@ the real logic into pure functions or test seams and test those:
   add per-file `vi.mock('@tauri-apps/api/core')`
 - Run `npm test` and `cargo test` before handing over for verification
 
+### External Processes (Windows Console Window)
+
+Every `Command::new` / `AsyncCommand::new` spawn **must set
+`CREATE_NO_WINDOW`** — follow the existing pattern in
+`src-tauri/src/handlers/` (e.g. `gif.rs`). Without it a console window
+pops up on Windows release builds only; dev builds and Ubuntu CI cannot
+catch this.
+
 ### Code Comments
 
 **Write all code comments in English.** This includes inline `//`


### PR DESCRIPTION
## Summary

Add an "External Processes (Windows Console Window)" section to CLAUDE.md's Required Rules: every `Command::new` / `AsyncCommand::new` spawn must set `CREATE_NO_WINDOW`, following the existing pattern in `src-tauri/src/handlers/` (e.g. `gif.rs`).

Rationale: `windows_subsystem = "windows"` in `main.rs` hides the app's own console on Windows release builds, but child processes still spawn a console window without this flag. Dev builds (console visible by design) and Ubuntu CI cannot catch the omission, so it surfaces only in user-facing release builds. Codifying the rule prevents future regressions.

Docs-only change; no code modified.

## Related Issue

None (no matching open issue found)

## Type of Change

- [x] 📝 Documentation

## Test Plan

- [x] N/A (docs-only)

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (N/A for docs)
- [x] i18n files synced (N/A for docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)