### PR TITLE
fix(ui): reserve scrollbar gutter space on scrollable pages

### DIFF
--- a/src/features/concat/ui/ConcatForm.tsx
+++ b/src/features/concat/ui/ConcatForm.tsx
@@ -67,7 +67,9 @@ export function ConcatForm() {
           // min-h-0 makes this region refuse to shrink, so `overflow-y-auto`
           // never fires, the section grows unbounded, and the output/action
           // rows get pushed off-screen (the original #461 symptom).
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          // Why: pr-5 reserves space so the scrollbar gutter does not
+          // overlap the flush-right edge of the file rows.
+          <div className="min-h-0 flex-1 overflow-y-auto pr-5">
             <FileList
               files={files}
               isProcessing={isConcatting}

--- a/src/pages/audio/index.tsx
+++ b/src/pages/audio/index.tsx
@@ -18,7 +18,9 @@ export function AudioContent() {
 
   return (
     <PageTemplate title={t('audio.title')} description={t('audio.description')}>
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+          the flush-right edge of the form sections. */}
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pr-5 pb-4 sm:pt-3 sm:pb-6">
         <AudioForm />
       </div>
     </PageTemplate>

--- a/src/pages/gif/index.tsx
+++ b/src/pages/gif/index.tsx
@@ -18,7 +18,9 @@ export function GifContent() {
 
   return (
     <PageTemplate title={t('gif.title')} description={t('gif.description')}>
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+          the flush-right edge of the form sections. */}
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pr-5 pb-4 sm:pt-3 sm:pb-6">
         <GifForm />
       </div>
     </PageTemplate>

--- a/src/pages/resolution/index.tsx
+++ b/src/pages/resolution/index.tsx
@@ -21,7 +21,9 @@ export function ResolutionContent() {
       title={t('resolution.title')}
       description={t('resolution.description')}
     >
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+          the flush-right edge of the form sections. */}
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pr-5 pb-4 sm:pt-3 sm:pb-6">
         <ResolutionForm />
       </div>
     </PageTemplate>

--- a/src/pages/rotation/index.tsx
+++ b/src/pages/rotation/index.tsx
@@ -21,7 +21,9 @@ export function RotationContent() {
       title={t('rotation.title')}
       description={t('rotation.description')}
     >
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+          the flush-right edge of the form sections. */}
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pr-5 pb-4 sm:pt-3 sm:pb-6">
         <RotationForm />
       </div>
     </PageTemplate>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -100,7 +100,9 @@ export function SettingsContent() {
     >
       <div className="flex min-h-0 flex-1 gap-6 pt-2 pb-4 sm:pt-3 sm:pb-6">
         <CategoryNav active={category} onSelect={setCategory} />
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+            the flush-right edge of the settings sections. */}
+        <div className="min-h-0 flex-1 overflow-y-auto pr-5">
           <Section />
         </div>
       </div>

--- a/src/pages/trim/index.tsx
+++ b/src/pages/trim/index.tsx
@@ -18,7 +18,9 @@ export function TrimContent() {
 
   return (
     <PageTemplate title={t('trim.title')} description={t('trim.description')}>
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pb-4 sm:pt-3 sm:pb-6">
+      {/* Why: pr-5 reserves space so the scrollbar gutter does not overlap
+          the flush-right edge of the form sections. */}
+      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-2 pr-5 pb-4 sm:pt-3 sm:pb-6">
         <TrimForm />
       </div>
     </PageTemplate>


### PR DESCRIPTION
## Summary

The vertical scrollbar overlapped the flush-right edge of the content on the scrollable pages. Add `pr-5` (20px) right padding to the page-level `overflow-y-auto` scroll containers so the scrollbar gutter no longer covers content:

- `src/pages/settings/index.tsx` (the reported page)
- `src/pages/trim/index.tsx`, `audio`, `resolution`, `rotation`, `gif`
- `src/features/concat/ui/ConcatForm.tsx` (file-list scroll region)

12px (`pr-3`) was tried first but still overlapped the macOS overlay scrollbar (~15px); 20px clears both macOS overlay and Windows classic (17px) scrollbars. List pages (history / favorite / watch-history) already had the same treatment on their Virtuoso rows, and home/releases dialogs keep their existing inner padding, so they are untouched.

## Related Issue

None (no matching open issue found)

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] `npm run lint` clean
- [x] `npm test` — 1325 tests pass
- [x] `npx prettier --check` clean on touched files
- [x] Manual verification on settings / tool pages: scrollbar no longer overlaps content

## Screenshots / Videos (Optional)

N/A

## Breaking Changes

None

## Checklist

- [x] Conventional Commits format followed in commit messages
- [x] PR title/body written in English
- [x] Tests added/updated (or N/A for docs/chore) — className-only change, no testable logic
- [x] i18n files synced (all 6 languages: en, ja, zh, ko, es, fr) — no user-facing text changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)